### PR TITLE
adds git fetch --tags

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -88,6 +88,8 @@ pipeline {
           steps {
             sh 'python3.11 -m venv --system-site-packages $HOME'
             sh '''#!/bin/bash -ex
+              # make sure we have the git tags, since we need that to correctly version plenoptic
+              git fetch --tags
               source $HOME/bin/activate
               pip install -U pip
               pip install .[docs]

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -98,8 +98,8 @@ pipeline {
               echo \$(ls \$HOME)
               echo \$(ls \$HOME/docs)
               echo \$(ls \$HOME/docs/_build)
-              mv docs/_build/ $HOME/build/
-              echo \$(ls \$HOME/build)
+              mv docs/_build/ $HOME/built-docs/
+              echo \$(ls \$HOME/built-docs)
            '''
             lock('plenoptic_docs_publish') {
               script {
@@ -120,9 +120,9 @@ pipeline {
                 mkdir -p \$DOCS_DIR
                 echo \$(ls \$HOME)
                 echo \$(ls \$HOME/docs)
-                echo \$(ls \$HOME/build)
+                echo \$(ls \$HOME/built-docs)
                 echo \$(ls \$DOCS_DIR)
-                cp -rp \$HOME/build/html/* \$DOCS_DIR
+                cp -rp \$HOME/built-docs/html/* \$DOCS_DIR
                 # using -f here makes sure we add the index.html files, which are included in workshops .gitignore (since some are auto-generated)
                 git add -A -f --verbose docs/\$PROJECT_NAME
                 GIT_COMMITTER_EMAIL="jenkins@flatironinstitute.org" GIT_COMMITTER_NAME="Flatiron Jenkins" git commit --author='Flatiron Jenkins <jenkins@flatironinstitute.org>' --allow-empty -m "Generated documentation for \$DOCS_DIR" -m '${env.BUILD_TAG}'

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -98,6 +98,8 @@ pipeline {
               echo \$(ls \$HOME)
               echo \$(ls \$HOME/docs)
               echo \$(ls \$HOME/docs/_build)
+              mv docs/_build/ $HOME/build/
+              echo \$(ls \$HOME/build)
            '''
             lock('plenoptic_docs_publish') {
               script {
@@ -118,9 +120,9 @@ pipeline {
                 mkdir -p \$DOCS_DIR
                 echo \$(ls \$HOME)
                 echo \$(ls \$HOME/docs)
-                echo \$(ls \$HOME/docs/_build)
+                echo \$(ls \$HOME/build)
                 echo \$(ls \$DOCS_DIR)
-                cp -rp \$HOME/docs/_build/html/* \$DOCS_DIR
+                cp -rp \$HOME/build/html/* \$DOCS_DIR
                 # using -f here makes sure we add the index.html files, which are included in workshops .gitignore (since some are auto-generated)
                 git add -A -f --verbose docs/\$PROJECT_NAME
                 GIT_COMMITTER_EMAIL="jenkins@flatironinstitute.org" GIT_COMMITTER_NAME="Flatiron Jenkins" git commit --author='Flatiron Jenkins <jenkins@flatironinstitute.org>' --allow-empty -m "Generated documentation for \$DOCS_DIR" -m '${env.BUILD_TAG}'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -555,6 +555,8 @@ class TestValidate:
             po.tools.validate.validate_metric(mean_metric, device=DEVICE)
 
     def test_validate_metric_nonnegative(self):
+        po.tools.set_seed(0)
+
         def sum_metric(x, y):
             return (x - y).sum()
 


### PR DESCRIPTION
By default, our Jenkins set up doesn't grab git tags, but we need them in order to properly version plenoptic when it's installed before building the docs (since sphinx includes the version in the output). This makes sure to fetch them before installing plenoptic in the docs build.