### PR TITLE
Fix failing ruff check, adds check for steerpyr height

### DIFF
--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -133,7 +133,7 @@ class SteerablePyramidFreq(nn.Module):
         if height == "auto":
             self.num_scales = int(max_ht)
         elif height > max_ht:
-            raise ValueError(f"Cannot build pyramid higher than {max_ht:d} levels.")
+            raise ValueError(f"Cannot build pyramid higher than {max_ht:.0f} levels.")
         else:
             self.num_scales = int(height)
 

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -47,9 +47,10 @@ class SteerablePyramidFreq(nn.Module):
     image_shape : `list or tuple`
         shape of input image
     height : 'auto' or `int`
-        The height of the pyramid. If 'auto', will automatically determine
-        based on the size of `image`. If an int, must be positive and less than
-        log2(min(image_shape[1], image_shape[1]))-2.
+        The height of the pyramid. If 'auto', will automatically determine based on the
+        size of `image`. If an int, must be non-negative and less than
+        log2(min(image_shape[1], image_shape[1]))-2. If height=0, this only returns the
+        residuals.
     order : `int`.
         The Gaussian derivative order used for the steerable filters, in [1,
         15]. Note that to achieve steerability the minimum number of
@@ -135,8 +136,8 @@ class SteerablePyramidFreq(nn.Module):
             self.num_scales = int(max_ht)
         elif height > max_ht:
             raise ValueError(f"Cannot build pyramid higher than {max_ht:.0f} levels.")
-        elif height < 1:
-            raise ValueError("Height must be a positive int.")
+        elif height < 0:
+            raise ValueError("Height must be a non-negative integer.")
         else:
             self.num_scales = int(height)
 

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -48,7 +48,8 @@ class SteerablePyramidFreq(nn.Module):
         shape of input image
     height : 'auto' or `int`
         The height of the pyramid. If 'auto', will automatically determine
-        based on the size of `image`.
+        based on the size of `image`. If an int, must be positive and less than
+        log2(min(image_shape[1], image_shape[1]))-2.
     order : `int`.
         The Gaussian derivative order used for the steerable filters, in [1,
         15]. Note that to achieve steerability the minimum number of
@@ -134,6 +135,8 @@ class SteerablePyramidFreq(nn.Module):
             self.num_scales = int(max_ht)
         elif height > max_ht:
             raise ValueError(f"Cannot build pyramid higher than {max_ht:.0f} levels.")
+        elif height < 1:
+            raise ValueError("Height must be a positive int.")
         else:
             self.num_scales = int(height)
 

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -133,7 +133,7 @@ class SteerablePyramidFreq(nn.Module):
         if height == "auto":
             self.num_scales = int(max_ht)
         elif height > max_ht:
-            raise ValueError("Cannot build pyramid higher than %d levels." % (max_ht))
+            raise ValueError(f"Cannot build pyramid higher than {max_ht:d} levels.")
         else:
             self.num_scales = int(height)
 
@@ -615,9 +615,9 @@ class SteerablePyramidFreq(nn.Module):
                 )
             levs_nums = np.array([int(i) for i in levels if isinstance(i, int)])
             assert (levs_nums >= 0).all(), "Level numbers must be non-negative."
-            assert (levs_nums < self.num_scales).all(), (
-                "Level numbers must be in the range [0, %d]" % (self.num_scales - 1)
-            )
+            assert (
+                levs_nums < self.num_scales
+            ).all(), f"Level numbers must be in the range [0, {self.num_scales - 1:d}]"
             levs_tmp = list(np.sort(levs_nums))  # we want smallest first
             if "residual_highpass" in levels:
                 levs_tmp = ["residual_highpass"] + levs_tmp
@@ -670,8 +670,8 @@ class SteerablePyramidFreq(nn.Module):
             bands: NDArray = np.array(bands, ndmin=1)
             assert (bands >= 0).all(), "Error: band numbers must be larger than 0."
             assert (bands < self.num_orientations).all(), (
-                "Error: band numbers must be in the range [0, %d]"
-                % (self.num_orientations - 1)
+                "Error: band numbers must be in the range [0, "
+                f"{self.num_orientations - 1:d}]"
             )
         return list(bands)
 
@@ -719,9 +719,9 @@ class SteerablePyramidFreq(nn.Module):
             for i in bands:
                 if i >= max_orientations:
                     warnings.warn(
-                        "You wanted band %d in the reconstruction but"
-                        " max_orientation is %d, so we're ignoring that band"
-                        % (i, max_orientations)
+                        f"You wanted band {i:d} in the reconstruction but"
+                        f" max_orientation is {max_orientations:d}, so we"
+                        "'re ignoring that band"
                     )
             bands = [i for i in bands if i < max_orientations]
         recon_keys = []

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -1042,7 +1042,7 @@ def plot_representation(
                     # need to keep the shape the same because of how we
                     # check for shape below (unbinding removes a dimension,
                     # so we add it back)
-                    data_dict[title + "_%02d" % i] = d.unsqueeze(1)
+                    data_dict[title + f"_{i:02d}"] = d.unsqueeze(1)
             else:
                 data_dict[title] = data
             data = data_dict

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -407,9 +407,9 @@ class TestSteerablePyramid:
 
     @pytest.mark.parametrize("height", range(-1, 8))
     def test_height_values(self, img, height):
-        if height < 1:
+        if height < 0:
             expectation = pytest.raises(
-                ValueError, match="Height must be a positive int"
+                ValueError, match="Height must be a non-negative int"
             )
         elif height > 6:
             expectation = pytest.raises(

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -405,6 +405,24 @@ class TestSteerablePyramid:
         with pytest.raises(Exception):
             spyr.recon_pyr(scales)
 
+    @pytest.mark.parametrize("height", range(-1, 8))
+    def test_height_values(self, img, height):
+        if height < 1:
+            expectation = pytest.raises(
+                ValueError, match="Height must be a positive int"
+            )
+        elif height > 6:
+            expectation = pytest.raises(
+                ValueError, match="Cannot build pyramid higher than"
+            )
+        else:
+            expectation = does_not_raise()
+        with expectation:
+            pyr = po.simul.SteerablePyramidFreq(img.shape[-2:], height=height).to(
+                DEVICE
+            )
+            pyr(img)
+
     @pytest.mark.parametrize("order", range(17))
     def test_order_values(self, img, order):
         if order in [0, 16]:

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -411,7 +411,7 @@ class TestSteerablePyramid:
             expectation = pytest.raises(
                 ValueError, match="Height must be a non-negative int"
             )
-        elif height > 6:
+        elif height > np.log2(min(img.shape[-2:])) - 2:
             expectation = pytest.raises(
                 ValueError, match="Cannot build pyramid higher than"
             )


### PR DESCRIPTION
An update in the ruff version caused more tests to fail. As part of that update, realized we weren't testing the steerable pyramid initialization with an invalid height value, so added that as well. The height must now be non-negative, and height=0 just returns the residuals.