### PR TITLE
Updates github org name

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,7 +36,7 @@ authors:
     given-names: Xinyuan
     orcid: "https://orcid.org/0000-0003-1770-631X"
 doi: 10.5281/zenodo.10151130
-repository-code: "https://github.com/LabForComputationalVision/plenoptic"
+repository-code: "https://github.com/plenoptic-org/plenoptic"
 url: "https://plenoptic.readthedocs.io/"
 license: MIT
 keywords:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,7 @@ several choices for how to run a subset of the tests:
 - Another example specifying a test method in the command line: `pytest
   test_mod.py::TestClass::test_method`
 
-View the [pytest documentation](http://doc.pytest.org/en/latest/usage.html) for
+View the [pytest documentation](https://doc.pytest.org/en/latest/usage.html) for
 more info.
 
 ### Adding tests 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@ overview of the project and how to get everything installed, as well as pointers
 for further reading, depending on your interests.
 
 If you encounter any issues with `plenoptic`, first search the existing
-[issues](https://github.com/LabForComputationalVision/plenoptic/issues) and
-[discussions](https://github.com/LabForComputationalVision/plenoptic/discussions)
+[issues](https://github.com/plenoptic-org/plenoptic/issues) and
+[discussions](https://github.com/plenoptic-org/plenoptic/discussions)
 to see if there's already information to help you. If not, please open a new
-[issue](https://github.com/LabForComputationalVision/plenoptic/issues)! We have
+[issue](https://github.com/plenoptic-org/plenoptic/issues)! We have
 a template for bug reports, and following it (so you provide the necessary
 details) will make solving your problem much easier.
 
@@ -23,26 +23,26 @@ familiar with the project, it can be very helpful for us if you go through the
 tutorials, README, and documentation and let us know if anything is unclear,
 what needs more detail (or clearer writing), etc. For those that want to
 contribute code, we also have many
-[issues](https://github.com/LabForComputationalVision/plenoptic/issues) that we
+[issues](https://github.com/plenoptic-org/plenoptic/issues) that we
 are working through. If you would like to work on one of those, please give it a
 try!
 
 In order to submit changes, create a branch or fork of the project, make your
 changes, add documentation and tests, and submit a [Pull
-Request](https://github.com/LabForComputationalVision/plenoptic/pulls). See
+Request](https://github.com/plenoptic-org/plenoptic/pulls). See
 [contributing to the code below](#contributing-to-the-code) for more details on
 this process.
 
 We try to keep all our communication on Github, and we use several channels:
 
--   [Discussions](https://github.com/LabForComputationalVision/plenoptic/discussions)
+-   [Discussions](https://github.com/plenoptic-org/plenoptic/discussions)
     is the place to ask usage questions, discuss issues too broad for a
     single issue, or show off what you've made with plenoptic.
 -   If you've come across a bug, open an
-    [issue](https://github.com/LabForComputationalVision/plenoptic/issues).
+    [issue](https://github.com/plenoptic-org/plenoptic/issues).
 -   If you have an idea for an extension or enhancement, please post in the
     [ideas
-    section](https://github.com/LabForComputationalVision/plenoptic/discussions/categories/ideas)
+    section](https://github.com/plenoptic-org/plenoptic/discussions/categories/ideas)
     of discussions first. We'll discuss it there and, if we decide to pursue it,
     open an issue to track progress.
 
@@ -74,15 +74,15 @@ increments the version number, and uploading the new release to PyPI (see
 
 In addition to the information that follows, [Github](https://docs.github.com/en/get-started/quickstart/github-flow) (unsurprisingly) has good information on this workflow, as does the [Caiman package](https://github.com/flatironinstitute/CaImAn/blob/main/CONTRIBUTING.md) (though note that the Caiman uses **git** flow, which involves a separate develop branch in addition to main).
 
-Before we begin: everyone finds `git` confusing the first few (dozen) times they encounter it! And even people with a hard-won understanding frequently look up information on how it works. If you find the following difficult, we're happy to help walk you through the process. Please [post on our GitHub discussions page](https://github.com/LabForComputationalVision/plenoptic/discussions) to get help.
+Before we begin: everyone finds `git` confusing the first few (dozen) times they encounter it! And even people with a hard-won understanding frequently look up information on how it works. If you find the following difficult, we're happy to help walk you through the process. Please [post on our GitHub discussions page](https://github.com/plenoptic-org/plenoptic/discussions) to get help.
 
 #### Creating a development environment
 
 You'll need a local installation of `plenoptic` which keeps up-to-date with any changes you make. To do so, you will need to fork and clone `plenoptic`:
 
-1. Go to the [plenoptic repo](https://github.com/LabForComputationalVision/plenoptic/) and click on the `Fork` button at the top right of the page. This creates a copy of plenoptic in your Github account.
-2. You should then clone *your fork* to your local machine and create an editable installation. To do so, follow the instructions for an editable install found in our [docs](https://plenoptic.readthedocs.io/en/latest/install.html#installation), replacing `git clone https://github.com/LabForComputationalVision/plenoptic.git` with `git clone https://github.com/<YourUserName>/plenoptic.git`.
-3. Add the `upstream` branch: `git remote add upstream https://github.com/LabForComputationalVision/plenoptic.git`. At this point, you have two remotes: `origin` (your fork) and `upstream` (the canonical version). You won't have permission to push to upstream (only `origin`), but this makes it easy to keep your `plenoptic` up to date with the canonical version by pulling from upstream: `git pull upstream`.
+1. Go to the [plenoptic repo](https://github.com/plenoptic-org/plenoptic/) and click on the `Fork` button at the top right of the page. This creates a copy of plenoptic in your Github account.
+2. You should then clone *your fork* to your local machine and create an editable installation. To do so, follow the instructions for an editable install found in our [docs](https://plenoptic.readthedocs.io/en/latest/install.html#installation), replacing `git clone https://github.com/plenoptic-org/plenoptic.git` with `git clone https://github.com/<YourUserName>/plenoptic.git`.
+3. Add the `upstream` branch: `git remote add upstream https://github.com/plenoptic-org/plenoptic.git`. At this point, you have two remotes: `origin` (your fork) and `upstream` (the canonical version). You won't have permission to push to upstream (only `origin`), but this makes it easy to keep your `plenoptic` up to date with the canonical version by pulling from upstream: `git pull upstream`.
 
 You should probably also install all the optional dependencies, so that you can run tests, build the documentation, and run the jupyter notebooks locally. To do so, run `pip install -e .[docs,dev,nb]` from within the copy of `plenoptic` on your machine (see [this section](https://plenoptic.readthedocs.io/en/latest/install.html#jupyter) of our documentation for information on how to set up jupyter if you don't want an extra copy of it in this environment).
 
@@ -157,7 +157,7 @@ versioning](https://semver.org/):
 When doing a new release, the following steps must be taken:
 1. In a new PR:
   - Update all the [binder](https://mybinder.org) links, which are of the form
-    `https://mybinder.org/v2/gh/LabForComputationalVision/plenoptic/X.Y.Z?filepath=examples`,
+    `https://mybinder.org/v2/gh/plenoptic-org/plenoptic/X.Y.Z?filepath=examples`,
     which are found in `README.md`, `index.rst`, `examples/README.md`, and some
     of the tutorial notebooks found in `examples/`. Note that the version tag
     must match the github tag (specified in the next step) or the link won't

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Documentation Status](https://readthedocs.org/projects/plenoptic/badge/?version=latest)](https://plenoptic.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10151131.svg)](https://doi.org/10.5281/zenodo.10151131)
 [![codecov](https://codecov.io/gh/plenoptic-org/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA)](https://codecov.io/gh/plenoptic-org/plenoptic)
-[![Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plenoptic-org/plenoptic/1.0.1?filepath=examples)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plenoptic-org/plenoptic/1.0.1?filepath=examples)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 
 ![](docs/images/plenoptic_logo_wide.svg)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![PyPI Version](https://img.shields.io/pypi/v/plenoptic.svg)](https://pypi.org/project/plenoptic/)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/plenoptic/badges/version.svg)](https://anaconda.org/conda-forge/plenoptic)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/LabForComputationalVision/plenoptic/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/plenoptic-org/plenoptic/blob/main/LICENSE)
 ![Python version](https://img.shields.io/badge/python-3.10|3.11|3.12-blue.svg)
-[![Build Status](https://github.com/LabForComputationalVision/plenoptic/workflows/build/badge.svg)](https://github.com/LabForComputationalVision/plenoptic/actions?query=workflow%3Abuild)
+[![Build Status](https://github.com/plenoptic-org/plenoptic/workflows/build/badge.svg)](https://github.com/plenoptic-org/plenoptic/actions?query=workflow%3Abuild)
 [![Documentation Status](https://readthedocs.org/projects/plenoptic/badge/?version=latest)](https://plenoptic.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10151131.svg)](https://doi.org/10.5281/zenodo.10151131)
-[![codecov](https://codecov.io/gh/LabForComputationalVision/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA)](https://codecov.io/gh/LabForComputationalVision/plenoptic)
-[![Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/LabForComputationalVision/plenoptic/1.0.1?filepath=examples)
+[![codecov](https://codecov.io/gh/plenoptic-org/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA)](https://codecov.io/gh/plenoptic-org/plenoptic)
+[![Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plenoptic-org/plenoptic/1.0.1?filepath=examples)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 
 ![](docs/images/plenoptic_logo_wide.svg)
@@ -55,7 +55,7 @@ Our dependencies include [pytorch](https://pytorch.org/) and
 care of them (along with our other dependencies) automatically, but if you have
 an installation problem (especially on a non-Linux operating system), it is
 likely that the problem lies with one of those packages. [Open an
-issue](https://github.com/LabForComputationalVision/plenoptic/issues) and we'll
+issue](https://github.com/plenoptic-org/plenoptic/issues) and we'll
 try to help you figure out the problem!
 
 See the [installation
@@ -137,14 +137,14 @@ with a random string, `matplotlib` will tell you the available choices.
 
 We communicate via several channels on Github:
 
--   [Discussions](https://github.com/LabForComputationalVision/plenoptic/discussions)
+-   [Discussions](https://github.com/plenoptic-org/plenoptic/discussions)
     is the place to ask usage questions, discuss issues too broad for a
     single issue, or show off what you've made with plenoptic.
 -   If you've come across a bug, open an
-    [issue](https://github.com/LabForComputationalVision/plenoptic/issues).
+    [issue](https://github.com/plenoptic-org/plenoptic/issues).
 -   If you have an idea for an extension or enhancement, please post in the
     [ideas
-    section](https://github.com/LabForComputationalVision/plenoptic/discussions/categories/ideas)
+    section](https://github.com/plenoptic-org/plenoptic/discussions/categories/ideas)
     of discussions first. We'll discuss it there and, if we decide to pursue it,
     open an issue to track progress.
 -   See the [contributing guide](CONTRIBUTING.md) for how to get involved.
@@ -190,4 +190,4 @@ for Computational Neuroscience.
     2019](https://proceedings.neurips.cc/paper_files/paper/2019/hash/ac27b77292582bc293a51055bfc994ee-Abstract.html),
     though we haven't yet implemented examples. If you're interested, please
     post in
-    [Discussions](https://github.com/LabForComputationalVision/plenoptic/discussions)!
+    [Discussions](https://github.com/plenoptic-org/plenoptic/discussions)!

--- a/docs/conceptual_intro.rst
+++ b/docs/conceptual_intro.rst
@@ -241,7 +241,8 @@ predictions to test.
    colours. The London, Edinburgh, and Dublin Philosophical Magazine and Journal
    of Science, 4(28), 519–534. https://dx.doi.org/10.1080/14786445208647175
 .. [Lettvin1976] Lettvin, J. Y. (1976). On Seeing Sidelong. The Sciences, 16(4),
-   10–20. https://jerome.lettvin.com/jerome/OnSeeingSidelong.pdf
+   10–20.
+   https://web.archive.org/web/20221016220044/https://jerome.lettvin.com/jerome/OnSeeingSidelong.pdf
 .. [Szegedy2013] Szegedy, C., Zaremba, W., Sutskever, I., Bruna, J., Erhan, D.,
    Goodfellow, I., & Fergus, R. (2013). Intriguing properties of neural
    networks. https://arxiv.org/abs/1312.6199

--- a/docs/conceptual_intro.rst
+++ b/docs/conceptual_intro.rst
@@ -239,9 +239,9 @@ predictions to test.
 
 .. [Helmholtz1852] Helmholtz, H. (1852). LXXXI. on the theory of compound
    colours. The London, Edinburgh, and Dublin Philosophical Magazine and Journal
-   of Science, 4(28), 519–534. http://dx.doi.org/10.1080/14786445208647175
+   of Science, 4(28), 519–534. https://dx.doi.org/10.1080/14786445208647175
 .. [Lettvin1976] Lettvin, J. Y. (1976). On Seeing Sidelong. The Sciences, 16(4),
-   10–20. http://jerome.lettvin.com/jerome/OnSeeingSidelong.pdf
+   10–20. https://jerome.lettvin.com/jerome/OnSeeingSidelong.pdf
 .. [Szegedy2013] Szegedy, C., Zaremba, W., Sutskever, I., Bruna, J., Erhan, D.,
    Goodfellow, I., & Fergus, R. (2013). Intriguing properties of neural
    networks. https://arxiv.org/abs/1312.6199

--- a/docs/conceptual_intro.rst
+++ b/docs/conceptual_intro.rst
@@ -231,7 +231,7 @@ predictions to test.
        <https://proceedings.neurips.cc/paper_files/paper/2019/hash/ac27b77292582bc293a51055bfc994ee-Abstract.html>`_
        though we haven't yet implemented examples. If you're interested, please
        post in `Discussions
-       <https://github.com/LabForComputationalVision/plenoptic/discussions)>`_!
+       <https://github.com/plenoptic-org/plenoptic/discussions)>`_!
 .. [#] for example, as of February 2022, more than 100 models have above 95% top
   5 accuracy on ImageNet, with 9 models within a percent of the top performer at
   99.02%. Furthermore, the state of the art top 5 accuracy has been at or above

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 #
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
+# https://www.sphinx-doc.org/en/master/config
 
 # -- Path setup --------------------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -235,7 +235,7 @@ cite us! See the :ref:`citation` for more details.
    https://www.cns.nyu.edu/pub/eero/portilla99-reprint.pdf
 .. [Freeman2011] Freeman, J., & Simoncelli, E. P. (2011). Metamers of the
    ventral stream. Nature Neuroscience, 14(9), 1195–1201.
-   http://www.cns.nyu.edu/pub/eero/freeman10-reprint.pdf
+   https://www.cns.nyu.edu/pub/eero/freeman10-reprint.pdf
 .. [Deza2019] Deza, A., Jonnalagadda, A., & Eckstein, M. P. (2019). Towards
    metamerism via foveated style transfer. In , International Conference on
    Learning Representations.
@@ -244,49 +244,49 @@ cite us! See the :ref:`citation` for more details.
    In NeurIPS (pp. 10078–10089).
 .. [Wallis2019] Wallis, T. S., Funke, C. M., Ecker, A. S., Gatys, L. A.,
    Wichmann, F. A., & Bethge, M. (2019). Image content is more important than
-   bouma's law for scene metamers. eLife. http://dx.doi.org/10.7554/elife.42512
+   bouma's law for scene metamers. eLife. https://dx.doi.org/10.7554/elife.42512
 .. [Berardino2017] Berardino, A., Laparra, V., J Ball\'e, & Simoncelli, E. P.
    (2017). Eigen-distortions of hierarchical representations. In I. Guyon, U.
    Luxburg, S. Bengio, H. Wallach, R. Fergus, S. Vishwanathan, & R. Garnett,
    Adv. Neural Information Processing Systems (NIPS*17) (pp. 1–10). : Curran
    Associates, Inc. https://www.cns.nyu.edu/~lcv/eigendistortions/
-   http://www.cns.nyu.edu/pub/lcv/berardino17c-final.pdf
+   https://www.cns.nyu.edu/pub/lcv/berardino17c-final.pdf
 .. [Wang2008] Wang, Z., & Simoncelli, E. P. (2008). Maximum differentiation
    (MAD) competition: A methodology for comparing computational models of
    perceptual discriminability. Journal of Vision, 8(12), 1–13.
    https://ece.uwaterloo.ca/~z70wang/research/mad/
-   http://www.cns.nyu.edu/pub/lcv/wang08-preprint.pdf
+   https://www.cns.nyu.edu/pub/lcv/wang08-preprint.pdf
 .. [Henaff2016] H\'enaff, O.~J., & Simoncelli, E.~P. (2016). Geodesics of
    learned representations. ICLR.
-   http://www.cns.nyu.edu/pub/lcv/henaff16b-reprint.pdf
+   https://www.cns.nyu.edu/pub/lcv/henaff16b-reprint.pdf
 .. [Henaff2020] O Hénaff, Y Bai, J Charlton, I Nauhaus, E P Simoncelli and R L T
    Goris. Primary visual cortex straightens natural video trajectories Nature
    Communications, vol.12(5982), Oct 2021.
    https://www.cns.nyu.edu/pub/lcv/henaff20-reprint.pdf
 .. [Simoncelli1992] Simoncelli, E. P., Freeman, W. T., Adelson, E. H., &
    Heeger, D. J. (1992). Shiftable Multi-Scale Transforms. IEEE Trans.
-   Information Theory, 38(2), 587–607. http://dx.doi.org/10.1109/18.119725
+   Information Theory, 38(2), 587–607. https://dx.doi.org/10.1109/18.119725
 .. [Simoncelli1995] Simoncelli, E. P., & Freeman, W. T. (1995). The steerable
    pyramid: A flexible architecture for multi-scale derivative computation. In ,
    Proc 2nd IEEE Int'l Conf on Image Proc (ICIP) (pp. 444–447). Washington, DC:
-   IEEE Sig Proc Society. http://www.cns.nyu.edu/pub/eero/simoncelli95b.pdf
+   IEEE Sig Proc Society. https://www.cns.nyu.edu/pub/eero/simoncelli95b.pdf
 .. [Wang2004] Wang, Z., Bovik, A., Sheikh, H., & Simoncelli, E. (2004). Image
    quality assessment: from error visibility to structural similarity. IEEE
    Transactions on Image Processing, 13(4), 600–612.
    https://www.cns.nyu.edu/~lcv/ssim/.
-   http://www.cns.nyu.edu/pub/lcv/wang03-reprint.pdf
+   https://www.cns.nyu.edu/pub/lcv/wang03-reprint.pdf
 .. [Wang2003] Z Wang, E P Simoncelli and A C Bovik. Multiscale structural
    similarity for image quality assessment Proc 37th Asilomar Conf on Signals,
    Systems and Computers, vol.2 pp. 1398--1402, Nov 2003.
-   http://www.cns.nyu.edu/pub/eero/wang03b.pdf
+   https://www.cns.nyu.edu/pub/eero/wang03b.pdf
 .. [Laparra2017] Laparra, V., Berardino, A., Johannes Ball\'e, &
    Simoncelli, E. P. (2017). Perceptually Optimized Image Rendering. Journal of
    the Optical Society of America A, 34(9), 1511.
-   http://www.cns.nyu.edu/pub/lcv/laparra17a.pdf
+   https://www.cns.nyu.edu/pub/lcv/laparra17a.pdf
 .. [Laparra2016] Laparra, V., Ballé, J., Berardino, A. and Simoncelli,
    E.P., 2016. Perceptual image quality assessment using a normalized Laplacian
    pyramid. Electronic Imaging, 2016(16), pp.1-6.
-   http://www.cns.nyu.edu/pub/lcv/laparra16a-reprint.pdf
+   https://www.cns.nyu.edu/pub/lcv/laparra16a-reprint.pdf
 .. [Ziemba2021] Ziemba, C.M., and Simoncelli, E.P. (2021). Opposing effects of selectivity and invariance in peripheral vision.
    Nature Communications, vol.12(4597).
    https://dx.doi.org/10.1038/s41467-021-24880-5

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,21 +5,21 @@
                   :target: https://anaconda.org/conda-forge/plenoptic
 
 .. |license-shield| image:: https://img.shields.io/badge/license-MIT-yellow.svg
-                    :target: https://github.com/LabForComputationalVision/plenoptic/blob/main/LICENSE
+                    :target: https://github.com/plenoptic-org/plenoptic/blob/main/LICENSE
 
 .. |python-version-shield| image:: https://img.shields.io/badge/python-3.10%7C3.11%7C3.12-blue.svg
 
-.. |build| image:: https://github.com/LabForComputationalVision/plenoptic/workflows/build/badge.svg
-		     :target: https://github.com/LabForComputationalVision/plenoptic/actions?query=workflow%3Abuild
+.. |build| image:: https://github.com/plenoptic-org/plenoptic/workflows/build/badge.svg
+		     :target: https://github.com/plenoptic-org/plenoptic/actions?query=workflow%3Abuild
 
 .. |zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.10151130.svg
             :target: https://zenodo.org/doi/10.5281/zenodo.10151130
 
-.. |codecov| image:: https://codecov.io/gh/LabForComputationalVision/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA
-             :target: https://codecov.io/gh/LabForComputationalVision/plenoptic
+.. |codecov| image:: https://codecov.io/gh/plenoptic-org/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA
+             :target: https://codecov.io/gh/plenoptic-org/plenoptic
 
 .. |binder| image:: https://mybinder.org/badge_logo.svg
-		    :target: https://mybinder.org/v2/gh/LabForComputationalVision/plenoptic/1.0.1?filepath=examples
+		    :target: https://mybinder.org/v2/gh/plenoptic-org/plenoptic/1.0.1?filepath=examples
 
 .. plenoptic documentation master file, created by
    sphinx-quickstart on Thu Jun 20 15:56:27 2019.
@@ -157,20 +157,20 @@ Getting help
 We communicate via several channels on Github:
 
 - To report a bug, open an `issue
-  <https://github.com/LabForComputationalVision/plenoptic/issues>`_.
+  <https://github.com/plenoptic-org/plenoptic/issues>`_.
 - To send suggestions for extensions or enhancements, please post in the `ideas
   section
-  <https://github.com/LabForComputationalVision/plenoptic/discussions/categories/ideas>`_
+  <https://github.com/plenoptic-org/plenoptic/discussions/categories/ideas>`_
   of discussions first. We'll discuss it there and, if we decide to pursue it,
   open an issue to track progress.
 - To ask usage questions, discuss broad issues, or
   show off what you've made with plenoptic, go to `Discussions
-  <https://github.com/LabForComputationalVision/plenoptic/discussions>`_.
+  <https://github.com/plenoptic-org/plenoptic/discussions>`_.
 - To contribute to the project, see the `contributing guide
-  <https://github.com/LabForComputationalVision/plenoptic/blob/main/CONTRIBUTING.md>`_.
+  <https://github.com/plenoptic-org/plenoptic/blob/main/CONTRIBUTING.md>`_.
 
 In all cases, we request that you respect our `code of conduct
-<https://github.com/LabForComputationalVision/plenoptic/blob/main/CODE_OF_CONDUCT.md>`_.
+<https://github.com/plenoptic-org/plenoptic/blob/main/CODE_OF_CONDUCT.md>`_.
 
 Citing us
 ---------
@@ -226,7 +226,7 @@ cite us! See the :ref:`citation` for more details.
        <https://proceedings.neurips.cc/paper_files/paper/2019/hash/ac27b77292582bc293a51055bfc994ee-Abstract.html>`_
        though we haven't yet implemented examples. If you're interested, please
        post in `Discussions
-       <https://github.com/LabForComputationalVision/plenoptic/discussions)>`_!
+       <https://github.com/plenoptic-org/plenoptic/discussions)>`_!
 
 .. [Portilla2000] Portilla, J., & Simoncelli, E. P. (2000). A parametric texture
    model based on joint statistics of complex wavelet coefficients.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,14 +3,14 @@
 Installation
 ************
 
-``plenoptic`` should work on Windows, Linux, or Mac. If you have a problem with installation, please open a `bug report <https://github.com/LabForComputationalVision/plenoptic/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=>`_!
+``plenoptic`` should work on Windows, Linux, or Mac. If you have a problem with installation, please open a `bug report <https://github.com/plenoptic-org/plenoptic/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=>`_!
 
 You can install ``plenoptic`` from `PyPI <https://pypi.org/project/plenoptic/>`_  (the Python Package Index) or `conda-forge <https://anaconda.org/conda-forge/plenoptic>`_, and we provide separate instructions for the two methods. If you will be contributing to ``plenoptic``, and so need an editable install and :ref:`optional-deps`, you should use :ref:`pip <pip>`. Otherwise, you can use whichever you are more familiar with, though we have noticed that it tends to be easier to install `pytorch <https://pytorch.org/>`_ with GPU support using ``conda``.
 
 .. tip::
    If you are unfamiliar with python environment management, we recommend :ref:`conda`.
 
-Our dependencies include `pytorch <https://pytorch.org/>`_ and `pyrtools <https://pyrtools.readthedocs.io/en/latest/>`_. Installation should take care of them (along with our other dependencies) automatically, but if you have an installation problem (especially on a non-Linux operating system), it is likely that the problem lies with one of those packages. `Open an issue <https://github.com/LabForComputationalVision/plenoptic/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=>`_ and we'll try to help you figure out the problem!
+Our dependencies include `pytorch <https://pytorch.org/>`_ and `pyrtools <https://pyrtools.readthedocs.io/en/latest/>`_. Installation should take care of them (along with our other dependencies) automatically, but if you have an installation problem (especially on a non-Linux operating system), it is likely that the problem lies with one of those packages. `Open an issue <https://github.com/plenoptic-org/plenoptic/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=>`_ and we'll try to help you figure out the problem!
 
 .. _conda:
 
@@ -65,13 +65,13 @@ Note that when using ``venv``, you have to decide where you'd like to place the 
 Installing from source (for developers)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can also install plenoptic directly from source in order to have a local editable copy. This is most useful for developing (for more info, see `our contributing guide <https://github.com/LabForComputationalVision/plenoptic/blob/main/CONTRIBUTING.md>`_) or if you want to use the most cutting-edge version.
+You can also install plenoptic directly from source in order to have a local editable copy. This is most useful for developing (for more info, see `our contributing guide <https://github.com/plenoptic-org/plenoptic/blob/main/CONTRIBUTING.md>`_) or if you want to use the most cutting-edge version.
 
 .. tab:: Linux / MacOS
 
    .. code-block:: shell
 
-      $ git clone https://github.com/LabForComputationalVision/plenoptic.git
+      $ git clone https://github.com/plenoptic-org/plenoptic.git
       $ cd plenoptic
       # create the environment
       $ python -m venv .venv
@@ -84,7 +84,7 @@ You can also install plenoptic directly from source in order to have a local edi
 
    .. code-block:: powershell
 
-      $ git clone https://github.com/LabForComputationalVision/plenoptic.git
+      $ git clone https://github.com/plenoptic-org/plenoptic.git
       $ cd plenoptic
       # create the environment
       $ python -m venv .venv
@@ -97,7 +97,7 @@ With an editable copy, any changes locally will be automatically reflected in yo
 
 Note that, with the above setup, all files related to your virtual environment are stored in a hidden directory named ``.venv`` within the ``plenoptic/`` directory you cloned. Therefore, if you delete the ``plenoptic/`` directory, you'll need to rerun the setup above to create a new virtual environment.
 
-.. attention:: To install ``plenoptic`` in editable mode, you need ``pip >= 21.3`` (see pip's `changelog <https://pip.pypa.io/en/stable/news/#id286>`_). If you run into `an error <https://github.com/LabForComputationalVision/plenoptic/issues/227>`_ after running the ``pip install -e .`` command, try updating your pip version with ``pip install --upgrade pip``.
+.. attention:: To install ``plenoptic`` in editable mode, you need ``pip >= 21.3`` (see pip's `changelog <https://pip.pypa.io/en/stable/news/#id286>`_). If you run into `an error <https://github.com/plenoptic-org/plenoptic/issues/227>`_ after running the ``pip install -e .`` command, try updating your pip version with ``pip install --upgrade pip``.
 
 .. _optional-deps:
 
@@ -106,20 +106,20 @@ Optional dependencies
 
 The above instructions will install plenoptic and its core dependencies. You may also wish to install some additional optional dependencies. These dependencies are specified using square brackets during the ``pip install`` command and can be installed for either a local, editable install or one directly from PyPI:
 
-* If you would like to run the jupyter notebooks locally: ``pip install plenoptic[nb]`` or ``pip install -e .[nb]``. This includes ``pooch`` (for downloading some extra data) ``torchvision`` (which has some models we'd like to use), ``jupyter``, and related libraries. See the :ref:`jupyter section <jupyter>` for a discussion of several ways to handle jupyter and python virtual environments. Note that you can run our notebooks in the cloud using `Binder <https://mybinder.org/v2/gh/LabForComputationalVision/plenoptic/1.0.1?filepath=examples>`_, no installation required!
+* If you would like to run the jupyter notebooks locally: ``pip install plenoptic[nb]`` or ``pip install -e .[nb]``. This includes ``pooch`` (for downloading some extra data) ``torchvision`` (which has some models we'd like to use), ``jupyter``, and related libraries. See the :ref:`jupyter section <jupyter>` for a discussion of several ways to handle jupyter and python virtual environments. Note that you can run our notebooks in the cloud using `Binder <https://mybinder.org/v2/gh/plenoptic-org/plenoptic/1.0.1?filepath=examples>`_, no installation required!
 * If you would like to locally build the documentation: ``pip install -e .[docs]``. This includes ``sphinx`` and related libraries. (This probably only makes sense if you have a local installation.)
 * If you would like to run the tests: ``pip install -e .[dev]``. This includes ``pytest`` and related libraries. (This probably only makes sense if you have a local installation.)
 
 These optional dependencies can be joined with a comma, e.g., ``pip install -e .[docs,dev]``
 
-.. note:: Note that ``conda`` does not support optional dependencies, though you can view our optional dependencies in the `pyproject.toml <https://github.com/LabForComputationalVision/plenoptic/blob/main/pyproject.toml#L35>`_ file, if you wish to install them yourself.
+.. note:: Note that ``conda`` does not support optional dependencies, though you can view our optional dependencies in the `pyproject.toml <https://github.com/plenoptic-org/plenoptic/blob/main/pyproject.toml#L35>`_ file, if you wish to install them yourself.
 
 .. _jupyter:
 
 Running notebooks locally
 -------------------------
 
-.. tip:: You can run the notebooks in the cloud using `Binder <https://mybinder.org/v2/gh/LabForComputationalVision/plenoptic/1.0.1?filepath=examples>`_, no installation required!
+.. tip:: You can run the notebooks in the cloud using `Binder <https://mybinder.org/v2/gh/plenoptic-org/plenoptic/1.0.1?filepath=examples>`_, no installation required!
 
 Installing jupyter and setting up the kernel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -310,7 +310,7 @@ Running the notebooks
 
 Once you have jupyter installed and the kernel set up, navigate to plenoptic's ``examples/`` directory on your terminal and activate the environment you installed jupyter into, then run ``jupyter`` and open up the notebooks. If you did not install ``jupyter`` into the same environment as ``plenoptic``, you should be prompted to select your kernel the first time you open a notebook: select the one named "plenoptic".
 
-.. attention:: If you did not install ``plenoptic`` from source, then you will not have the notebooks on your machine and will need to download them directly from `our GitHub repo <https://github.com/LabForComputationalVision/plenoptic/tree/main/examples>`_. If installed them from source (and thus ran ``git clone``), then the notebooks can be found in the ``examples/`` directory.
+.. attention:: If you did not install ``plenoptic`` from source, then you will not have the notebooks on your machine and will need to download them directly from `our GitHub repo <https://github.com/plenoptic-org/plenoptic/tree/main/examples>`_. If installed them from source (and thus ran ``git clone``), then the notebooks can be found in the ``examples/`` directory.
 
 ffmpeg and videos
 -----------------

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -21,7 +21,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -64,5 +64,5 @@ for an example):
 .. [PS] J Portilla and E P Simoncelli. A Parametric Texture Model based on Joint
         Statistics of Complex Wavelet Coefficients. Int'l Journal of Computer
         Vision. 40(1):49-71, October, 2000. `abstract
-        <http://www.cns.nyu.edu/~eero/ABSTRACTS/portilla99-abstract.html>`_,
-        `paper <http://www.cns.nyu.edu/~lcv/texture/>`_.
+        <https://www.cns.nyu.edu/~eero/ABSTRACTS/portilla99-abstract.html>`_,
+        `paper <https://www.cns.nyu.edu/~lcv/texture/>`_.

--- a/docs/reproducibility.rst
+++ b/docs/reproducibility.rst
@@ -26,7 +26,7 @@ reproducibility:
 - PyTorch 1.8 and 1.9 give the same results, but 1.10 changes results in
   changes, probably due to the difference in how the sub-gradient for
   ``torch.min`` and ``torch.max`` are computed (`see this PR
-  <https://github.com/LabForComputationalVision/plenoptic/pull/96#issuecomment-973318291>`_).
+  <https://github.com/plenoptic-org/plenoptic/pull/96#issuecomment-973318291>`_).
 
 - PyTorch 1.12 breaks reproducibility with 1.10 and 1.11, unclear why (`see this
-  issue <https://github.com/LabForComputationalVision/plenoptic/issues/165>`_).
+  issue <https://github.com/plenoptic-org/plenoptic/issues/165>`_).

--- a/docs/scripts/conceptual_intro.py
+++ b/docs/scripts/conceptual_intro.py
@@ -13,7 +13,7 @@ plt.rcParams['savefig.edgecolor'] = 'white'
 plt.rcParams['savefig.bbox'] = 'tight'
 
 # 2-deg fundamentals (energy linear, 5nm stepsize) from Stockman & Sharpe 2000,
-# downloaded from https://www.cvrl.org/cones.htm
+# downloaded from http://www.cvrl.org/cones.htm
 CONES = {"nm": [400, 405, 410, 415, 420, 425, 430, 435, 440, 445, 450, 455,
                 460, 465, 470, 475, 480, 485, 490, 495, 500, 505, 510, 515,
                 520, 525, 530, 535, 540, 545, 550, 555, 560, 565, 570, 575,

--- a/docs/scripts/conceptual_intro.py
+++ b/docs/scripts/conceptual_intro.py
@@ -13,7 +13,7 @@ plt.rcParams['savefig.edgecolor'] = 'white'
 plt.rcParams['savefig.bbox'] = 'tight'
 
 # 2-deg fundamentals (energy linear, 5nm stepsize) from Stockman & Sharpe 2000,
-# downloaded from http://www.cvrl.org/cones.htm
+# downloaded from https://www.cvrl.org/cones.htm
 CONES = {"nm": [400, 405, 410, 415, 420, 425, 430, 435, 440, 445, 450, 455,
                 460, 465, 470, 475, 480, 485, 490, 495, 500, 505, 510, 515,
                 520, 525, 530, 535, 540, 545, 550, 555, 560, 565, 570, 575,

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -113,4 +113,4 @@ methods.
 
 If you extend a method successfully or would like help making it work, please
 let us know by posting a `discussion!
-<https://github.com/LabForComputationalVision/plenoptic/discussions>`_
+<https://github.com/plenoptic-org/plenoptic/discussions>`_

--- a/examples/02_Eigendistortions.ipynb
+++ b/examples/02_Eigendistortions.ipynb
@@ -31,9 +31,9 @@
     "Eigen-distortions of hierarchical representations.\n",
     "In Advances in neural information processing systems (pp. 3530-3539)._\n",
     "\n",
-    "http://www.cns.nyu.edu/pub/lcv/berardino17c-final.pdf\n",
+    "https://www.cns.nyu.edu/pub/lcv/berardino17c-final.pdf\n",
     "\n",
-    "http://www.cns.nyu.edu/~lcv/eigendistortions/\n",
+    "https://www.cns.nyu.edu/~lcv/eigendistortions/\n",
     "\n",
     "**See the last section of this notebook for more mathematical detail**\n"
    ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 # Plenoptic example notebooks
-[![Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/LabForComputationalVision/plenoptic/1.0.1?filepath=examples)
+[![Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plenoptic-org/plenoptic/1.0.1?filepath=examples)
 
 Browse, preview, and run these notebooks in your browser without installing 
 ``plenoptic.py`` using the ``launch Binder`` button above.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 # Plenoptic example notebooks
-[![Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plenoptic-org/plenoptic/1.0.1?filepath=examples)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plenoptic-org/plenoptic/1.0.1?filepath=examples)
 
 Browse, preview, and run these notebooks in your browser without installing 
 ``plenoptic.py`` using the ``launch Binder`` button above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ nb = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/LabForComputationalVision/plenoptic"
+"Homepage" = "https://github.com/plenoptic-org/plenoptic"
 "Documentation" = "https://plenoptic.readthedocs.io/en/latest/"
 "Download" = "https://zenodo.org/doi/10.5281/zenodo.10151130"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dev = [
     "pytest>=5.1.2",
     'pytest-cov',
     'pytest-xdist',
-    "requests>=2.21",
     "pooch>=1.2.0",
 ]
 

--- a/src/plenoptic/metric/perceptual_distance.py
+++ b/src/plenoptic/metric/perceptual_distance.py
@@ -181,7 +181,7 @@ def ssim(img1, img2, weighted=False, pad=False):
     .. [4] Wang, Z., & Simoncelli, E. P. (2008). Maximum differentiation (MAD)
        competition: A methodology for comparing computational models of
        perceptual discriminability. Journal of Vision, 8(12), 1–13.
-       http://dx.doi.org/10.1167/8.12.8
+       https://dx.doi.org/10.1167/8.12.8
 
     """
     # these are named map_ssim instead of the perhaps more natural ssim_map
@@ -253,7 +253,7 @@ def ssim_map(img1, img2):
     .. [4] Wang, Z., & Simoncelli, E. P. (2008). Maximum differentiation (MAD)
        competition: A methodology for comparing computational models of
        perceptual discriminability. Journal of Vision, 8(12), 1–13.
-       http://dx.doi.org/10.1167/8.12.8
+       https://dx.doi.org/10.1167/8.12.8
 
     """
     if min(img1.shape[2], img1.shape[3]) < 11:

--- a/src/plenoptic/simulate/models/frontend.py
+++ b/src/plenoptic/simulate/models/frontend.py
@@ -7,7 +7,7 @@ References
 ----------
 .. [1] A Berardino, J Ballé, V Laparra, EP Simoncelli, Eigen-distortions of hierarchical
     representations, NeurIPS 2017; https://arxiv.org/abs/1710.02266
-.. [2] http://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
+.. [2] https://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
 """
 
 from typing import Tuple, Union, Callable
@@ -61,7 +61,7 @@ class LinearNonlinear(nn.Module):
     ----------
     .. [1] A Berardino, J Ballé, V Laparra, EP Simoncelli, Eigen-distortions of hierarchical
         representations, NeurIPS 2017; https://arxiv.org/abs/1710.02266
-    .. [2] http://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
+    .. [2] https://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
     """
 
     def __init__(
@@ -148,7 +148,7 @@ class LuminanceGainControl(nn.Module):
     ----------
     .. [1] A Berardino, J Ballé, V Laparra, EP Simoncelli, Eigen-distortions of hierarchical
         representations, NeurIPS 2017; https://arxiv.org/abs/1710.02266
-    .. [2] http://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
+    .. [2] https://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
     """
     def __init__(
         self,
@@ -250,7 +250,7 @@ class LuminanceContrastGainControl(nn.Module):
     ----------
     .. [1] A Berardino, J Ballé, V Laparra, EP Simoncelli, Eigen-distortions of hierarchical
         representations, NeurIPS 2017; https://arxiv.org/abs/1710.02266
-    .. [2] http://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
+    .. [2] https://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
     """
 
     def __init__(
@@ -364,7 +364,7 @@ class OnOff(nn.Module):
     ----------
     .. [1] A Berardino, J Ballé, V Laparra, EP Simoncelli, Eigen-distortions of
         hierarchical representations, NeurIPS 2017; https://arxiv.org/abs/1710.02266
-    .. [2] http://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
+    .. [2] https://www.cns.nyu.edu/~lcv/eigendistortions/ModelsIQA.html
     """
 
     def __init__(

--- a/src/plenoptic/simulate/models/portilla_simoncelli.py
+++ b/src/plenoptic/simulate/models/portilla_simoncelli.py
@@ -68,8 +68,8 @@ class PortillaSimoncelli(nn.Module):
     .. [1] J Portilla and E P Simoncelli. A Parametric Texture Model based on
        Joint Statistics of Complex Wavelet Coefficients. Int'l Journal of
        Computer Vision. 40(1):49-71, October, 2000.
-       http://www.cns.nyu.edu/~eero/ABSTRACTS/portilla99-abstract.html
-       http://www.cns.nyu.edu/~lcv/texture/
+       https://www.cns.nyu.edu/~eero/ABSTRACTS/portilla99-abstract.html
+       https://www.cns.nyu.edu/~lcv/texture/
     .. [2] E P Simoncelli and W T Freeman, "The Steerable Pyramid: A Flexible
        Architecture for Multi-Scale Derivative Computation," Second Int'l Conf
        on Image Processing, Washington, DC, Oct 1995.

--- a/src/plenoptic/synthesize/eigendistortion.py
+++ b/src/plenoptic/synthesize/eigendistortion.py
@@ -110,8 +110,8 @@ class Eigendistortion(Synthesis):
     .. [1] Berardino, A., Laparra, V., Ballé, J. and Simoncelli, E., 2017.
            Eigen-distortions of hierarchical representations. In Advances in
            neural information processing systems (pp. 3530-3539).
-           http://www.cns.nyu.edu/pub/lcv/berardino17c-final.pdf
-           http://www.cns.nyu.edu/~lcv/eigendistortions/
+           https://www.cns.nyu.edu/pub/lcv/berardino17c-final.pdf
+           https://www.cns.nyu.edu/~lcv/eigendistortions/
 
     """
 

--- a/src/plenoptic/synthesize/geodesic.py
+++ b/src/plenoptic/synthesize/geodesic.py
@@ -93,7 +93,7 @@ class Geodesic(OptimizedSynthesis):
     .. [1] Geodesics of learned representations
         O J Hénaff and E P Simoncelli
         Published in Int'l Conf on Learning Representations (ICLR), May 2016.
-        http://www.cns.nyu.edu/~lcv/pubs/makeAbs.php?loc=Henaff16b
+        https://www.cns.nyu.edu/~lcv/pubs/makeAbs.php?loc=Henaff16b
 
     """
     def __init__(self, image_a: Tensor, image_b: Tensor,

--- a/src/plenoptic/synthesize/mad_competition.py
+++ b/src/plenoptic/synthesize/mad_competition.py
@@ -94,7 +94,7 @@ class MADCompetition(OptimizedSynthesis):
     .. [1] Wang, Z., & Simoncelli, E. P. (2008). Maximum differentiation (MAD)
            competition: A methodology for comparing computational models of
            perceptual discriminability. Journal of Vision, 8(12), 1–13.
-           http://dx.doi.org/10.1167/8.12.8
+           https://dx.doi.org/10.1167/8.12.8
 
     """
     def __init__(self, image: Tensor,

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -78,8 +78,8 @@ class Metamer(OptimizedSynthesis):
     .. [1] J Portilla and E P Simoncelli. A Parametric Texture Model
        based on Joint Statistics of Complex Wavelet Coefficients. Int'l
        Journal of Computer Vision. 40(1):49-71, October, 2000.
-       http://www.cns.nyu.edu/~eero/ABSTRACTS/portilla99-abstract.html
-       http://www.cns.nyu.edu/~lcv/texture/
+       https://www.cns.nyu.edu/~eero/ABSTRACTS/portilla99-abstract.html
+       https://www.cns.nyu.edu/~lcv/texture/
 
     """
     def __init__(self, image: Tensor, model: torch.nn.Module,


### PR DESCRIPTION
Updates links from `LabForComputationalVision/plenoptic` to `plenoptic-org/plenoptic`