### PR TITLE
Update how dynamic version is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ docs/tutorials/assets
 
 *.mypy_cache
 
-# created automatically by setuptools.scm, don't track
-src/plenoptic/version.py
-
 # gets created during install
 build/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,7 @@
 #
 import os
 import sys
-
-import plenoptic
+from importlib.metadata import version
 
 sys.path.insert(0, os.path.abspath(".."))
 sys.path.insert(0, os.path.abspath("./tutorials/"))
@@ -25,12 +24,10 @@ project = "plenoptic"
 copyright = "2019, Plenoptic authors"
 author = "Plenoptic authors"
 
-# The short X.Y version
-version = ""
-# The full version, including alpha/beta/rc tags
-
-
-release = plenoptic.__version__
+release: str = version("plenoptic")
+# this will grab major.minor.patch (excluding any .devN afterwards, which should only
+# show up when building locally during development)
+version: str = ".".join(release.split(".")[:3])
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ nb = [
 where = ["src"]
 
 [tool.setuptools_scm]
-write_to = "src/plenoptic/version.py"
 version_scheme = 'python-simplified-semver'
 local_scheme = 'no-local-version'
 

--- a/src/plenoptic/__init__.py
+++ b/src/plenoptic/__init__.py
@@ -7,4 +7,12 @@ from . import synthesize as synth
 from . import data, metric, tools
 from .tools.data import load_images, to_numpy
 from .tools.display import animshow, imshow, pyrshow
-from .version import version as __version__
+
+# preface with underscore so they're not exposed to __all__
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _get_version
+import contextlib as _contextlib
+
+
+with _contextlib.suppress(_PackageNotFoundError):
+    __version__ = _get_version("plenoptic")


### PR DESCRIPTION
While putting together PRs for nemos and pynapple to use `setuptools_scm` to set the package version dynamically, realized that setuptools_scm doesn't recommend writing version to file anymore but using `importlib.metadata` ([docs](https://setuptools-scm.readthedocs.io/en/latest/usage/), in line with [PEP 566](https://peps.python.org/pep-0566/).

This similarly updates how sphinx grabs the version, in line with their suggestions as well.