### PR TITLE
corrects even/odd in steerpyr docstring

### DIFF
--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -65,8 +65,8 @@ class SteerablePyramidFreq(nn.Module):
         octaves.
     is_complex
         Whether the pyramid coefficients should be complex or not. If True, the
-        real and imaginary parts correspond to a pair of even and odd symmetric
-        filters. If False, the coefficients only include the real part / even filters.
+        real and imaginary parts correspond to a pair of odd and even symmetric
+        filters. If False, the coefficients only include the real part / odd filters.
     downsample
         Whether to downsample each scale in the pyramid or keep the output
         pyramid coefficients in fixed bands of size ``image_shape``. When


### PR DESCRIPTION
@Bichidian noticed that they were swapped.

The real-valued is odd symmetric (like sine), the imaginary-valued is even symmetric (like cosine).