### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ import plenoptic as po
 import torch
 import imageio
 
-img = torch.tensor(imageio.imread('data/einstein.pgm'), dtype=torch.float32).unsqueeze(0).unsqueeze(0)
+img = po.data.einstein()
 model = SomeModel()
 met = po.synth.Metamer(img, model)
 # this raises an error

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,6 @@ Please provide a short, reproducible example of the error, for example:
 ```
 import plenoptic as po
 import torch
-import imageio
 
 img = po.data.einstein()
 model = SomeModel()

--- a/src/plenoptic/simulate/canonical_computations/filters.py
+++ b/src/plenoptic/simulate/canonical_computations/filters.py
@@ -81,7 +81,7 @@ def circular_gaussian2d(
     shift_y = torch.arange(1, kernel_size[0] + 1, device=device) - origin[0]  # height
     shift_x = torch.arange(1, kernel_size[1] + 1, device=device) - origin[1]  # width
 
-    (xramp, yramp) = torch.meshgrid(shift_y, shift_x)
+    (xramp, yramp) = torch.meshgrid(shift_y, shift_x, indexing="xy")
 
     log_filt = (xramp**2) + (yramp**2)
     log_filt = log_filt.repeat(out_channels, 1, 1, 1)  # 4D

--- a/src/plenoptic/simulate/canonical_computations/filters.py
+++ b/src/plenoptic/simulate/canonical_computations/filters.py
@@ -141,7 +141,7 @@ def circular_gaussian2d(
     shift_y = torch.arange(1, kernel_size[0] + 1, device=device) - origin[0]  # height
     shift_x = torch.arange(1, kernel_size[1] + 1, device=device) - origin[1]  # width
 
-    (xramp, yramp) = torch.meshgrid(shift_y, shift_x, indexing="xy")
+    (xramp, yramp) = torch.meshgrid(shift_x, shift_y, indexing="xy")
 
     log_filt = (xramp**2) + (yramp**2)
     log_filt = log_filt.repeat(out_channels, 1, 1, 1)  # 4D

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -176,6 +176,7 @@ class SteerablePyramidFreq(nn.Module):
         (xramp, yramp) = np.meshgrid(
             np.linspace(-1, 1, dims[1] + 1)[:-1],
             np.linspace(-1, 1, dims[0] + 1)[:-1],
+            indexing="xy",
         )
 
         self.angle = np.arctan2(yramp, xramp)

--- a/src/plenoptic/tools/data.py
+++ b/src/plenoptic/tools/data.py
@@ -321,14 +321,10 @@ def polar_radius(
     elif not hasattr(origin, "__iter__"):
         origin = (origin, origin)
 
-    # for some reason, torch.meshgrid returns them in the opposite order
-    # that np.meshgrid does. So, in order to get the same output, we
-    # grab them as (yramp, xramp) instead of (xramp, yramp). similarly,
-    # we have to reverse the order from (size[1], size[0]) to (size[0],
-    # size[1])
-    yramp, xramp = torch.meshgrid(
-        torch.arange(1, size[0] + 1, device=device) - origin[0],
+    xramp, yramp = torch.meshgrid(
         torch.arange(1, size[1] + 1, device=device) - origin[1],
+        torch.arange(1, size[0] + 1, device=device) - origin[0],
+        indexing="xy",
     )
 
     if exponent <= 0:
@@ -397,14 +393,10 @@ def polar_angle(
     elif not hasattr(origin, "__iter__"):
         origin = (origin, origin)
 
-    # for some reason, torch.meshgrid returns them in the opposite order
-    # that np.meshgrid does. So, in order to get the same output, we
-    # grab them as (yramp, xramp) instead of (xramp, yramp). similarly,
-    # we have to reverse the order from (size[1], size[0]) to (size[0],
-    # size[1])
-    yramp, xramp = torch.meshgrid(
-        torch.arange(1, size[0] + 1, device=device) - origin[0],
+    xramp, yramp = torch.meshgrid(
         torch.arange(1, size[1] + 1, device=device) - origin[1],
+        torch.arange(1, size[0] + 1, device=device) - origin[0],
+        indexing="xy",
     )
     if direction == "counter-clockwise":
         yramp = torch.flip(yramp, [0])

--- a/src/plenoptic/tools/data.py
+++ b/src/plenoptic/tools/data.py
@@ -3,7 +3,7 @@ import pathlib
 import warnings
 from typing import Literal
 
-import imageio
+import imageio.v3 as iio
 import numpy as np
 import torch
 from deprecated.sphinx import deprecated
@@ -108,7 +108,7 @@ def load_images(paths: str | list[str], as_gray: bool = True) -> Tensor:
             raise FileNotFoundError(f"File {p} not found!")
 
         try:
-            im = imageio.imread(p)
+            im = iio.imread(p)
         except ValueError:
             warnings.warn(
                 f"Unable to load in file {p}, it's probably not an image, skipping..."

--- a/src/plenoptic/tools/data.py
+++ b/src/plenoptic/tools/data.py
@@ -73,7 +73,7 @@ def load_images(paths: str | list[str], as_gray: bool = True) -> Tensor:
         A str or list of strs. If a list, must contain paths of image
         files. If a str, can either be the path of a single image file
         or of a single directory. If a directory, we try to load every
-        file it contains (using imageio.imwrite) and skip those we
+        file it contains (using imageio.imread) and skip those we
         cannot (thus, for efficiency you should not point this to a
         directory with lots of non-image files). This is NOT recursive.
     as_gray

--- a/src/plenoptic/tools/external.py
+++ b/src/plenoptic/tools/external.py
@@ -6,7 +6,7 @@ For example, pre-existing synthesized images
 
 import os.path as op
 
-import imageio
+import imageio.v3 as iio
 import matplotlib.lines as lines
 import numpy as np
 import pyrtools as pt
@@ -82,7 +82,7 @@ def plot_MAD_results(
     if ssim_images_dir is None:
         ssim_images_dir = str(fetch_data("ssim_images.tar.gz"))
     img_path = op.join(op.expanduser(ssim_images_dir), f"{original_image}.tif")
-    orig_img = imageio.imread(img_path)
+    orig_img = iio.imread(img_path)
     blanks = np.ones((*orig_img.shape, 4))
     if noise_levels is None:
         noise_levels = [2**i for i in range(1, 11)]


### PR DESCRIPTION
Fix two deprecation warnings:
- imageio API change. I believe this change doesn't affect me (after looking through [their migration guide](https://imageio.readthedocs.io/en/stable/reference/userapi.html#migrating-to-the-v3-api)), so this just explicitly imports `imageio.v3` to suppress the warning.
- torch.meshgrid change, see [docs](https://pytorch.org/docs/stable/generated/torch.meshgrid.html), [issue](https://github.com/pytorch/pytorch/issues/50276). torch's meshgrid default behavior was backwards from that of numpy. they are planning on changing default behavior to match that of numpy. now, I explicitly set indexing arg for all calls to either numpy or torch meshgrid. I had ran into this at one point when creating the `polar_radius` / `polar_angle` functions and had a comment to the effect of "why is this different". Removed that comment and reverted the call to look the standard way.

closes #273 