### PR TITLE
Improvements to center_crop, simple models

### DIFF
--- a/src/plenoptic/simulate/canonical_computations/filters.py
+++ b/src/plenoptic/simulate/canonical_computations/filters.py
@@ -87,7 +87,7 @@ def gaussian1d(kernel_size: int = 11, std: int | float | Tensor = 1.5) -> Tensor
 
 def circular_gaussian2d(
     kernel_size: int | tuple[int, int],
-    std: float | Tensor,
+    std: int | list[int] | float | list[float] | Tensor,
     out_channels: int = 1,
 ) -> Tensor:
     """Creates normalized, centered circular 2D gaussian tensor with which to convolve.
@@ -100,9 +100,10 @@ def circular_gaussian2d(
         faster, see
         https://pytorch.org/docs/stable/generated/torch.nn.functional.conv2d.html
     std:
-        Standard deviation of 2D circular Gaussian.
+        Standard deviation of 2D circular Gaussian. If more than one value, ``len(std)``
+        must equal ``out_channels``.
     out_channels:
-        Number of channels with same kernel repeated along channel dim.
+        Number of output channels.
 
     Returns
     -------
@@ -112,6 +113,9 @@ def circular_gaussian2d(
 
     Examples
     --------
+
+    Single output channel.
+
     .. plot::
 
       >>> import plenoptic as po
@@ -120,39 +124,161 @@ def circular_gaussian2d(
       >>> import torch
       >>> import matplotlib.pyplot as plt
       >>> kernel_size = 32
-      >>> filt_2d = circular_gaussian2d(kernel_size=kernel_size, std=2.)
+      >>> filt_2d = circular_gaussian2d(kernel_size=kernel_size, std=2)
       >>> einstein_img = po.data.einstein()
       >>> blurred_einstein = conv2d(einstein_img, filt_2d, padding="same")
       >>> po.imshow(
-      ...     [filt_2d, einstein_img, blurred_einstein],
-      ...     title=["2D Gaussian Filter", "Einstein", "Blurred Einstein"]
+      ...     [einstein_img, filt_2d, blurred_einstein],
+      ...     title=["Einstein", "2D Gaussian Filter", "Blurred Einstein"]
       ... )  #doctest: +ELLIPSIS
       <PyrFigure ...>
 
+    Multiple output channels with different standard deviations.
+
+    .. plot::
+
+      >>> import plenoptic as po
+      >>> from plenoptic.simulate import circular_gaussian2d
+      >>> from torch.nn.functional import conv2d
+      >>> import torch
+      >>> import matplotlib.pyplot as plt
+      >>> kernel_size = 32
+      >>> filt_2d = circular_gaussian2d(kernel_size=kernel_size, std=[2, 5.5],
+      ...                               out_channels=2)
+      >>> einstein_img = po.data.einstein()
+      >>> blurred_einstein = conv2d(einstein_img, filt_2d, padding="same")
+      >>> titles = ["Einstein", "2D Gaussian Filter", "Larger 2D Gaussian Filter",
+      ...           "Blurred Einstein", "Blurrier Einstein"]
+      >>> po.imshow(
+      ...     [einstein_img, filt_2d, blurred_einstein], title=titles
+      ... )  #doctest: +ELLIPSIS
+      <PyrFigure ...>
+
+    Multiple input and output channels, convolved independently. See [conv2d
+    documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.conv2d.html)
+    to understand the behavior below:
+
+    .. plot::
+
+      >>> import plenoptic as po
+      >>> from plenoptic.simulate import circular_gaussian2d
+      >>> from torch.nn.functional import conv2d
+      >>> import torch
+      >>> import matplotlib.pyplot as plt
+      >>> kernel_size = 32
+      >>> filt_2d = circular_gaussian2d(kernel_size=kernel_size, std=[2, 5.5],
+      ...                               out_channels=2)
+      >>> wheel = po.data.color_wheel(as_gray=False)
+      >>> blurred_wheel = conv2d(wheel, filt_2d.repeat(3, 1, 1, 1), groups=3,
+      ...                        padding="same")
+      >>> titles = ["Wheel", "Blurred Wheel", "Blurrier Wheel"]
+      >>> # note that the order of channels: the first two correspond to the first
+      >>> # channel of the input image, convolved with the each of the two gaussians,
+      >>> # and so on.
+      >>> po.imshow(
+      ...     [wheel, blurred_wheel[:, ::2], blurred_wheel[:, 1::2]], title=titles,
+      ...     as_rgb=True,
+      ... )  #doctest: +ELLIPSIS
+      <PyrFigure ...>
+
+    Raises
+    ------
+    ValueError:
+        If out_channels is not a positive integer.
+    ValueError:
+        If kernel_size is not a positive integer.
+    ValueError:
+        If std is not positive.
+    ValueError:
+        If std has more than one value and ``len(std) != out_channels``
+
     """
-    device = torch.device("cpu") if isinstance(std, float) else std.device
+    kernel_size, std = _validate_filter_args(kernel_size, std, out_channels)
 
-    if isinstance(kernel_size, int):
-        kernel_size = (kernel_size, kernel_size)
-    if isinstance(std, float) or std.shape == torch.Size([]):
-        std = torch.ones(out_channels, device=device) * std
+    origin = (kernel_size + 1) / 2
 
-    assert out_channels >= 1, "number of filters must be positive integer"
-    assert torch.all(std > 0.0), "stdev must be positive"
-    assert len(std) == out_channels, "Number of stds must equal out_channels"
-    origin = torch.as_tensor(((kernel_size[0] + 1) / 2.0, (kernel_size[1] + 1) / 2.0))
-    origin = origin.to(device)
-
-    shift_y = torch.arange(1, kernel_size[0] + 1, device=device) - origin[0]  # height
-    shift_x = torch.arange(1, kernel_size[1] + 1, device=device) - origin[1]  # width
+    shift_y = torch.arange(1, kernel_size[0] + 1, device=std.device) - origin[0]
+    shift_x = torch.arange(1, kernel_size[1] + 1, device=std.device) - origin[1]
 
     (xramp, yramp) = torch.meshgrid(shift_x, shift_y, indexing="xy")
 
     log_filt = (xramp**2) + (yramp**2)
-    log_filt = log_filt.repeat(out_channels, 1, 1, 1)  # 4D
+    log_filt = log_filt.repeat(out_channels, 1, 1, 1)
     log_filt = log_filt / (-2.0 * std**2).view(out_channels, 1, 1, 1)
 
     filt = torch.exp(log_filt)
-    filt = filt / torch.sum(filt, dim=[1, 2, 3], keepdim=True)  # normalize
+    # normalize
+    filt = filt / torch.sum(filt, dim=[1, 2, 3], keepdim=True)
 
     return filt
+
+
+def _validate_filter_args(
+    kernel_size: int | tuple[int, int],
+    std: int | list[int] | float | list[float] | Tensor,
+    out_channels: int,
+) -> tuple[Tensor, Tensor]:
+    """Validate common filter args
+
+    Checks that:
+
+    - kernel_size is positive, integer-valued, and has 1 or 2 values
+
+    - std is positive and either a single value (i.e., an int, float, or scalar tensor)
+      or ``len(std) == out_channels``
+
+    - out_channels must be a positive integer.
+
+    Also converts both kernel_size and std to tensors and:
+    - makes kernel_size a 1d tensor of size 2
+    - makes std a float32 1d tensor of size ``out_channels``
+
+    Parameters
+    ----------
+    kernel_size:
+        Filter kernel size.
+    std:
+        Standard deviation of 2D circular Gaussian. If more than one value, ``len(std)``
+        must equal ``out_channels``.
+    out_channels:
+        Number of output channels.
+
+    Returns
+    -------
+    kernel_size, std
+
+    Raises
+    ------
+    ValueError:
+        If out_channels is not a positive integer.
+    ValueError:
+        If kernel_size is not a positive integer.
+    ValueError:
+        If std is not positive.
+    ValueError:
+        If std has more than one value and ``len(std) != out_channels``
+
+    """
+    if out_channels < 1 or isinstance(out_channels, float):
+        raise ValueError("out_channels must be positive integer")
+
+    std = torch.as_tensor(std)
+    if not torch.is_floating_point(std):
+        std = std.to(torch.float32)
+    if std.ndim == 0:
+        std = std.repeat(out_channels)
+
+    kernel_size = torch.as_tensor(kernel_size).to(std.device)
+    if kernel_size.numel() == 1:
+        kernel_size = kernel_size.repeat(2)
+    if torch.is_floating_point(kernel_size):
+        raise ValueError("kernel_size must be integer-valued")
+    if torch.any(kernel_size < 1):
+        raise ValueError("kernel_size must be positive")
+
+    if torch.any(std <= 0):
+        raise ValueError("std must be positive")
+    if len(std) != out_channels:
+        raise ValueError("Number of stds must equal out_channels")
+
+    return kernel_size, std

--- a/src/plenoptic/simulate/canonical_computations/filters.py
+++ b/src/plenoptic/simulate/canonical_computations/filters.py
@@ -111,6 +111,22 @@ def circular_gaussian2d(
         Circular gaussian kernel, normalized by total pixel-sum (_not_ by 2pi*std).
         ``filt`` has shape ``(out_channels=n_channels, in_channels=1, height, width)``
 
+    Raises
+    ------
+    ValueError:
+        If out_channels is not a positive integer.
+    ValueError:
+        If kernel_size is not one or two positive integers.
+    ValueError:
+        If std is not positive.
+    ValueError:
+        If std has more than one value and ``len(std) != out_channels``
+
+    See also
+    --------
+    Gaussian
+        Torch Module to perform this convolution.
+
     Examples
     --------
 
@@ -181,17 +197,6 @@ def circular_gaussian2d(
       ... )  #doctest: +ELLIPSIS
       <PyrFigure ...>
 
-    Raises
-    ------
-    ValueError:
-        If out_channels is not a positive integer.
-    ValueError:
-        If kernel_size is not a positive integer.
-    ValueError:
-        If std is not positive.
-    ValueError:
-        If std has more than one value and ``len(std) != out_channels``
-
     """
     kernel_size, std = _validate_filter_args(kernel_size, std, out_channels)
 
@@ -252,7 +257,7 @@ def _validate_filter_args(
     ValueError:
         If out_channels is not a positive integer.
     ValueError:
-        If kernel_size is not a positive integer.
+        If kernel_size is not one or two positive integers.
     ValueError:
         If std is not positive.
     ValueError:

--- a/src/plenoptic/simulate/models/naive.py
+++ b/src/plenoptic/simulate/models/naive.py
@@ -27,18 +27,18 @@ class Identity(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
-    def forward(self, img):
-        """Return a copy of the image
+    def forward(self, x: Tensor) -> Tensor:
+        """Return a copy of the tensor
 
         Parameters
         ----------
-        img : torch.Tensor
-            The image to return
+        x : torch.Tensor
+            The tensor to return
 
         Returns
         -------
-        img : torch.Tensor
-            a clone of the input image
+        x : torch.Tensor
+            a clone of the input tensor
 
         Examples
         --------
@@ -53,7 +53,7 @@ class Identity(torch.nn.Module):
            <PyrFigure ...>
 
         """
-        y = 1 * img
+        y = 1 * x
         return y
 
 
@@ -124,17 +124,19 @@ class Linear(nn.Module):
             self.conv.weight.data = torch.cat([f1, f2], dim=0)
 
     def forward(self, x: Tensor) -> Tensor:
-        """Return a linear convolution of the image
+        """Convolve filter with input tensor.
+
+        We use same-padding to ensure that the output and input shapes are matched.
 
         Parameters
         ----------
-        x : torch.Tensor
-            The image to return (4D tensor)
+        x :
+            The input tensor, should be 4d (batch, channel, height, width)
 
         Returns
         -------
-        img : torch.Tensor
-            a linear convolution of the input image
+        y :
+            a linear convolution of the input image, of same shape as the input.
 
         Examples
         --------
@@ -224,16 +226,21 @@ class Gaussian(nn.Module):
             return filt
 
     def forward(self, x: Tensor, **conv2d_kwargs) -> Tensor:
-        """Return an isotropic gaussian convolutional filter of the image
+        """Convolve Gaussian filter with input tensor
+
+        We use same-padding to ensure that the output and input shapes are matched.
 
         Parameters
         ----------
-        x : torch.Tensor
-            The image to return (4D tensor)
+        x :
+            The input tensor, should be 4d (batch, channel, height, width)
+        conv2d_kwargs :
+            Passed to [](torch.nn.functional.conv2d).
 
         Returns
         -------
-        img : torch.Tensor
+        y :
+            a linear convolution of the input image, of same shape as the input.
 
         Examples
         --------
@@ -409,16 +416,19 @@ class CenterSurround(nn.Module):
         return filt
 
     def forward(self, x: Tensor) -> Tensor:
-        """Return a difference of Gaussians (DoG) filter model of the image
+        """Convolve center-surround filter with input tensor.
+
+        We use same-padding to ensure that the output and input shapes are matched.
 
         Parameters
         ----------
-        x : torch.Tensor
-            The image to return (4D tensor)
+        x :
+            The input tensor, should be 4d (batch, channel, height, width)
 
         Returns
         -------
-        img : torch.Tensor
+        y :
+            a linear convolution of the input image, of same shape as the input.
 
         Examples
         --------

--- a/src/plenoptic/simulate/models/naive.py
+++ b/src/plenoptic/simulate/models/naive.py
@@ -377,9 +377,12 @@ class CenterSurround(nn.Module):
             raise ValueError("len(on_center) must equal out_channels")
         self.on_center = on_center
 
+        amplitude_ratio = torch.as_tensor(amplitude_ratio)
+        if amplitude_ratio.nelement() > 1:
+            raise ValueError("amplitude_ratio must be a scalar")
         if amplitude_ratio < 1.0:
             raise ValueError("amplitude_ratio must at least be 1.")
-        self.register_buffer("amplitude_ratio", torch.as_tensor(amplitude_ratio))
+        self.register_buffer("amplitude_ratio", amplitude_ratio)
 
         self.out_channels = out_channels
         self.pad_mode = pad_mode

--- a/src/plenoptic/tools/signal.py
+++ b/src/plenoptic/tools/signal.py
@@ -423,10 +423,11 @@ def center_crop(x: Tensor, output_size: int) -> Tensor:
 
     """
     h, w = x.shape[-2:]
-    if hasattr(output_size, "__len__") and (
-        not hasattr(output_size, "ndim") or output_size.ndim > 0
-    ):
+    output_size = torch.as_tensor(output_size)
+    if output_size.ndim > 0:
         raise TypeError("output_size must be a single number!")
+    if torch.is_floating_point(output_size):
+        raise TypeError("output_size must be an int!")
     if output_size > h or output_size > w:
         raise ValueError("output_size is bigger than image height/width!")
     if output_size <= 0:

--- a/src/plenoptic/tools/signal.py
+++ b/src/plenoptic/tools/signal.py
@@ -402,8 +402,8 @@ def center_crop(x: Tensor, output_size: int) -> Tensor:
         N-dimensional tensor, we assume the last two dimensions are height and
         width.
     output_size :
-        The size of the output. Note that we only support a single number, so
-        both dimensions are cropped identically
+        The size of the output. Must be a positive int. Note that we only support a
+        single number, so both dimensions are cropped identically
 
     Returns
     -------
@@ -411,8 +411,26 @@ def center_crop(x: Tensor, output_size: int) -> Tensor:
         Tensor whose last two dimensions have each been cropped to
         ``output_size``
 
+    Examples
+    --------
+    >>> import plenoptic as po
+    >>> img = po.data.einstein()
+    >>> img.shape
+    torch.Size([1, 1, 256, 256])
+    >>> img = po.tools.center_crop(img, 128)
+    >>> img.shape
+    torch.Size([1, 1, 128, 128])
+
     """
     h, w = x.shape[-2:]
+    if hasattr(output_size, "__len__") and (
+        not hasattr(output_size, "ndim") or output_size.ndim > 0
+    ):
+        raise TypeError("output_size must be a single number!")
+    if output_size > h or output_size > w:
+        raise ValueError("output_size is bigger than image height/width!")
+    if output_size <= 0:
+        raise ValueError("output_size must be positive!")
     return x[
         ...,
         (h // 2 - output_size // 2) : (h // 2 + (output_size + 1) // 2),

--- a/src/plenoptic/tools/validate.py
+++ b/src/plenoptic/tools/validate.py
@@ -187,7 +187,7 @@ def validate_model(
     if model(test_img).ndimension() not in [3, 4]:
         raise ValueError(
             "When given a 4d input, model output must be three- or"
-            " four-dimensional but had {model(test_img).ndimension()}"
+            f" four-dimensional but had {model(test_img).ndimension()}"
             " dimensions instead!"
         )
     if model(test_img).device != test_img.device:
@@ -246,7 +246,7 @@ def validate_coarse_to_fine(
                 if model_output_shape == model(test_img, scales=sc).shape:
                     raise ValueError(
                         "Output of model forward method doesn't change"
-                        " shape when scales keyword arg is set to {sc} {msg}"
+                        f" shape when scales keyword arg is set to {sc} {msg}"
                     )
             except TypeError:
                 raise TypeError(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -328,6 +328,27 @@ class TestNaive:
                 (31, 31), center_std=center_std, out_channels=out_channels
             )
 
+    @pytest.mark.parametrize(
+        "amplitude_ratio,expectation",
+        [
+            (0, pytest.raises(ValueError, match=".*must at least be 1")),
+            (1, does_not_raise()),
+            (1.0, does_not_raise()),
+            (torch.as_tensor(1, dtype=int), does_not_raise()),
+            (torch.as_tensor(1.0), does_not_raise()),
+            (torch.as_tensor(1.0), does_not_raise()),
+            (torch.as_tensor([1.0]), does_not_raise()),
+            (
+                torch.as_tensor([1, 2]),
+                pytest.raises(ValueError, match=".*must be a scalar"),
+            ),
+            ([1, 2], pytest.raises(ValueError, match=".*must be a scalar")),
+        ],
+    )
+    def test_CenterSurround_amplitude_ratio(self, amplitude_ratio, expectation):
+        with expectation:
+            po.simul.CenterSurround(31, amplitude_ratio=amplitude_ratio)
+
     def test_linear(self, basic_stim):
         model = po.simul.Linear().to(DEVICE)
         assert model(basic_stim).requires_grad
@@ -1278,13 +1299,13 @@ class TestFilters:
             ),
         ],
     )
-    def test_circluar_gaussian2d_std(self, std, expectation):
+    def test_circular_gaussian2d_std(self, std, expectation):
         with expectation:
             filt = circular_gaussian2d((31, 31), std, out_channels=1)
             assert filt.sum().isclose(torch.ones(1, device=DEVICE))
             assert filt.shape[-2:] == torch.Size((31, 31))
 
-    def test_circluar_gaussian2d_std_out_channel(self):
+    def test_circular_gaussian2d_std_out_channel(self):
         filt = circular_gaussian2d((31, 31), [2, 3, 4])
         assert filt.sum().isclose(3 * torch.ones(1, device=DEVICE))
         assert filt.shape[-2:] == torch.Size((31, 31))
@@ -1308,7 +1329,7 @@ class TestFilters:
             ),
         ],
     )
-    def test_circluar_gaussian2d_kernel_size(self, kernel_size, expectation):
+    def test_circular_gaussian2d_kernel_size(self, kernel_size, expectation):
         with expectation:
             filt = circular_gaussian2d(kernel_size, 2)
             assert filt.sum().isclose(torch.ones(1, device=DEVICE))
@@ -1345,7 +1366,7 @@ class TestFilters:
             ),
         ],
     )
-    def test_circluar_gaussian2d_out_channels(self, out_channels, expectation):
+    def test_circular_gaussian2d_out_channels(self, out_channels, expectation):
         with expectation:
             circular_gaussian2d((31, 31), 2, out_channels)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -317,7 +317,7 @@ class TestNaive:
     @pytest.mark.parametrize("on_center", [True, [True, False]])
     def test_CenterSurround_channels(self, center_std, out_channels, on_center):
         if not isinstance(center_std, float) and len(center_std) != out_channels:
-            with pytest.raises(AssertionError):
+            with pytest.raises(ValueError, match="Number of stds must equal"):
                 po.simul.CenterSurround(
                     (31, 31), center_std=center_std, out_channels=out_channels
                 )
@@ -1330,9 +1330,10 @@ class TestFilters:
         img = po.data.color_wheel(as_gray=False)
         output = torch.nn.functional.conv2d(img, filt.repeat(3, 1, 1, 1), groups=3)
         test = []
-        for ch, f in zip(range(3), range(2)):
-            test.append(
-                torch.nn.functional.conv2d(img[:, ch : ch + 1], filt[f : f + 1])
-            )
+        for ch in range(3):
+            for f in range(2):
+                test.append(
+                    torch.nn.functional.conv2d(img[:, ch : ch + 1], filt[f : f + 1])
+                )
         test = torch.concat(test, dim=1)
         assert torch.allclose(test, output)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -57,6 +57,35 @@ class TestSignal:
         assert torch.linalg.vector_norm((a - A).flatten(), ord=2) < 1e-3
         assert torch.linalg.vector_norm((b - B).flatten(), ord=2) < 1e-3
 
+    @pytest.mark.parametrize(
+        "size, expectation",
+        [
+            (500, pytest.raises(ValueError, match="output_size is bigger than")),
+            (256, does_not_raise()),
+            (128, does_not_raise()),
+            (0, pytest.raises(ValueError, match="output_size must be positive")),
+            (-10, pytest.raises(ValueError, match="output_size must be positive")),
+            (10.0, pytest.raises(TypeError, match="slice indices must be integers")),
+            (torch.as_tensor(128), does_not_raise()),
+            (np.asarray(128), does_not_raise()),
+            (
+                torch.as_tensor(128.0),
+                pytest.raises(TypeError, match="only integer tensors"),
+            ),
+            (
+                [10, 10],
+                pytest.raises(TypeError, match="output_size must be a single number"),
+            ),
+            (
+                torch.as_tensor([10, 10]),
+                pytest.raises(TypeError, match="output_size must be a single number"),
+            ),
+        ],
+    )
+    def test_center_crop(self, einstein_img, size, expectation):
+        with expectation:
+            po.tools.center_crop(einstein_img, size)
+
     @pytest.mark.parametrize("n", range(1, 15))
     def test_autocorrelation(self, n, basic_stim):
         x = basic_stim

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -65,12 +65,12 @@ class TestSignal:
             (128, does_not_raise()),
             (0, pytest.raises(ValueError, match="output_size must be positive")),
             (-10, pytest.raises(ValueError, match="output_size must be positive")),
-            (10.0, pytest.raises(TypeError, match="slice indices must be integers")),
+            (10.0, pytest.raises(TypeError, match="output_size must be an int")),
             (torch.as_tensor(128), does_not_raise()),
             (np.asarray(128), does_not_raise()),
             (
                 torch.as_tensor(128.0),
-                pytest.raises(TypeError, match="only integer tensors"),
+                pytest.raises(TypeError, match="output_size must be an int"),
             ),
             (
                 [10, 10],


### PR DESCRIPTION
This PR makes several small quality-of-life changes:
- Makes center_crop better behaved. We now validate the input args and raise informative ValueErrors if e.g., you want to crop the center 200 pixels of a 100x100 image
- finishes adding type-hinting and doctests to models/naive.py and models/frontend.py
- better validation of inputs to `circular_gaussian2d`, raising more informative error messages when things go wrong