### PR TITLE
Specify docutils version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ docs = [
      'sphinx-copybutton',
      'sphinxemoji',
      'sphinx-inline-tabs',
+     'docutils>=0.18.1,<0.21',
 ]
 
 dev = [


### PR DESCRIPTION
Sphinx build is failing because of a change to docutils, which is discussed [here](https://github.com/CrossNox/m2r2/issues/68). By specifying the docutils version, this should solve the issue, but it should be only necessary temporarily until [nbsphinx-link makes the relevant update](https://github.com/vidartf/nbsphinx-link/pull/23)