### PR TITLE
Updates steerable pyramid error message on shape mismatch

### DIFF
--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -310,7 +310,7 @@ class SteerablePyramidFreq(nn.Module):
             raise ValueError(
                 f"Input tensor height/width {tuple(x.shape[-2:])} does not match "
                 f"image_shape set at initialization {tuple(self.image_shape)}. "
-                "Either resize the input or re-initialize this pyramid."
+                "Either resize the input or re-initialize this model."
             )
         pyr_coeffs = OrderedDict()
         if scales is None:

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -110,7 +110,20 @@ class SteerablePyramidFreq(nn.Module):
 
         self.pyr_size = OrderedDict()
         self.order = order
-        self.image_shape = image_shape
+        try:
+            self.image_shape = tuple([int(i) for i in image_shape])
+        except ValueError:
+            raise ValueError(
+                f"image_shape must be castable to ints, but got {image_shape}!"
+            )
+        if self.image_shape != tuple(image_shape):
+            raise ValueError(
+                f"image_shape must be castable to ints, but got {image_shape}!"
+            )
+        if len(self.image_shape) != 2:
+            raise ValueError(
+                f"image_shape must be a tuple of length 2, but got {self.image_shape}!"
+            )
 
         if (self.image_shape[0] % 2 != 0) or (self.image_shape[1] % 2 != 0):
             warnings.warn("Reconstruction will not be perfect with odd-sized images")

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -306,6 +306,12 @@ class SteerablePyramidFreq(nn.Module):
             Pyramid coefficients
 
         """
+        if self.image_shape != x.shape[-2:]:
+            raise ValueError(
+                f"Input tensor height/width {tuple(x.shape[-2:])} does not match "
+                f"image_shape set at initialization {tuple(self.image_shape)}. "
+                "Either resize the input or re-initialize this pyramid."
+            )
         pyr_coeffs = OrderedDict()
         if scales is None:
             scales = self.scales

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -453,3 +453,10 @@ class TestSteerablePyramid:
             names
         ), "pyramid doesn't have the right number of buffers!"
         assert set(buffers) == set(names), "pyramid doesn't have the right buffers!"
+
+    def test_img_shape_error(self, img):
+        pyr = po.simul.SteerablePyramidFreq((255, 255))
+        with pytest.raises(
+            ValueError, match="Input tensor height/width.*does not match"
+        ):
+            pyr(img)

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -455,7 +455,7 @@ class TestSteerablePyramid:
         assert set(buffers) == set(names), "pyramid doesn't have the right buffers!"
 
     def test_img_shape_error(self, curie_img):
-        pyr = po.simul.SteerablePyramidFreq((255, 255))
+        pyr = po.simul.SteerablePyramidFreq((255, 255)).to(DEVICE)
         with pytest.raises(
             ValueError, match="Input tensor height/width.*does not match"
         ):
@@ -473,7 +473,7 @@ class TestSteerablePyramid:
             shape = curie_img.shape[-2:]
         elif shape_type == "floats":
             shape = (256.0, 256.0)
-        pyr = po.simul.SteerablePyramidFreq(shape)
+        pyr = po.simul.SteerablePyramidFreq(shape).to(DEVICE)
         pyr(curie_img)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
The error message when the steerable pyramid was passed an input with the wrong shape was confusing, hopefully this makes it clearer.

Also adds validation and casting for steerpyr's image shape: image shape must be an iterable of length two whose values are castable to ints.