### PR TITLE
Fix jenkins

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
       pip install -U pip
 	  pip install -U .[dev] --verbose
       python3.11 -c "import torch; print(torch.cuda.current_device())"
-	  python3.11 -m pytest
+	  python3.11 -m pytest -n 8
 	'''
       }
     }


### PR DESCRIPTION
Small fix to the jenkins job that runs when a PR is merged: need to add `-n 8`, because `-n auto` causes too many jobs to be run at once and thus CUDA to run out of memory. Had already done this for the jenkins jobs that run during a PR, but not the merge one.