### PR TITLE
Allows user to specify polar_angle direction

### DIFF
--- a/src/plenoptic/tools/data.py
+++ b/src/plenoptic/tools/data.py
@@ -159,7 +159,6 @@ def load_images(paths: str | list[str], as_gray: bool = True) -> Tensor:
     return images
 
 
-@deprecated("Load images using :py:func:`load_images` instead", "1.1.0")
 def convert_float_to_int(im: np.ndarray, dtype=np.uint8) -> np.ndarray:
     r"""Convert image from float to 8 or 16 bit image
 

--- a/src/plenoptic/tools/data.py
+++ b/src/plenoptic/tools/data.py
@@ -355,6 +355,10 @@ def polar_angle(
     increasing in user-defined direction from the X-axis, ranging from -pi to pi),
     relative to given phase, about the given origin pixel.
 
+    Note that by default, the angle increases in a clockwise direction, which is NOT the
+    standard mathematical convention. Use the ``direction`` argument to change that
+    behavior.
+
     Parameters
     ----------
     size

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -578,3 +578,31 @@ class TestOptim:
         img = 0.5 * torch.ones((1, 1, 4, 4))
         img[..., 0, :] = -1
         assert po.tools.optim.penalize_range(img).item() == 4
+
+
+class TestPolarImages:
+    def test_polar_angle_clockwise(self):
+        ang = po.tools.polar_angle(100, direction="clockwise")
+        idx = np.argmin((ang - np.pi / 2) ** 2)
+        assert (
+            np.unravel_index(idx, (100, 100))[0] > 50
+        ), "pi/2 should be in bottom half of image!"
+        idx = np.argmin((ang + np.pi / 2) ** 2)
+        assert (
+            np.unravel_index(idx, (100, 100))[0] < 50
+        ), "pi/2 should be in top half of image!"
+
+    def test_polar_angle_counterclockwise(self):
+        ang = po.tools.polar_angle(100, direction="counter-clockwise")
+        idx = np.argmin((ang - np.pi / 2) ** 2)
+        assert (
+            np.unravel_index(idx, (100, 100))[0] < 50
+        ), "pi/2 should be in top half of image!"
+        idx = np.argmin((ang + np.pi / 2) ** 2)
+        assert (
+            np.unravel_index(idx, (100, 100))[0] > 50
+        ), "pi/2 should be in bottom half of image!"
+
+    def test_polar_angle_direction(self):
+        with pytest.raises(ValueError, match="direction must be one of"):
+            po.tools.polar_angle(100, direction="-clockwise")


### PR DESCRIPTION
This small PR allows the user to specify the direction of the polar angle in the polar_angle synthetic image. By default, it increases clockwise, which matches the previous behavior (and documentation). However, the standard convention is to have the angle increase counter-clockwise, which this then allows the user to do.

Also removes an unnecessary deprecated decorator.
