### PR TITLE
Hotfix: fix eigendistortion.to()

### DIFF
--- a/src/plenoptic/synthesize/eigendistortion.py
+++ b/src/plenoptic/synthesize/eigendistortion.py
@@ -574,7 +574,7 @@ class Eigendistortion(Synthesis):
             pass to ``torch.device``
         tensor_equality_atol :
             Absolute tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating
@@ -583,7 +583,7 @@ class Eigendistortion(Synthesis):
             dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating

--- a/src/plenoptic/synthesize/eigendistortion.py
+++ b/src/plenoptic/synthesize/eigendistortion.py
@@ -532,16 +532,16 @@ class Eigendistortion(Synthesis):
             "_representation_flat",
         ]
         super().to(*args, attrs=attrs, **kwargs)
-        # we need _representation_flat and _image_flat to be connected in the
-        # computation graph for the autograd calls to work, so we reinitialize
-        # it here
-        self._init_representation(self.image)
         # try to call .to() on model. this should work, but it might fail if e.g., this
         # a custom model that doesn't inherit torch.nn.Module
         try:
             self._model = self._model.to(*args, **kwargs)
         except AttributeError:
             warnings.warn("Unable to call model.to(), so we leave it as is.")
+        # we need _representation_flat and _image_flat to be connected in the
+        # computation graph for the autograd calls to work, so we reinitialize
+        # it here
+        self._init_representation(self.image)
 
     def load(
         self,

--- a/src/plenoptic/synthesize/eigendistortion.py
+++ b/src/plenoptic/synthesize/eigendistortion.py
@@ -576,12 +576,20 @@ class Eigendistortion(Synthesis):
             Absolute tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.

--- a/src/plenoptic/synthesize/eigendistortion.py
+++ b/src/plenoptic/synthesize/eigendistortion.py
@@ -547,6 +547,8 @@ class Eigendistortion(Synthesis):
         self,
         file_path: str,
         map_location: str | None = None,
+        tensor_equality_atol: float = 1e-8,
+        tensor_equality_rtol: float = 1e-5,
         **pickle_load_args,
     ):
         r"""Load all relevant stuff from a .pt file.
@@ -570,6 +572,16 @@ class Eigendistortion(Synthesis):
             CPU, you'll need this to make sure everything lines up
             properly. This should be structured like the str you would
             pass to ``torch.device``
+        tensor_equality_atol :
+            Absolute tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
+        tensor_equality_rtol :
+            Relative tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.
@@ -601,6 +613,8 @@ class Eigendistortion(Synthesis):
             map_location=map_location,
             check_attributes=check_attributes,
             check_io_attributes=check_io_attrs,
+            tensor_equality_atol=tensor_equality_atol,
+            tensor_equality_rtol=tensor_equality_rtol,
             **pickle_load_args,
         )
         # make these require a grad again

--- a/src/plenoptic/synthesize/mad_competition.py
+++ b/src/plenoptic/synthesize/mad_competition.py
@@ -571,7 +571,7 @@ class MADCompetition(OptimizedSynthesis):
             pass to ``torch.device``
         tensor_equality_atol :
             Absolute tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating
@@ -580,7 +580,7 @@ class MADCompetition(OptimizedSynthesis):
             dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating

--- a/src/plenoptic/synthesize/mad_competition.py
+++ b/src/plenoptic/synthesize/mad_competition.py
@@ -573,12 +573,20 @@ class MADCompetition(OptimizedSynthesis):
             Absolute tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.

--- a/src/plenoptic/synthesize/mad_competition.py
+++ b/src/plenoptic/synthesize/mad_competition.py
@@ -544,6 +544,8 @@ class MADCompetition(OptimizedSynthesis):
         self,
         file_path: str,
         map_location: str | None = None,
+        tensor_equality_atol: float = 1e-8,
+        tensor_equality_rtol: float = 1e-5,
         **pickle_load_args,
     ):
         r"""Load all relevant stuff from a .pt file.
@@ -567,6 +569,16 @@ class MADCompetition(OptimizedSynthesis):
             CPU, you'll need this to make sure everything lines up
             properly. This should be structured like the str you would
             pass to ``torch.device``
+        tensor_equality_atol :
+            Absolute tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
+        tensor_equality_rtol :
+            Relative tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.
@@ -610,6 +622,8 @@ class MADCompetition(OptimizedSynthesis):
             check_attributes=check_attributes,
             check_io_attributes=check_io_attrs,
             state_dict_attributes=["_optimizer", "_scheduler"],
+            tensor_equality_atol=tensor_equality_atol,
+            tensor_equality_rtol=tensor_equality_rtol,
             **pickle_load_args,
         )
         # make this require a grad again

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -504,12 +504,20 @@ class Metamer(OptimizedSynthesis):
             Absolute tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.
@@ -1042,12 +1050,20 @@ class MetamerCTF(Metamer):
             Absolute tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -533,7 +533,13 @@ class Metamer(OptimizedSynthesis):
         >>> metamer_copy.load('metamers.pt')
 
         """
-        self._load(file_path, map_location, **pickle_load_args)
+        self._load(
+            file_path,
+            map_location,
+            tensor_equality_atol=tensor_equality_atol,
+            tensor_equality_rtol=tensor_equality_rtol,
+            **pickle_load_args,
+        )
 
     def _load(
         self,
@@ -1062,6 +1068,8 @@ class MetamerCTF(Metamer):
             file_path,
             map_location,
             ["_coarse_to_fine"],
+            tensor_equality_atol=tensor_equality_atol,
+            tensor_equality_rtol=tensor_equality_rtol,
             **pickle_load_args,
         )
 

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -475,6 +475,8 @@ class Metamer(OptimizedSynthesis):
         self,
         file_path: str,
         map_location: str | None = None,
+        tensor_equality_atol: float = 1e-8,
+        tensor_equality_rtol: float = 1e-5,
         **pickle_load_args,
     ):
         r"""Load all relevant stuff from a .pt file.
@@ -498,6 +500,16 @@ class Metamer(OptimizedSynthesis):
             CPU, you'll need this to make sure everything lines up
             properly. This should be structured like the str you would
             pass to ``torch.device``
+        tensor_equality_atol :
+            Absolute tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
+        tensor_equality_rtol :
+            Relative tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.
@@ -529,6 +541,8 @@ class Metamer(OptimizedSynthesis):
         map_location: str | None = None,
         additional_check_attributes: list[str] = [],
         additional_check_io_attributes: list[str] = [],
+        tensor_equality_atol: float = 1e-8,
+        tensor_equality_rtol: float = 1e-5,
         **pickle_load_args,
     ):
         r"""Helper function for loading.
@@ -555,6 +569,8 @@ class Metamer(OptimizedSynthesis):
             check_attributes=check_attributes,
             check_io_attributes=check_io_attrs,
             state_dict_attributes=["_optimizer", "_scheduler"],
+            tensor_equality_atol=tensor_equality_atol,
+            tensor_equality_rtol=tensor_equality_rtol,
             **pickle_load_args,
         )
         # make this require a grad again
@@ -994,6 +1010,8 @@ class MetamerCTF(Metamer):
         self,
         file_path: str,
         map_location: str | None = None,
+        tensor_equality_atol: float = 1e-8,
+        tensor_equality_rtol: float = 1e-5,
         **pickle_load_args,
     ):
         r"""Load all relevant stuff from a .pt file.
@@ -1014,6 +1032,16 @@ class MetamerCTF(Metamer):
             CPU, you'll need this to make sure everything lines up
             properly. This should be structured like the str you would
             pass to ``torch.device``
+        tensor_equality_atol :
+            Absolute tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
+        tensor_equality_rtol :
+            Relative tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -502,7 +502,7 @@ class Metamer(OptimizedSynthesis):
             pass to ``torch.device``
         tensor_equality_atol :
             Absolute tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating
@@ -511,7 +511,7 @@ class Metamer(OptimizedSynthesis):
             dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating
@@ -1048,7 +1048,7 @@ class MetamerCTF(Metamer):
             pass to ``torch.device``
         tensor_equality_atol :
             Absolute tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating
@@ -1057,7 +1057,7 @@ class MetamerCTF(Metamer):
             dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating

--- a/src/plenoptic/synthesize/synthesis.py
+++ b/src/plenoptic/synthesize/synthesis.py
@@ -165,12 +165,20 @@ class Synthesis(abc.ABC):
             Absolute tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
             passed to :func:`torch.allclose`. It may be necessary to decrease if you are
             saving and loading on two machines with torch built by different cuda
-            versions. Be careful when changing this!
+            versions. Be careful when changing this! See
+            :class:`torch.finfo<torch.torch.finfo>` for more details about floating
+            point precision of different data types (especially, ``eps``); if you have
+            to increase this by more than 1 or 2 decades, then you are probably not
+            dealing with a numerical issue.
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.

--- a/src/plenoptic/synthesize/synthesis.py
+++ b/src/plenoptic/synthesize/synthesis.py
@@ -163,7 +163,7 @@ class Synthesis(abc.ABC):
             Synthesis object to properly handle it when needed.
         tensor_equality_atol :
             Absolute tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating
@@ -172,7 +172,7 @@ class Synthesis(abc.ABC):
             dealing with a numerical issue.
         tensor_equality_rtol :
             Relative tolerance to use when checking for tensor equality during load,
-            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            passed to :func:`torch.allclose`. It may be necessary to increase if you are
             saving and loading on two machines with torch built by different cuda
             versions. Be careful when changing this! See
             :class:`torch.finfo<torch.torch.finfo>` for more details about floating

--- a/src/plenoptic/synthesize/synthesis.py
+++ b/src/plenoptic/synthesize/synthesis.py
@@ -124,6 +124,8 @@ class Synthesis(abc.ABC):
         check_attributes: list[str] = [],
         check_io_attributes: list[str] = [],
         state_dict_attributes: list[str] = [],
+        tensor_equality_atol: float = 1e-8,
+        tensor_equality_rtol: float = 1e-5,
         **pickle_load_args,
     ):
         r"""Load all relevant attributes from a .pt file.
@@ -159,6 +161,16 @@ class Synthesis(abc.ABC):
             are identical and then load the state_dict. If the attribute is None on the
             initialized Synthesis object, then we set the tuple, and count on the
             Synthesis object to properly handle it when needed.
+        tensor_equality_atol :
+            Absolute tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
+        tensor_equality_rtol :
+            Relative tolerance to use when checking for tensor equality during load,
+            passed to :func:`torch.allclose`. It may be necessary to decrease if you are
+            saving and loading on two machines with torch built by different cuda
+            versions. Be careful when changing this!
         pickle_load_args :
             any additional kwargs will be added to ``pickle_module.load`` via
             ``torch.load``, see that function's docstring for details.
@@ -228,6 +240,8 @@ class Synthesis(abc.ABC):
                         f"different {{error_type}}!"
                     ),
                     error_append_str=check_str,
+                    atol=tensor_equality_atol,
+                    rtol=tensor_equality_rtol,
                 )
             elif isinstance(getattr(self, k), float):
                 if not np.allclose(getattr(self, k), tmp_dict[k]):
@@ -263,6 +277,8 @@ class Synthesis(abc.ABC):
                     f"different {{error_type}}!"
                 ),
                 error_append_str=check_str,
+                atol=tensor_equality_atol,
+                rtol=tensor_equality_rtol,
             )
         for k, v in tmp_dict.items():
             # check_io_attributes is a tuple

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -346,6 +346,11 @@ class TestEigendistortionSynthesis:
             ed.to("cpu")
         ed.eigendistortions - ed.image
         ed.synthesize(max_iter=5, method="power")
+        # reset so we don't mess up further tests
+        if to_type == "dtype":
+            ed.to(torch.float32)
+        elif to_type == "device" and DEVICE.type != "cpu":
+            ed.to(DEVICE)
 
     # test that we support models with 3d and 4d outputs
     @pytest.mark.parametrize(

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -327,7 +327,9 @@ class TestEigendistortionSynthesis:
         ):
             eig.load(op.join(tmp_path, "test_eigendistortion_load_attributes.pt"))
 
-    @pytest.mark.parametrize("model", ["naive.Identity", "NonModule"], indirect=True)
+    @pytest.mark.parametrize(
+        "model", ["naive.Identity", "NonModule", "naive.CenterSurround"], indirect=True
+    )
     @pytest.mark.parametrize("to_type", ["dtype", "device"])
     @pytest.mark.filterwarnings("ignore:Unable to call model.to:UserWarning")
     def test_to(self, curie_img, model, to_type):

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -328,6 +328,23 @@ class TestEigendistortionSynthesis:
             eig.load(op.join(tmp_path, "test_eigendistortion_load_attributes.pt"))
 
     @pytest.mark.parametrize(
+        "model", ["frontend.LinearNonlinear.nograd"], indirect=True
+    )
+    def test_load_tol(self, einstein_img, model, tmp_path):
+        eig = Eigendistortion(einstein_img, model)
+        eig.synthesize(max_iter=5)
+        eig.save(op.join(tmp_path, "test_eigendistortion_load_tol.pt"))
+        eig = Eigendistortion(
+            einstein_img + 1e-7 * torch.rand_like(einstein_img), model
+        )
+        with pytest.raises(ValueError, match="Saved and initialized attribute image"):
+            eig.load(op.join(tmp_path, "test_eigendistortion_load_tol.pt"))
+        eig.load(
+            op.join(tmp_path, "test_eigendistortion_load_tol.pt"),
+            tensor_equality_atol=1e-7,
+        )
+
+    @pytest.mark.parametrize(
         "model", ["naive.Identity", "NonModule", "frontend.OnOff.nograd"], indirect=True
     )
     @pytest.mark.parametrize("to_type", ["dtype", "device"])

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -328,7 +328,7 @@ class TestEigendistortionSynthesis:
             eig.load(op.join(tmp_path, "test_eigendistortion_load_attributes.pt"))
 
     @pytest.mark.parametrize(
-        "model", ["naive.Identity", "NonModule", "naive.CenterSurround"], indirect=True
+        "model", ["naive.Identity", "NonModule", "frontend.OnOff.nograd"], indirect=True
     )
     @pytest.mark.parametrize("to_type", ["dtype", "device"])
     @pytest.mark.filterwarnings("ignore:Unable to call model.to:UserWarning")

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -690,7 +690,7 @@ class TestMetamers:
         model.to(DEVICE)
 
     @pytest.mark.parametrize(
-        "model", ["naive.Identity", "NonModule", "naive.CenterSurround"], indirect=True
+        "model", ["naive.Identity", "NonModule", "frontend.OnOff.nograd"], indirect=True
     )
     @pytest.mark.parametrize("to_type", ["dtype", "device"])
     @pytest.mark.filterwarnings("ignore:Unable to call model.to:UserWarning")

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -689,7 +689,9 @@ class TestMetamers:
         # reset model device for other tests
         model.to(DEVICE)
 
-    @pytest.mark.parametrize("model", ["naive.Identity", "NonModule"], indirect=True)
+    @pytest.mark.parametrize(
+        "model", ["naive.Identity", "NonModule", "naive.CenterSurround"], indirect=True
+    )
     @pytest.mark.parametrize("to_type", ["dtype", "device"])
     @pytest.mark.filterwarnings("ignore:Unable to call model.to:UserWarning")
     def test_to(self, curie_img, model, to_type):

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -477,6 +477,24 @@ class TestMetamers:
     @pytest.mark.parametrize(
         "model", ["frontend.LinearNonlinear.nograd"], indirect=True
     )
+    def test_load_tol(self, einstein_img, model, tmp_path):
+        met = po.synth.Metamer(einstein_img, model, allowed_range=(-1, 2))
+        met.synthesize(5)
+        met.save(op.join(tmp_path, "test_metamer_load_tol.pt"))
+        met = po.synth.Metamer(
+            einstein_img + 1e-7 * torch.rand_like(einstein_img),
+            model,
+            allowed_range=(-1, 2),
+        )
+        with pytest.raises(ValueError, match="Saved and initialized attribute image"):
+            met.load(op.join(tmp_path, "test_metamer_load_tol.pt"))
+        met.load(
+            op.join(tmp_path, "test_metamer_load_tol.pt"), tensor_equality_atol=1e-7
+        )
+
+    @pytest.mark.parametrize(
+        "model", ["frontend.LinearNonlinear.nograd"], indirect=True
+    )
     @pytest.mark.parametrize("load", [True, False])
     @pytest.mark.filterwarnings("ignore:You will need to call setup:UserWarning")
     def test_resume_synthesis(self, einstein_img, curie_img, model, load, tmp_path):

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -706,6 +706,11 @@ class TestMetamers:
             met.to("cpu")
         met.metamer - met.image
         met.synthesize(max_iter=5)
+        # reset so we don't mess up further tests
+        if to_type == "dtype":
+            met.to(torch.float32)
+        elif to_type == "device" and DEVICE.type != "cpu":
+            met.to(DEVICE)
 
     # this determines whether we mix across channels or treat them separately,
     # both of which are supported


### PR DESCRIPTION
Issue with calling `eigendistortion.to` with the frontend models (and similar).

updates `test_to` to check for this, and updates metamer tests to make sure we similarly check for it.

Additionally, allow user to set atol/rtol used when checking tensor equality during load. When trying to save/load on two machines, you can end up with very small differences that are not easily resolvable. (I ran into this on my work laptop and linux workstation, which both had the same versions of plenoptic and torch, and the problem didn't depend on GPU vs CPU; my guess is that it was something related to CUDA or BLAS). For example:

```python
# on my work laptop
img = po.data.einstein()
model = po.simul.CenterSurround(31, cache_filt=True, pad_mode='circular')
eig = po.synth.Eigendistortion(img, model)
eig.synthesize(5)
eig.save('test.pt')

# on my linux workstation
img = po.data.einstein()
model = po.simul.CenterSurround(31, cache_filt=True, pad_mode='circular')
eig = po.synth.Eigendistortion(img, model)
# FAIL
eig.load('test.pt')
# PASS
eig.load('test.pt', tensor_equality_atol=1e-7)
```

Obviously, this can be abused to avoid the load checks at all, but I think that's on the user.