### PR TITLE
Fix malformed sphinx directives

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,11 @@ repos:
   - id: end-of-file-fixer
   # Removes trailing whitespace characters from files.
   - id: trailing-whitespace
+
+- repo: local
+  hooks:
+    - id: check-malformed-directive
+      language: system
+      name: Check for malformed sphinx directives
+      types_or: ["python", "rst", "markdown"]
+      entry: python tests/check_sphinx_directives.py

--- a/docs/conceptual_intro.md
+++ b/docs/conceptual_intro.md
@@ -41,7 +41,7 @@ A worked example may help demonstrate this point more clearly. Let's match the r
 (primaries)=
 
 ```{eval-rst}
-..plot:: scripts/conceptual_intro.py primaries
+.. plot:: scripts/conceptual_intro.py primaries
   :include-source: false
   :show-source-link: true
 

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -672,7 +672,7 @@ def clean_stem_plot(data, ax=None, title="", ylim=None, xvals=None, **kwargs):
     We allow for breaks in the baseline value if we want to visually
     break up the plot, as we see below.
 
-    ..plot::
+    .. plot::
       :include-source:
 
       import plenoptic as po
@@ -693,7 +693,7 @@ def clean_stem_plot(data, ax=None, title="", ylim=None, xvals=None, **kwargs):
     the default xvals (``None``). In this case, this function will just
     clean up the plot a little bit
 
-    ..plot::
+    .. plot::
       :include-source:
 
       import plenoptic as po

--- a/tests/check_sphinx_directives.py
+++ b/tests/check_sphinx_directives.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+
+failures = []
+
+for p in sys.argv[1:]:
+    with open(p) as f:
+        contents = f.read()
+    fail = re.findall(r"\.\.[a-zA-Z]+::", contents)
+    if len(fail):
+        failures.append((p, fail))
+
+if len(failures):
+    print("Found the following malformed sphinx directives! Add a space after the dots")
+    for p, fail in failures:
+        fail = ", ".join(fail)
+        print(f"{p}: {fail}")
+    sys.exit(1)


### PR DESCRIPTION
I add a couple of `..plot::`, which don't render correctly. They should look like `.. plot::` (note the space).

This fixes that and then adds a small script with accompanying pre-commit hook which checks for anything that matches the regex `\.\.[a-z]+::` and raises an error if so. Hopefully this will catch that in the future. The script is intended to run on only python, markdown, and rST; that constraint is handled by pre-commit. 