### PR TITLE
Fix broken to method, test non-standard models/metrics, don't assume dtype

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -46,9 +46,10 @@ metric meets the following requirements and see :class:`plenoptic.metric` for
 some examples):
 
 * a metric must be callable, accept two 4d ``torch.Tensor`` objects as inputs,
-  and return a scalar as output. This can be a ``torch.nn.Module`` object, like
-  models, but the examples metrics are all functions.
+  and return a scalar as output. It can be a ``torch.nn.Module`` object or other
+  callable object, like models, as well as a function.
 * when called on two identical inputs, the metric must return a value of 0.
+* it must always return a non-negative number.
 
 Finally, :class:`plenoptic.synthesize.metamer.Metamer` supports coarse-to-fine
 synthesis, as described in [PS]_. To make use of coarse-to-fine synthesis, your

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -12,8 +12,12 @@ way to check whether your model meets the following requirements, and see
 * should inherit ``torch.nn.Module`` (this is not strictly necessary, but will
   make meeting the other requirements easier).
 * must be callable, be able to accept a 4d ``torch.Tensor`` as input, and return
-  a 3d or 4d ``torch.Tensor`` as output. If you inherit ``torch.nn.Module``,
-  implementing the ``forward()`` method will make your model callable.
+  a 3d or 4d ``torch.Tensor`` as output.
+
+  * If you inherit ``torch.nn.Module``, implementing the ``forward()`` method
+    will make your model callable.
+  * Otherwise, implement the ``__call__()`` method.
+
 * the above transformation must be differentiable by ``torch``. In practice,
   this generally means you perform all computations using ``torch`` functions
   (unless you want to write a custom ``.backward()`` method).

--- a/src/plenoptic/metric/perceptual_distance.py
+++ b/src/plenoptic/metric/perceptual_distance.py
@@ -373,7 +373,7 @@ def normalized_laplacian_pyramid(img):
     padd = 2
     normalized_laplacian_activations = []
     for N_b in range(0, N_scales):
-        filt = torch.as_tensor(spatialpooling_filters[N_b], dtype=torch.float32,
+        filt = torch.as_tensor(spatialpooling_filters[N_b], dtype=img.dtype,
                             device=img.device).repeat(channel, 1, 1, 1)
         filtered_activations = F.conv2d(torch.abs(laplacian_activations[N_b]), filt, padding=padd, groups=channel)
         normalized_laplacian_activations.append(laplacian_activations[N_b] / (sigmas[N_b] + filtered_activations))

--- a/src/plenoptic/synthesize/eigendistortion.py
+++ b/src/plenoptic/synthesize/eigendistortion.py
@@ -507,9 +507,19 @@ class Eigendistortion(Synthesis):
 
         """
         attrs = ["_jacobian", "_eigendistortions", "_eigenvalues",
-                 "_eigenindex", "_model", "_image", "_image_flat",
+                 "_eigenindex", "_image", "_image_flat",
                  "_representation_flat"]
         super().to(*args, attrs=attrs, **kwargs)
+        # we need _representation_flat and _image_flat to be connected in the
+        # computation graph for the autograd calls to work, so we reinitialize
+        # it here
+        self._init_representation(self.image)
+        # try to call .to() on model. this should work, but it might fail if e.g., this
+        # a custom model that doesn't inherit torch.nn.Module
+        try:
+            self._model = self._model.to(*args, **kwargs)
+        except AttributeError:
+            warnings.warn("Unable to call model.to(), so we leave it as is.")
 
     def load(self, file_path: str,
              map_location: Union[str, None] = None,

--- a/src/plenoptic/synthesize/mad_competition.py
+++ b/src/plenoptic/synthesize/mad_competition.py
@@ -127,7 +127,7 @@ class MADCompetition(OptimizedSynthesis):
         # approximately the same magnitude
         if metric_tradeoff_lambda is None:
             loss_ratio = torch.as_tensor(self.optimized_metric_loss[-1] / self.reference_metric_loss[-1],
-                                      dtype=torch.float32)
+                                         dtype=image.dtype)
             metric_tradeoff_lambda = torch.pow(torch.as_tensor(10),
                                                torch.round(torch.log10(loss_ratio))).item()
             warnings.warn("Since metric_tradeoff_lamda was None, automatically set"

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -387,8 +387,14 @@ class Metamer(OptimizedSynthesis):
 
         """
         attrs = ['_image', '_target_representation',
-                 '_metamer', '_model', '_saved_metamer']
+                 '_metamer', '_saved_metamer']
         super().to(*args, attrs=attrs, **kwargs)
+        # try to call .to() on model. this should work, but it might fail if e.g., this
+        # a custom model that doesn't inherit torch.nn.Module
+        try:
+            self._model = self._model.to(*args, **kwargs)
+        except AttributeError:
+            warnings.warn("Unable to call model.to(), so we leave it as is.")
 
     def load(self, file_path: str,
              map_location: Optional[str] = None,

--- a/src/plenoptic/synthesize/synthesis.py
+++ b/src/plenoptic/synthesize/synthesis.py
@@ -2,6 +2,7 @@
 import abc
 import warnings
 import torch
+import numpy as np
 from typing import Optional, List, Tuple, Union
 
 
@@ -149,6 +150,11 @@ class Synthesis(abc.ABC):
                                            f"{tmp_dict[k].dtype}")
                     else:
                         raise e
+            elif isinstance(getattr(self, k), float):
+                if not np.allclose(getattr(self, k), tmp_dict[k]):
+                    raise ValueError(f"Saved and initialized {display_k} are different!"
+                                     f" Self: {getattr(self, k)}, "
+                                     f"Saved: {tmp_dict[k]}")
             else:
                 if getattr(self, k) != tmp_dict[k]:
                     raise ValueError(f"Saved and initialized {display_k} are different!"

--- a/src/plenoptic/synthesize/synthesis.py
+++ b/src/plenoptic/synthesize/synthesis.py
@@ -205,11 +205,6 @@ class Synthesis(abc.ABC):
             attrs (:class:`list`): list of strs containing the attributes of
                 this object to move to the specified device/dtype
         """
-        try:
-            self.model = self.model.to(*args, **kwargs)
-        except AttributeError:
-            warnings.warn("model has no `to` method, so we leave it as is...")
-
         device, dtype, non_blocking, memory_format = torch._C._nn._parse_to(*args, **kwargs)
 
         def move(a, k):
@@ -224,12 +219,16 @@ class Synthesis(abc.ABC):
             if hasattr(self, k):
                 attr = getattr(self, k)
                 if isinstance(attr, torch.Tensor):
-                    attr = move(attr, k)
+                    attr = move(attr.data, k)
                     if isinstance(getattr(self, k), torch.nn.Parameter):
                         attr = torch.nn.Parameter(attr)
+                    if getattr(self, k).requires_grad:
+                        attr = attr.requires_grad_()
                     setattr(self, k, attr)
                 elif isinstance(attr, list):
                     setattr(self, k, [move(a, k) for a in attr])
+                elif attr is not None:
+                    setattr(self, k, move(attr, k))
 
 
 class OptimizedSynthesis(Synthesis):

--- a/src/plenoptic/tools/conv.py
+++ b/src/plenoptic/tools/conv.py
@@ -77,7 +77,7 @@ def blur_downsample(x, n_scales=1, filtname="binom5", scale_filter=True):
     """
 
     f = pt.named_filter(filtname)
-    filt = torch.as_tensor(np.outer(f, f), dtype=torch.float32, device=x.device)
+    filt = torch.as_tensor(np.outer(f, f), dtype=x.dtype, device=x.device)
     if scale_filter:
         filt = filt / 2
     for _ in range(n_scales):
@@ -103,7 +103,7 @@ def upsample_blur(x, odd, filtname="binom5", scale_filter=True):
     """
 
     f = pt.named_filter(filtname)
-    filt = torch.as_tensor(np.outer(f, f), dtype=torch.float32, device=x.device)
+    filt = torch.as_tensor(np.outer(f, f), dtype=x.dtype, device=x.device)
     if scale_filter:
         filt = filt * 2
     return upsample_convolve(x, odd, filt)

--- a/src/plenoptic/tools/signal.py
+++ b/src/plenoptic/tools/signal.py
@@ -376,7 +376,7 @@ def add_noise(img: Tensor, noise_mse: Union[float, List[float]]) -> Tensor:
 
     """
     noise_mse = torch.as_tensor(
-        noise_mse, dtype=torch.float32, device=img.device
+        noise_mse, dtype=img.dtype, device=img.device
     ).unsqueeze(0)
     noise_mse = noise_mse.view(noise_mse.nelement(), 1, 1, 1)
     noise = 200 * torch.randn(

--- a/src/plenoptic/tools/validate.py
+++ b/src/plenoptic/tools/validate.py
@@ -284,6 +284,11 @@ def validate_metric(metric: Union[torch.nn.Module, Callable[[Tensor, Tensor], Te
         raise ValueError(
             f"metric should return <= 5e-7 on two identical images but got {same_val}"
         )
+    # this is hard to test
+    for i in range(20):
+        second_test_img = torch.rand_like(test_img)
+        if metric(test_img, second_test_img).item() < 0:
+            raise ValueError("metric should always return non-negative numbers!")
 
 
 def remove_grad(model: torch.nn.Module):

--- a/src/plenoptic/tools/validate.py
+++ b/src/plenoptic/tools/validate.py
@@ -174,7 +174,7 @@ def validate_model(model: torch.nn.Module,
     if model(test_img).device != test_img.device:
         # pytorch device errors are RuntimeErrors
         raise RuntimeError("model changes device of input, don't do that!")
-    if model.training:
+    if hasattr(model, 'training') and model.training:
         warnings.warn(
             "model is in training mode, you probably want to call eval()"
             " to switch to evaluation mode"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,13 @@ def get_model(name):
         return model
     elif name == "PortillaSimoncelli":
         return po.simul.PortillaSimoncelli((256, 256))
+    elif name == "NonModule":
+        class NonModule:
+            def __init__(self):
+                self.name = "nonmodule"
+            def __call__(self, x):
+                return 1 * x
+        return NonModule()
 
 
 @pytest.fixture(scope='package')

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -171,13 +171,16 @@ class TestEigendistortionSynthesis:
         ed = Eigendistortion(curie_img, model)
         ed.synthesize(max_iter=5, method='power')
         if to_type == 'dtype':
-            ed.to(torch.float16)
-            assert ed.image.dtype == torch.float16
-            assert ed.eigendistortions.dtype == torch.float16
+            # can't use the power method on a float16 tensor, so we use float64 instead
+            # here.
+            ed.to(torch.float64)
+            assert ed.image.dtype == torch.float64
+            assert ed.eigendistortions.dtype == torch.float64
         # can only run this one if we're on a device with CPU and GPU.
         elif to_type == 'device' and DEVICE.type != 'cpu':
             ed.to('cpu')
         ed.eigendistortions - ed.image
+        ed.synthesize(max_iter=5, method='power')
 
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Only makes sense to test on cuda")
     @pytest.mark.parametrize('model', ['Identity'], indirect=True)

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -165,7 +165,7 @@ class TestEigendistortionSynthesis:
             # check that can resume
             ed_copy.synthesize(max_iter=4, method=method)
 
-    @pytest.mark.parametrize('model', ['Identity'], indirect=True)
+    @pytest.mark.parametrize('model', ['Identity', 'NonModule'], indirect=True)
     @pytest.mark.parametrize('to_type', ['dtype', 'device'])
     def test_to(self, curie_img, model, to_type):
         ed = Eigendistortion(curie_img, model)

--- a/tests/test_mad.py
+++ b/tests/test_mad.py
@@ -126,6 +126,7 @@ class TestMAD(object):
         # this
         mad.initial_image - mad.image
         mad.mad_image - mad.image
+        mad.synthesize(max_iter=5)
 
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Only makes sense to test on cuda")
     def test_map_location(self, curie_img, tmp_path):

--- a/tests/test_mad.py
+++ b/tests/test_mad.py
@@ -28,6 +28,21 @@ def dis_ssim(*args):
     return (1 - po.metric.ssim(*args)).mean()
 
 
+class ModuleMetric(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mdl = po.metric.NLP()
+    def forward(self, x, y):
+        return (self.mdl(x) - self.mdl(y)).abs().mean()
+
+
+class NonModuleMetric:
+    def __init__(self):
+        self.name = 'nonmodule'
+    def __call__(self, x, y):
+        return (x-y).abs().sum()
+
+
 class TestMAD(object):
 
     @pytest.mark.parametrize('target', ['min', 'max'])
@@ -109,16 +124,17 @@ class TestMAD(object):
                 scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer)
         mad.synthesize(max_iter=5, optimizer=optimizer, scheduler=scheduler)
 
+    @pytest.mark.parametrize('metric', [po.metric.mse, ModuleMetric(), NonModuleMetric()])
     @pytest.mark.parametrize('to_type', ['dtype', 'device'])
-    def test_to(self, curie_img, to_type):
-        mad = po.synth.MADCompetition(curie_img, po.metric.mse,
+    def test_to(self, curie_img, metric, to_type):
+        mad = po.synth.MADCompetition(curie_img, metric,
                                       po.tools.optim.l2_norm, 'min')
         mad.synthesize(max_iter=5)
         if to_type == 'dtype':
-            mad.to(torch.float16)
-            assert mad.initial_image.dtype == torch.float16
-            assert mad.image.dtype == torch.float16
-            assert mad.mad_image.dtype == torch.float16
+            mad.to(torch.float64)
+            assert mad.initial_image.dtype == torch.float64
+            assert mad.image.dtype == torch.float64
+            assert mad.mad_image.dtype == torch.float64
         # can only run this one if we're on a device with CPU and GPU.
         elif to_type == 'device' and DEVICE.type != 'cpu':
             mad.to('cpu')

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -167,6 +167,7 @@ class TestMetamers(object):
         elif to_type == 'device' and DEVICE.type != 'cpu':
             met.to('cpu')
         met.metamer - met.image
+        met.synthesize(max_iter=5)
 
     # this determines whether we mix across channels or treat them separately,
     # both of which are supported

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -154,7 +154,7 @@ class TestMetamers(object):
         assert met_copy.image.device.type == 'cpu'
         met_copy.synthesize(max_iter=4, store_progress=True)
 
-    @pytest.mark.parametrize('model', ['Identity'], indirect=True)
+    @pytest.mark.parametrize('model', ['Identity', 'NonModule'], indirect=True)
     @pytest.mark.parametrize('to_type', ['dtype', 'device'])
     def test_to(self, curie_img, model, to_type):
         met = po.synth.Metamer(curie_img, model)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -80,8 +80,9 @@ class TestSignal(object):
     
     @pytest.mark.parametrize('size_A', [1, 3])
     @pytest.mark.parametrize('size_B', [1, 2, 3])
-    def test_add_noise(self, einstein_img, size_A, size_B):
-        A = einstein_img.repeat(size_A, 1, 1, 1)
+    @pytest.mark.parametrize('dtype', [torch.float16, torch.float32, torch.float64])
+    def test_add_noise(self, einstein_img, size_A, size_B, dtype):
+        A = einstein_img.repeat(size_A, 1, 1, 1).to(dtype)
         B = size_B * [4]
         if size_A != size_B and size_A != 1 and size_B != 1:
             with pytest.raises(Exception):
@@ -249,13 +250,14 @@ class TestDownsampleUpsample(object):
 
     @pytest.mark.parametrize('odd', [0, 1])
     @pytest.mark.parametrize('size', [9, 10, 11, 12])
-    def test_filter(self, odd, size):
-        img = torch.zeros([1, 1, 24 + odd, 25], device=DEVICE, dtype=torch.float32)
+    @pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
+    def test_filter(self, odd, size, dtype):
+        img = torch.zeros([1, 1, 24 + odd, 25], device=DEVICE, dtype=dtype)
         img[0, 0, 12, 12] = 1
         filt = np.zeros([size, size + 1])
         filt[5, 5] = 1
         filt = scipy.ndimage.gaussian_filter(filt, sigma=1)
-        filt = torch.as_tensor(filt, dtype=torch.float32, device=DEVICE)
+        filt = torch.as_tensor(filt, dtype=dtype, device=DEVICE)
         img_down = po.tools.correlate_downsample(img, filt=filt)
         img_up = po.tools.upsample_convolve(img_down, odd=(odd, 1), filt=filt)
         assert np.unravel_index(img_up.cpu().numpy().argmax(), img_up.shape) == (0, 0, 12, 12)
@@ -453,6 +455,11 @@ class TestValidate(object):
     def test_validate_metric_identical(self):
         metric = lambda x, y : (x+y).mean()
         with pytest.raises(ValueError, match="metric should return <= 5e-7 on two identical"):
+            po.tools.validate.validate_metric(metric, device=DEVICE)
+
+    def test_validate_metric_nonnegative(self):
+        metric = lambda x, y : (x-y).sum()
+        with pytest.raises(ValueError, match="metric should always return non-negative"):
             po.tools.validate.validate_metric(metric, device=DEVICE)
 
     @pytest.mark.parametrize('model', ['frontend.OnOff.nograd'], indirect=True)


### PR DESCRIPTION
As documented in #283, calling `.synthesize()` after `.to()` raises a `ValueError` because `met.metamer` was no longer a leaf tensor. This is because, for some reason, `Tensor.to` is considered a differentiable operation. I'm not sure why that's desirable behavior, but this PR adds a solution: when moving tensors, we call `tensor.data.to` (instead of `tensor.to`) and then check whether the original version required a gradient and, if so, add it back. This is similar to how we behave in `load`. 

You can find some discussions of this issue: [on the pytorch forum](https://discuss.pytorch.org/t/moving-tensors-between-devices/83261/3), and on stackoverflow ([one](https://stackoverflow.com/questions/63662624/how-do-i-retain-grads-and-also-change-device-type-in-pytorch), [two](https://stackoverflow.com/questions/65301875/how-to-understand-creating-leaf-tensors-in-pytorch)).

Additionally,:
- the warning being raised was because I was trying to set `self.model`, instead of `self._model`, which was raising an `AttributeError` because `model` doesn't have a setter method. `self.model.to` was still being called (and modified in place), which was why `met.model(met.metamer)` worked without a problem. Replacing `self.model` with `self._model` solves this problem.
- moves this `self._model.to` out of `Synthesis` and into the child classes (eigendistortion, metamer), since not all synthesis objects will have model attributes.
- This is wrapped in try/except because we do not require that models have a to method (see [model requirements](https://plenoptic.readthedocs.io/en/latest/models.html)). it is possible that a model will not have a to method but still behaves correctly, basing all their tensor dtype and devices on their input. so we simply raise a warning.
- adds tests for this behavior (just call `synthesize()` after `to()` to our existing tests)


closes #283 