### PR TITLE
Adding docstring for model_metric

### DIFF
--- a/src/plenoptic/metric/model_metric.py
+++ b/src/plenoptic/metric/model_metric.py
@@ -7,15 +7,22 @@ def model_metric(x, y, model):
 
     Parameters
     ----------
-    image: torch.Tensor
+    x: torch.Tensor
+        image, (B x C x H x W)
+    y: torch.Tensor
         image, (B x C x H x W)
     model: torch class
         torch model with defined forward and backward operations
 
-    Notes
-    -----
-
-
+    Examples
+    --------
+    >>> import plenoptic as po
+    >>> einstein_img = po.data.einstein()
+    >>> curie_img = po.data.curie()
+    >>> model = po.simul.Gaussian(30)
+    >>> model_metric = po.metric.model_metric(einstein_img, curie_img, model)
+    >>> model_metric
+    tensor(0.3128, grad_fn=<SqrtBackward0>)
     """
 
     repx = model(x)

--- a/src/plenoptic/simulate/models/naive.py
+++ b/src/plenoptic/simulate/models/naive.py
@@ -95,7 +95,7 @@ class Gaussian(nn.Module):
     kernel_size:
         Size of convolutional kernel.
     std:
-        Standard deviation of circularly symmtric Gaussian kernel.
+        Standard deviation of circularly symmetric Gaussian kernel.
     pad_mode:
         Padding mode argument to pass to `torch.nn.functional.pad`.
     out_channels:


### PR DESCRIPTION
Here is the code : 

    Examples
    --------
    >>> import plenoptic as po
    >>> einstein_img = po.data.einstein()
    >>> curie_img = po.data.curie()
    >>> model = po.simul.Gaussian(30)
    >>> model_metric = po.metric.model_metric(einstein_img, curie_img, model)
    >>> model_metric
    tensor(0.3128, grad_fn=<SqrtBackward0>)