### PR TITLE
Remove duplicate `exclude_patterns`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,11 +62,6 @@ extensions = [
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #


### PR DESCRIPTION
Removes duplicate `exclude_patterns` from conf.py, since that means the first one was getting ignored.

Closes #299 