### PR TITLE
More docstrings!

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,10 @@ napoleon_use_rtype = False
 
 numfig = True
 
+# SPHINX CROSS REFERENCES
+
+add_function_parentheses = False
+
 # numpydoc
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ intersphinx_mapping = {
     "torch": ("https://pytorch.org/docs/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
+    "pyrtools": ("https://pyrtools.readthedocs.io/en/latest", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ docs = [
 ]
 
 dev = [
-    "pytest>=5.1.2,<8.4",
+    "pytest>=5.1.2",
     'pytest-cov',
     'pytest-xdist',
     "pooch>=1.2.0",
@@ -99,7 +99,11 @@ filterwarnings = [
     # https://github.com/fatiando/pooch/pull/458 but not in release as of April
     # 2025.
     "ignore:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning",
+    "ignore:Failed to generate report:",
 ]
+
+[tool.coverage.run]
+disable_warnings = ["module-not-measured"]
 
 [tool.ruff]
 extend-include = ["*.ipynb"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,9 +99,11 @@ filterwarnings = [
     # https://github.com/fatiando/pooch/pull/458 but not in release as of April
     # 2025.
     "ignore:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning",
+    # seems to be necessary to solve https://github.com/pytest-dev/pytest-cov/issues/693
     "ignore:Failed to generate report:",
 ]
 
+# seems to be necessary to solve https://github.com/pytest-dev/pytest-cov/issues/693
 [tool.coverage.run]
 disable_warnings = ["module-not-measured"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ docs = [
 ]
 
 dev = [
-    "pytest>=5.1.2",
+    "pytest>=5.1.2,<8.4",
     'pytest-cov',
     'pytest-xdist',
     "pooch>=1.2.0",

--- a/src/plenoptic/metric/classes.py
+++ b/src/plenoptic/metric/classes.py
@@ -15,11 +15,11 @@ class NLP(torch.nn.Module):
     Simple class for implementing normalized laplacian pyramid.
 
     This class just calls
-    ``plenoptic.metric.normalized_laplacian_pyramid`` on the image and
+    :func:`plenoptic.metric.normalized_laplacian_pyramid` on the image and
     returns a 3d tensor with the flattened activations.
 
     NOTE: synthesis using this class will not be the exact same as
-    synthesis using the ``plenoptic.metric.nlpd`` function (by default),
+    synthesis using the :func:`plenoptic.metric.nlpd` function (by default),
     because the ``nlpd`` function uses the root-mean square of the L2 distance (i.e.,
     ``torch.sqrt(torch.mean(x-y)**2))`` as the distance metric between representations.
 

--- a/src/plenoptic/metric/classes.py
+++ b/src/plenoptic/metric/classes.py
@@ -15,13 +15,14 @@ class NLP(torch.nn.Module):
     Simple class for implementing normalized laplacian pyramid.
 
     This class just calls
-    :func:`plenoptic.metric.normalized_laplacian_pyramid` on the image and
-    returns a 3d tensor with the flattened activations.
+    :func:`~plenoptic.metric.perceptual_distance.normalized_laplacian_pyramid`
+    on the image and returns a 3d tensor with the flattened activations.
 
     NOTE: synthesis using this class will not be the exact same as
-    synthesis using the :func:`plenoptic.metric.nlpd` function (by default),
-    because the ``nlpd`` function uses the root-mean square of the L2 distance (i.e.,
-    ``torch.sqrt(torch.mean(x-y)**2))`` as the distance metric between representations.
+    synthesis using the :func:`~plenoptic.metric.perceptual_distance.nlpd` function
+    (by default), because the ``nlpd`` function uses the root-mean square of the
+    L2 distance (i.e., ``torch.sqrt(torch.mean(x-y)**2))`` as the distance metric
+    between representations.
 
     Model parameters are those used in [1]_, copied from the matlab code used in the
     paper, found at [2]_.

--- a/src/plenoptic/metric/perceptual_distance.py
+++ b/src/plenoptic/metric/perceptual_distance.py
@@ -182,7 +182,7 @@ def ssim(
     This implementation follows the original implementation, as found at [2]_,
     as well as providing the option to use the weighted version used in [4]_
     (which was shown to consistently improve the image quality prediction on
-    the LIVE database).
+    the LIVE database). More info can be found at [3]_.
 
     Note that this is a similarity metric (not a distance), and so 1 means the
     two images are identical and 0 means they're very different. When the two
@@ -303,7 +303,7 @@ def ssim_map(img1: torch.Tensor, img2: torch.Tensor) -> torch.Tensor:
     This implementation follows the original implementation, as found at [2]_,
     as well as providing the option to use the weighted version used in [4]_
     (which was shown to consistently improve the image quality prediction on
-    the LIVE database).
+    the LIVE database). More info can be found at [3]_.
 
     Note that this is a similarity metric (not a distance), and so 1 means the
     two images are identical and 0 means they're very different. When the two

--- a/src/plenoptic/simulate/canonical_computations/non_linearities.py
+++ b/src/plenoptic/simulate/canonical_computations/non_linearities.py
@@ -29,10 +29,10 @@ def rectangular_to_polar_dict(
     Returns
     -------
     energy
-        The dictionary of torch.Tensors containing the local complex
+        The dictionary of :class:`torch.Tensor` containing the local complex
         modulus of ``coeff_dict``.
     state
-        The dictionary of torch.Tensors containing the local phase of
+        The dictionary of :class:`torch.Tensor` containing the local phase of
         ``coeff_dict``.
 
     See Also
@@ -70,10 +70,10 @@ def polar_to_rectangular_dict(
     Parameters
     ----------
     energy
-        The dictionary of torch.Tensors containing the local complex
+        The dictionary of :class:`torch.Tensor` containing the local complex
         modulus.
     state
-        The dictionary of torch.Tensors containing the local phase.
+        The dictionary of :class:`torch.Tensor` containing the local phase.
     residuals
         An option to carry around residuals in the energy branch.
 
@@ -228,10 +228,10 @@ def local_gain_control_dict(
     Returns
     -------
     energy
-        The dictionary of torch.Tensors containing the local energy of
+        The dictionary of :class:`torch.Tensor` containing the local energy of
         ``x``.
     state
-        The dictionary of torch.Tensors containing the local phase of
+        The dictionary of :class:`torch.Tensor` containing the local phase of
         ``x``.
 
     See Also
@@ -270,10 +270,10 @@ def local_gain_release_dict(energy: dict, state: dict, residuals: bool = True) -
     Parameters
     ----------
     energy
-        The dictionary of torch.Tensors containing the local energy of
+        The dictionary of :class:`torch.Tensor` containing the local energy of
         ``x``.
     state
-        The dictionary of torch.Tensors containing the local phase of
+        The dictionary of :class:`torch.Tensor` containing the local phase of
         ``x``.
     residuals
         An option to carry around residuals in the energy dict.

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -64,8 +64,8 @@ class SteerablePyramidFreq(nn.Module):
         The width of the transition region of the radial lowpass function, in
         octaves.
     is_complex
-        Whether the pyramid coefficients should be complex or not. If True, the real and
-        imaginary parts correspond to a pair of odd and even symmetric filters. If
+        Whether the pyramid coefficients should be complex or not. If ``True``, the real
+        and imaginary parts correspond to a pair of odd and even symmetric filters. If
         False, the coefficients only include the real part. Regardless of the value of
         ``is_complex``, the symmetry of the real part is determined by the ``order``
         parameter: if ``order`` is even, then the real coefficients are even symmetric;
@@ -79,7 +79,7 @@ class SteerablePyramidFreq(nn.Module):
     tight_frame
         Whether the pyramid obeys the generalized parseval theorem or not (i.e.
         is a tight frame). If ``True``, the energy of the pyr_coeffs equals the energy
-        of the image. If not this is not true. In order to match the `matlabPyrTools
+        of the image. In order to match the `matlabPyrTools
         <http://github.com/labForComputationalVision/matlabpyrtools>`_ or `pyrtools
         <https://github.com/labForComputationalVision/pyrtools>`_ implementations, this
         must be set to ``False``.

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -64,9 +64,14 @@ class SteerablePyramidFreq(nn.Module):
         The width of the transition region of the radial lowpass function, in
         octaves.
     is_complex
-        Whether the pyramid coefficients should be complex or not. If True, the
-        real and imaginary parts correspond to a pair of odd and even symmetric
-        filters. If False, the coefficients only include the real part / odd filters.
+        Whether the pyramid coefficients should be complex or not. If True, the real and
+        imaginary parts correspond to a pair of odd and even symmetric filters. If
+        False, the coefficients only include the real part. Regardless of the value of
+        ``is_complex``, the symmetry of the real part is determined by the ``order``
+        parameter: if ``order`` is even, then the real coefficients are even symmetric;
+        if ``order`` is odd, then the real coefficients are odd symmetric. (If
+        ``is_complex=True``, then the imaginary coefficients will have the opposite
+        symmetry of the real ones).
     downsample
         Whether to downsample each scale in the pyramid or keep the output
         pyramid coefficients in fixed bands of size ``image_shape``. When

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -1125,9 +1125,7 @@ class SteerablePyramidFreq(nn.Module):
             )
 
             for j, a in enumerate(angles):
-                res, steervect = steer(
-                    basis, a, return_weights=True, even_phase=even_phase
-                )
+                res, steervect = steer(basis, a, even_phase=even_phase)
                 resteering_weights[(i, j)] = steervect
                 resteered_coeffs[(i, num_orientations + j)] = res.reshape(
                     pyr_coeffs[(i, 0)].shape

--- a/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
+++ b/src/plenoptic/simulate/canonical_computations/steerable_pyramid_freq.py
@@ -66,8 +66,8 @@ class SteerablePyramidFreq(nn.Module):
     is_complex
         Whether the pyramid coefficients should be complex or not. If ``True``, the real
         and imaginary parts correspond to a pair of odd and even symmetric filters. If
-        False, the coefficients only include the real part. Regardless of the value of
-        ``is_complex``, the symmetry of the real part is determined by the ``order``
+        ``False``, the coefficients only include the real part. Regardless of the value
+        of ``is_complex``, the symmetry of the real part is determined by the ``order``
         parameter: if ``order`` is even, then the real coefficients are even symmetric;
         if ``order`` is odd, then the real coefficients are odd symmetric. (If
         ``is_complex=True``, then the imaginary coefficients will have the opposite

--- a/src/plenoptic/simulate/models/frontend.py
+++ b/src/plenoptic/simulate/models/frontend.py
@@ -172,9 +172,10 @@ class LinearNonlinear(nn.Module):
         Parameters
         ----------
         vrange, zoom, title
-            Arguments for :func:`plenoptic.imshow`, see its docstrings for details.
+            Arguments for :func:`~plenoptic.tools.display.imshow`, see its
+            docstrings for details.
         **kwargs
-            Keyword args for :func:`plenoptic.imshow`.
+            Keyword args for :func:`~plenoptic.tools.display.imshow`.
 
         Returns
         -------
@@ -370,9 +371,10 @@ class LuminanceGainControl(nn.Module):
         Parameters
         ----------
         vrange, zoom, title, col_wrap
-            Arguments for :func:`plenoptic.imshow`, see its docstrings for details.
+            Arguments for :func:`~plenoptic.tools.display.imshow`, see its
+            docstrings for details.
         **kwargs
-            Keyword args for :func:`plenoptic.imshow`.
+            Keyword args for :func:`~plenoptic.tools.display.imshow`.
 
         Returns
         -------
@@ -606,9 +608,10 @@ class LuminanceContrastGainControl(nn.Module):
         Parameters
         ----------
         vrange, zoom, title, col_wrap
-            Arguments for :func:`plenoptic.imshow`, see its docstrings for details.
+            Arguments for :func:`~plenoptic.tools.display.imshow`, see
+            its docstrings for details.
         **kwargs
-            Keyword args for :func:`plenoptic.imshow`.
+            Keyword args for :func:`~plenoptic.tools.display.imshow`.
 
         Returns
         -------
@@ -863,10 +866,10 @@ class OnOff(nn.Module):
         Parameters
         ----------
         vrange, zoom, title, col_wrap
-            Arguments for :func:`plenoptic.imshow`, see its docstrings for
-            details.
+            Arguments for :func:`~plenoptic.tools.display.imshow`, see its
+            docstrings for details.
         **kwargs
-            Keyword args for :func:`plenoptic.imshow`.
+            Keyword args for :func:`~plenoptic.tools.display.imshow`.
 
         Returns
         -------

--- a/src/plenoptic/simulate/models/naive.py
+++ b/src/plenoptic/simulate/models/naive.py
@@ -305,7 +305,7 @@ class CenterSurround(nn.Module):
     Filter is constructed as:
 
     .. math::
-        f &= amplitude\_ratio * center - surround \\
+        f &= \text{amplitude\_ratio} * \text{center} - \text{surround} \\
         f &= f/f.sum()
 
     The signs of center and surround are determined by ``on_center`` argument.

--- a/src/plenoptic/simulate/models/naive.py
+++ b/src/plenoptic/simulate/models/naive.py
@@ -304,9 +304,10 @@ class CenterSurround(nn.Module):
 
     Filter is constructed as:
 
-    .. math::
-        f &= \text{amplitude\_ratio} * \text{center} - \text{surround} \\
-        f &= f/f.sum()
+    .. code::
+
+        f = amplitude_ratio * center - surround
+        f = f / f.sum()
 
     The signs of center and surround are determined by ``on_center`` argument.
 

--- a/src/plenoptic/simulate/models/portilla_simoncelli.py
+++ b/src/plenoptic/simulate/models/portilla_simoncelli.py
@@ -52,13 +52,15 @@ class PortillaSimoncelli(nn.Module):
     images have the same values for all PS texture stats, humans should
     consider them as members of the same family of textures.
 
-    The PS stats are computed based on the :class:`SteerablePyramidFreq` [2]_.
-    They consist of the local auto-correlations, cross-scale (within-orientation)
-    correlations, and cross-orientation (within-scale) correlations of both the
-    pyramid coefficients and the local energy (as computed by those
-    coefficients). Additionally, they include the first four global moments
-    (mean, variance, skew, and kurtosis) of the image and down-sampled versions
-    of that image. See the paper and notebook for more description.
+    The PS stats are computed based on the
+    :class:`~plenoptic.simulate.canonical_computations.steerable_pyramid_freq.SteerablePyramidFreq`
+    [2]_. They consist of the local auto-correlations, cross-scale
+    (within-orientation) correlations, and cross-orientation (within-scale)
+    correlations of both the pyramid coefficients and the local energy (as
+    computed by those coefficients). Additionally, they include the first four
+    global moments (mean, variance, skew, and kurtosis) of the image and
+    down-sampled versions of that image. See the paper and notebook for more
+    description.
 
     Parameters
     ----------

--- a/src/plenoptic/synthesize/autodiff.py
+++ b/src/plenoptic/synthesize/autodiff.py
@@ -96,13 +96,13 @@ def vector_jacobian_product(
         ``k`` is the number of directions.
     retain_graph
         Whether or not to keep graph after doing one :meth:`vector_jacobian_product`.
-        Must be set to True if ``k>1``.
+        Must be set to ``True`` if ``k>1``.
     create_graph
-        Whether or not to create computational graph. Usually should be set to True
+        Whether or not to create computational graph. Usually should be set to ``True``
         unless you're reusing the graph like in the second step
         of :meth:`jacobian_vector_product`.
     detach
-        As with ``create_graph``, only necessary to be True when reusing the output
+        As with ``create_graph``, only necessary to be ``True`` when reusing the output
         like we do in the 2nd step of :meth:`jacobian_vector_product`.
 
     Returns

--- a/src/plenoptic/synthesize/eigendistortion.py
+++ b/src/plenoptic/synthesize/eigendistortion.py
@@ -779,16 +779,16 @@ def display_eigendistortion(
     ax
         Axis handle on which to plot.
     plot_complex
-        Parameter for :meth:`plenoptic.imshow` determining how to handle complex values.
-        Defaults to ``'rectangular'``, which plots real and complex components as
-        separate images. See that method's docstring for details.
+        Parameter for :func:`~plenoptic.tools.display.imshow` determining how to handle
+        complex values. Defaults to ``'rectangular'``, which plots real and complex
+        components as separate images. See that method's docstring for details.
     **kwargs
-        Additional arguments for :meth:`po.imshow()`.
+        Additional arguments for :func:`~plenoptic.tools.display.imshow`.
 
     Returns
     -------
     fig
-        Figure handle returned by :meth:`plenoptic.imshow()`.
+        Figure containing the displayed images.
     """
     # reshape so channel dim is last
     im_shape = eigendistortion._image_shape

--- a/src/plenoptic/synthesize/mad_competition.py
+++ b/src/plenoptic/synthesize/mad_competition.py
@@ -830,11 +830,11 @@ def display_mad_image(
     You can specify what iteration to view by using the ``iteration`` arg.
     The default, ``None``, shows the final one.
 
-    We use :func:`plenoptic.imshow` to display the synthesized image and attempt to
-    automatically find the most reasonable zoom value. You can override this
-    value using the zoom arg, but remember that :func:`plenoptic.imshow` is
-    opinionated about the size of the resulting image and will throw an
-    Exception if the axis created is not big enough for the selected zoom.
+    We use :func:`~plenoptic.tools.display.imshow` to display the synthesized image and
+    attempt to automatically find the most reasonable zoom value. You can override this
+    value using the zoom arg, but remember that :func:`~plenoptic.tools.display.imshow`
+    is opinionated about the size of the resulting image and will throw an Exception if
+    the axis created is not big enough for the selected zoom.
 
     Parameters
     ----------
@@ -857,7 +857,7 @@ def display_mad_image(
     title :
         Title of the axis.
     **kwargs
-        Passed to :func:`plenoptic.imshow`.
+        Passed to :func:`~plenoptic.tools.display.imshow`.
 
     Returns
     -------
@@ -1186,7 +1186,7 @@ def plot_synthesis_status(
         the most recent one. Negative values are also allowed.
     vrange
         The vrange option to pass to ``display_mad_image()``. See
-        docstring of :func:`plenoptic.imshow` for possible values.
+        docstring of :func:`~plenoptic.tools.display.imshow` for possible values.
     zoom
         How much to zoom in / enlarge the synthesized image, the ratio
         of display pixels to image pixels. If ``None``, we
@@ -1515,10 +1515,10 @@ def display_mad_image_all(
         Name of the second metric. If ``None``, we use the name of the
         ``optimized_metric`` function from ``mad_metric2_min``.
     zoom
-        Ratio of display pixels to image pixels. See :func:`plenoptic.imshow` for
-        details.
+        Ratio of display pixels to image pixels. See
+        :func:`~plenoptic.tools.display.imshow` for details.
     **kwargs
-        Passed to :func:`plenoptic.imshow`.
+        Passed to :func:`~plenoptic.tools.display.imshow`.
 
     Returns
     -------

--- a/src/plenoptic/synthesize/mad_competition.py
+++ b/src/plenoptic/synthesize/mad_competition.py
@@ -1062,7 +1062,7 @@ def _setup_synthesis_fig(
     Parameters
     ----------
     fig
-        The figure to plot on or None. If None, we create a new figure.
+        The figure to plot on or ``None``. If ``None``, we create a new figure.
     axes_idx
         Dictionary specifying which axes contains which type of plot, allows for more
         fine-grained control of the resulting figure. Probably only helpful if fig is

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -1435,7 +1435,7 @@ def plot_representation_error(
     Plot distance ratio showing how close we are to convergence.
 
     We plot ``_representation_error(metamer, iteration)``. For more details, see
-    ``plenoptic.tools.display.plot_representation``.
+    :func:`plenoptic.tools.display.plot_representation`.
 
     Parameters
     ----------

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -1326,10 +1326,10 @@ def display_metamer(
     You can specify what iteration to view by using the ``iteration`` arg.
     The default, ``None``, shows the final one.
 
-    We use :func:`plenoptic.imshow` to display the metamer and attempt to
+    We use :func:`~plenoptic.tools.display.imshow` to display the metamer and attempt to
     automatically find the most reasonable zoom value. You can override this
-    value using the zoom arg, but remember that :func:`plenoptic.imshow` is
-    opinionated about the size of the resulting image and will throw an
+    value using the zoom arg, but remember that :func:`~plenoptic.tools.display.imshow`
+    is opinionated about the size of the resulting image and will throw an
     Exception if the axis created is not big enough for the selected zoom.
 
     Parameters
@@ -1351,7 +1351,7 @@ def display_metamer(
     ax
         Pre-existing axes for plot. If ``None``, we call :func:`matplotlib.pyplot.gca`.
     **kwargs
-        Passed to :func:`plenoptic.imshow`.
+        Passed to :func:`~plenoptic.tools.display.imshow`.
 
     Returns
     -------
@@ -1458,7 +1458,7 @@ def plot_representation_error(
         image or not, so the user must set this flag to tell us. It will be
         ignored if the response doesn't look image-like or if the model has its
         own ``plot_representation_error()`` method. Else, it will be passed to
-        :func:`plenoptic.imshow()`, see that methods docstring for details.
+        :func:`~plenoptic.tools.display.imshow`, see that methods docstring for details.
     **kwargs
         Passed to ``metamer.model.forward``.
 
@@ -1799,7 +1799,7 @@ def plot_synthesis_status(
         this value directly to ``plot_representation_error``.
     vrange
         The vrange option to pass to :func:`display_metamer()`. See
-        docstring of :func:`plenoptic.imshow` for possible values.
+        docstring of :func:`~plenoptic.tools.display.imshow` for possible values.
     zoom
         How much to zoom in / enlarge the metamer, the ratio
         of display pixels to image pixels. If ``None``, we
@@ -1810,7 +1810,8 @@ def plot_synthesis_status(
         image or not, so the user must set this flag to tell us. It will be
         ignored if the response doesn't look image-like or if the
         model has its own plot_representation_error() method. Else, it will
-        be passed to :func:`plenoptic.imshow`, see that methods docstring for details.
+        be passed to :func:`~plenoptic.tools.display.imshow`, see that method's
+        docstring for details.
     fig
         If ``None``, we create a new figure. otherwise we assume this is
         an empty figure that has the appropriate size and number of
@@ -2006,7 +2007,7 @@ def animate(
 
     vrange
         The vrange option to pass to :func:`display_metamer()`. See
-        docstring of :func:`plenoptic.imshow` for possible values.
+        docstring of :func:`~plenoptic.tools.display.imshow` for possible values.
     zoom
         How much to zoom in / enlarge the metamer, the ratio
         of display pixels to image pixels. If ``None``, we
@@ -2016,9 +2017,9 @@ def animate(
         have no way to determine whether it should be represented as an RGB
         image or not, so the user must set this flag to tell us. It will be
         ignored if the representation doesn't look image-like or if the
-        model has its own plot_representation_error() method. Else, it will
-        be passed to :func:`plenoptic.imshow()`, see that methods docstring for details.
-        since plot_synthesis_status normally sets it up for us.
+        model has its own ``plot_representation_error()`` method. Else, it will
+        be passed to :func:`~plenoptic.tools.display.imshow`, see that method's
+        docstring for details.
     fig
         If ``None``, create the figure from scratch. Else, should be an empty
         figure with enough axes (the expected use here is have same-size

--- a/src/plenoptic/tools/__init__.py
+++ b/src/plenoptic/tools/__init__.py
@@ -1,3 +1,5 @@
+"""Miscellaneous tools."""
+
 # ignore F401 (unused import) and F403 (import * is bad practice)
 # ruff: noqa:  F401, F403
 from . import validate

--- a/src/plenoptic/tools/conv.py
+++ b/src/plenoptic/tools/conv.py
@@ -175,6 +175,8 @@ def blur_downsample(
     upsample_blur
         Perform the inverse operation, upsampling and convolving a user-specified number
         of times using a named filter.
+    :func:`~plenoptic.tools.signal.shrink`
+        An alternative downsampling operation.
     """
     if n_scales < 1:
         raise ValueError("n_scales must be positive!")
@@ -236,6 +238,8 @@ def upsample_blur(
     blur_downsample
         Perform the inverse operation, correlating and downsampling a user-specified
         number of times using a named filter.
+    :func:`~plenoptic.tools.signal.expand`
+        An alternative upsampling operation.
     """
     if n_scales < 1:
         raise ValueError("n_scales must be positive!")

--- a/src/plenoptic/tools/conv.py
+++ b/src/plenoptic/tools/conv.py
@@ -1,4 +1,7 @@
+"""Convolution-related utility functions."""  # numpydoc ignore=ES01
+
 import math
+from typing import Literal
 
 import numpy as np
 import pyrtools as pt
@@ -7,21 +10,49 @@ import torch.nn.functional as F
 from torch import Tensor
 
 
-def correlate_downsample(image, filt, padding_mode="reflect"):
-    """Correlate with a filter and downsample by 2
+def correlate_downsample(
+    image: Tensor,
+    filt: Tensor,
+    padding_mode: Literal["constant", "reflect", "replicate", "circular"] = "reflect",
+) -> Tensor:
+    """
+    Correlate with a filter and downsample by a factor of 2.
+
+    This operation allows one to downsample in an alias-resistant manner, removing the
+    high frequencies that would result in aliasing in a smaller image.
 
     Parameters
     ----------
-    image: torch.Tensor of shape (batch, channel, height, width)
-        Image, or batch of images. Channels are treated in the same way as batches.
-    filt: 2-D torch.Tensor
-        The filter to correlate with the input image
-    padding_mode: string, optional
-        One of "constant", "reflect", "replicate", "circular". The option "constant"
-        means padding with zeros.
-    """
+    image
+        Image, or batch of images, of shape (batch, channel, height, width).
+        Batches and channels are handled independently.
+    filt
+        2D tensor defining the filter to correlate with the input ``image``.
+    padding_mode
+        How to pad the image, so that we return an image of the appropriate size. The
+        option ``"constant"`` means padding with zeros.
 
-    assert isinstance(image, torch.Tensor) and isinstance(filt, torch.Tensor)
+    Returns
+    -------
+    downsampled_image
+        The downsampled image.
+
+    Raises
+    ------
+    ValueError
+        If ``filt`` or ``image`` has the wrong number of dimensions.
+
+    See Also
+    --------
+    blur_downsample
+        Perform this operation a user-specified number of times using a named filter.
+    upsample_convolve
+        Perform the inverse operation, upsampling and convolving with a filter.
+    """
+    if image.ndim != 4:
+        raise ValueError(f"image must be 4d but has {image.ndim} dimensions instead!")
+    if filt.ndim != 2:
+        raise ValueError(f"filt must be 2d but has {filt.ndim} dimensions instead!")
     assert image.ndim == 4 and filt.ndim == 2
     n_channels = image.shape[1]
     image_padded = same_padding(image, kernel_size=filt.shape, pad_mode=padding_mode)
@@ -33,26 +64,53 @@ def correlate_downsample(image, filt, padding_mode="reflect"):
     )
 
 
-def upsample_convolve(image, odd, filt, padding_mode="reflect"):
-    """Upsample by 2 and convolve with a filter
+def upsample_convolve(
+    image: Tensor,
+    odd: tuple[int, int],
+    filt: Tensor,
+    padding_mode: Literal["constant", "reflect", "replicate", "circular"] = "reflect",
+) -> Tensor:
+    """
+    Upsample by 2 and convolve with a filter.
+
+    When upsampling an image, we need some way to estimate the new pixels; convolving
+    with a filter allows us to interpolate these pixels from their neighbors.
 
     Parameters
     ----------
-    image: torch.Tensor of shape (batch, channel, height, width)
-        Image, or batch of images. Channels are treated in the same way as
-        batches.
-    odd: tuple, list or numpy.ndarray
+    image
+        Image, or batch of images, of shape (batch, channel, height, width).
+        Batches and channels are handled independently.
+    odd
         This should contain two integers of value 0 or 1, which determines whether
         the output height and width should be even (0) or odd (1).
-    filt: 2-D torch.Tensor
-        The filter to convolve with the upsampled image
-    padding_mode: string, optional
-        One of "constant", "reflect", "replicate", "circular". The option "constant"
-        means padding with zeros.
-    """
+    filt
+        2D tensor defining the filter to correlate with the input ``image``.
+    padding_mode
+        How to pad the image, so that we return an image of the appropriate size. The
+        option ``"constant"`` means padding with zeros.
 
-    assert isinstance(image, torch.Tensor) and isinstance(filt, torch.Tensor)
-    assert image.ndim == 4 and filt.ndim == 2
+    Returns
+    -------
+    upsampled_image
+        The upsampled image.
+
+    Raises
+    ------
+    ValueError
+        If ``filt`` or ``image`` has the wrong number of dimensions.
+
+    See Also
+    --------
+    upsample_blur
+        Perform this operation a user-specified number of times using a named filter.
+    correlate_downsample
+        Perform the inverse operation, correlating and downsampling an image.
+    """
+    if image.ndim != 4:
+        raise ValueError(f"image must be 4d but has {image.ndim} dimensions instead!")
+    if filt.ndim != 2:
+        raise ValueError(f"filt must be 2d but has {filt.ndim} dimensions instead!")
     filt = filt.flip((0, 1))
 
     n_channels = image.shape[1]
@@ -72,79 +130,176 @@ def upsample_convolve(image, odd, filt, padding_mode="reflect"):
     return F.conv2d(image_postpad, filt.repeat(n_channels, 1, 1, 1), groups=n_channels)
 
 
-def blur_downsample(x, n_scales=1, filtname="binom5", scale_filter=True):
-    """Correlate with a binomial coefficient filter and downsample by 2
+def blur_downsample(
+    image: Tensor,
+    n_scales: int = 1,
+    filtname: str = "binom5",
+    scale_filter: bool = True,
+) -> Tensor:
+    """
+    Correlate with a named filter and downsample by 2.
+
+    This operation allows one to downsample in an alias-resistant manner, removing the
+    high frequencies that would result in aliasing in a smaller image.
 
     Parameters
     ----------
-    x: torch.Tensor of shape (batch, channel, height, width)
-        Image, or batch of images. Channels are treated in the same way as batches.
-    n_scales: int, optional. Should be non-negative.
-        Apply the blur and downsample procedure recursively `n_scales` times. Default to
-        1.
-    filtname: str, optional
-        Name of the filter. See `pt.named_filter` for options. Default to "binom5".
-    scale_filter: bool, optional
-        If true (default), the filter sums to 1 (ie. it does not affect the DC
-        component of the signal). If false, the filter sums to 2.
-    """
+    image
+        Image, or batch of images, of shape (batch, channel, height, width).
+        Batches and channels are handled independently.
+    n_scales
+        Apply the blur and downsample procedure recursively ``n_scales`` times.
+        Must be positive.
+    filtname
+        Name of the filter. See ``pyrtools.named_filter`` for options.
+    scale_filter
+        If ``True``, the filter sums to 1 (i.e., it does not affect the DC component of
+        the signal and the output's mean will approximately match that of the input). If
+        ``False``, the filter sums to 2 (and the output's mean will be roughly double
+        that of the input).
 
+    Returns
+    -------
+    downsampled_image
+        The downsampled image.
+
+    Raises
+    ------
+    ValueError
+        If ``n_scales`` is not positive.
+
+    See Also
+    --------
+    correlate_downsample
+        Perform this operation once using a user-specified filter.
+    upsample_blur
+        Perform the inverse operation, upsampling and convolving a user-specified number
+        of times using a named filter.
+    """
+    if n_scales < 1:
+        raise ValueError("n_scales must be positive!")
     f = pt.named_filter(filtname)
-    filt = torch.as_tensor(np.outer(f, f), dtype=x.dtype, device=x.device)
+    filt = torch.as_tensor(np.outer(f, f), dtype=image.dtype, device=image.device)
     if scale_filter:
         filt = filt / 2
     for _ in range(n_scales):
-        x = correlate_downsample(x, filt)
-    return x
+        image = correlate_downsample(image, filt)
+    return image
 
 
-def upsample_blur(x, odd, filtname="binom5", scale_filter=True):
-    """Upsample by 2 and convolve with a binomial coefficient filter
+def upsample_blur(
+    image: Tensor,
+    odd: tuple[int, int],
+    n_scales: int = 1,
+    filtname: str = "binom5",
+    scale_filter: bool = True,
+) -> Tensor:
+    """
+    Upsample by 2 and convolve with named filter.
+
+    When upsampling an image, we need some way to estimate the new pixels; convolving
+    with a filter allows us to interpolate these pixels from their neighbors.
 
     Parameters
     ----------
-    x: torch.Tensor of shape (batch, channel, height, width)
-        Image, or batch of images. Channels are treated in the same way as batches.
-    odd: tuple, list or numpy.ndarray
+    image
+        Image, or batch of images, of shape (batch, channel, height, width).
+        Batches and channels are handled independently.
+    odd
         This should contain two integers of value 0 or 1, which determines whether
         the output height and width should be even (0) or odd (1).
-    filtname: str, optional
-        Name of the filter. See `pt.named_filter` for options. Default to "binom5".
-    scale_filter: bool, optional
-        If true (default), the filter sums to 4 (ie. it multiplies the signal
-        by 4 before the blurring operation). If false, the filter sums to 2.
-    """
+    n_scales
+        Apply the blur and downsample procedure recursively ``n_scales`` times.
+        Must be positive.
+    filtname
+        Name of the filter. See ``pyrtools.named_filter`` for options.
+    scale_filter
+        If ``True``, the filter sums to 4 (i.e., it does not affect the DC component of
+        the signal and the output's mean will approximately match that of the input). If
+        ``False``, the filter sums to 2 (and the output's mean will be roughly half
+        that of the input).
 
+    Returns
+    -------
+    upsampled_image
+        The upsampled image.
+
+    Raises
+    ------
+    ValueError
+        If ``n_scales`` is not positive.
+
+    See Also
+    --------
+    upsample_convolve
+        Perform this operation once using a user-specified filter.
+    blur_downsample
+        Perform the inverse operation, correlating and downsampling a user-specified
+        number of times using a named filter.
+    """
+    if n_scales < 1:
+        raise ValueError("n_scales must be positive!")
     f = pt.named_filter(filtname)
-    filt = torch.as_tensor(np.outer(f, f), dtype=x.dtype, device=x.device)
+    filt = torch.as_tensor(np.outer(f, f), dtype=image.dtype, device=image.device)
     if scale_filter:
         filt = filt * 2
-    return upsample_convolve(x, odd, filt)
+    for _ in range(n_scales):
+        image = upsample_convolve(image, odd, filt)
+    return image
 
 
 def _get_same_padding(x: int, kernel_size: int, stride: int, dilation: int) -> int:
-    """Helper function to determine integer padding for F.pad() given img and kernel"""
+    """Determine integer padding for F.pad() given img and kernel."""  # noqa: DOC201
+    # numpydoc ignore=ES01,PR01,RT01
     pad = (math.ceil(x / stride) - 1) * stride + (kernel_size - 1) * dilation + 1 - x
     pad = max(pad, 0)
     return pad
 
 
 def same_padding(
-    x: Tensor,
+    image: Tensor,
     kernel_size: tuple[int, int],
     stride: int | tuple[int, int] = (1, 1),
     dilation: int | tuple[int, int] = (1, 1),
     pad_mode: str = "circular",
 ) -> Tensor:
-    """Pad a tensor so that 2D convolution will result in output with same dims."""
-    assert len(x.shape) > 2, "Input must be tensor whose last dims are height x width"
-    ih, iw = x.shape[-2:]
+    """
+    Pad a tensor so that 2D convolution will result in output with same dims.
+
+    Parameters
+    ----------
+    image
+        Image, or batch of images, with at least 2 dimensions (height and width).
+        Any additional dimensions are handled independently.
+    kernel_size
+        Size of the kernel that ``image`` will be convolved with.
+    stride
+        Stride argument that will be passed to the convolution function.
+    dilation
+        Dilation argument that will be passed to the convolution function.
+    pad_mode
+        How to pad ``image``. See :func:`torch.nn.functional.pad` for possible
+        values.
+
+    Returns
+    -------
+    padded_image
+        The padded tensor.
+
+    Raises
+    ------
+    ValueError
+        If ``image`` is not 4d.
+    """  # numpydoc ignore=ES01
+    if len(image.shape) < 2:
+        raise ValueError("Input must be tensor whose last dims are height x width")
+    ih, iw = image.shape[-2:]
     pad_h = _get_same_padding(ih, kernel_size[0], stride[0], dilation[0])
     pad_w = _get_same_padding(iw, kernel_size[1], stride[1], dilation[1])
     if pad_h > 0 or pad_w > 0:
-        x = F.pad(
-            x,
+        image = F.pad(
+            image,
             [pad_w // 2, pad_w - pad_w // 2, pad_h // 2, pad_h - pad_h // 2],
             mode=pad_mode,
         )
-    return x
+    return image

--- a/src/plenoptic/tools/conv.py
+++ b/src/plenoptic/tools/conv.py
@@ -151,7 +151,8 @@ def blur_downsample(
         Apply the blur and downsample procedure recursively ``n_scales`` times.
         Must be positive.
     filtname
-        Name of the filter. See ``pyrtools.named_filter`` for options.
+        Name of the filter. See :func:`~pyrtools.pyramids.filters.named_filter` for
+        options.
     scale_filter
         If ``True``, the filter sums to 1 (i.e., it does not affect the DC component of
         the signal and the output's mean will approximately match that of the input). If
@@ -214,7 +215,8 @@ def upsample_blur(
         Apply the blur and downsample procedure recursively ``n_scales`` times.
         Must be positive.
     filtname
-        Name of the filter. See ``pyrtools.named_filter`` for options.
+        Name of the filter. See :func:`~pyrtools.pyramids.filters.named_filter` for
+        options.
     scale_filter
         If ``True``, the filter sums to 4 (i.e., it does not affect the DC component of
         the signal and the output's mean will approximately match that of the input). If

--- a/src/plenoptic/tools/convergence.py
+++ b/src/plenoptic/tools/convergence.py
@@ -23,12 +23,12 @@ They must return a single ``bool``: ``True`` if we've reached convergence,
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ..synthesize.metamer import Metamer
+    from ..synthesize.metamer import MetamerCTF
     from ..synthesize.synthesis import OptimizedSynthesis
 
 
 def loss_convergence(
-    synth: "OptimizedSynthesis",
+    synth: OptimizedSynthesis,
     stop_criterion: float,
     stop_iters_to_check: int,
 ) -> bool:
@@ -67,7 +67,7 @@ def loss_convergence(
     )
 
 
-def coarse_to_fine_enough(synth: "Metamer", i: int, ctf_iters_to_check: int) -> bool:
+def coarse_to_fine_enough(synth: MetamerCTF, i: int, ctf_iters_to_check: int) -> bool:
     r"""
     Check whether we've been synthesized all scales for long enough.
 
@@ -87,7 +87,7 @@ def coarse_to_fine_enough(synth: "Metamer", i: int, ctf_iters_to_check: int) -> 
     Parameters
     ----------
     synth
-        The Metamer object to check.
+        The MetamerCTF object to check.
     i
         The current iteration (0-indexed).
     ctf_iters_to_check
@@ -110,7 +110,7 @@ def coarse_to_fine_enough(synth: "Metamer", i: int, ctf_iters_to_check: int) -> 
 
 
 def pixel_change_convergence(
-    synth: "OptimizedSynthesis",
+    synth: OptimizedSynthesis,
     stop_criterion: float,
     stop_iters_to_check: int,
 ) -> bool:

--- a/src/plenoptic/tools/convergence.py
+++ b/src/plenoptic/tools/convergence.py
@@ -33,7 +33,7 @@ def loss_convergence(
     stop_iters_to_check: int,
 ) -> bool:
     r"""
-    Check whether the loss has stabilized and, if so, return True.
+    Check whether the loss has stabilized and, if so, return ``True``.
 
     We check whether:
 
@@ -115,7 +115,7 @@ def pixel_change_convergence(
     stop_iters_to_check: int,
 ) -> bool:
     """
-    Check whether the pixel change norm has stabilized and, if so, return True.
+    Check whether the pixel change norm has stabilized and, if so, return ``True``.
 
     We check whether:
 

--- a/src/plenoptic/tools/convergence.py
+++ b/src/plenoptic/tools/convergence.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 def loss_convergence(
-    synth: OptimizedSynthesis,
+    synth: "OptimizedSynthesis",
     stop_criterion: float,
     stop_iters_to_check: int,
 ) -> bool:
@@ -67,7 +67,7 @@ def loss_convergence(
     )
 
 
-def coarse_to_fine_enough(synth: MetamerCTF, i: int, ctf_iters_to_check: int) -> bool:
+def coarse_to_fine_enough(synth: "MetamerCTF", i: int, ctf_iters_to_check: int) -> bool:
     r"""
     Check whether we've been synthesized all scales for long enough.
 
@@ -110,7 +110,7 @@ def coarse_to_fine_enough(synth: MetamerCTF, i: int, ctf_iters_to_check: int) ->
 
 
 def pixel_change_convergence(
-    synth: OptimizedSynthesis,
+    synth: "OptimizedSynthesis",
     stop_criterion: float,
     stop_iters_to_check: int,
 ) -> bool:

--- a/src/plenoptic/tools/data.py
+++ b/src/plenoptic/tools/data.py
@@ -410,7 +410,7 @@ def _check_tensor_equality(
         Names of the tensors, used in error messages.
     rtol, atol
         Relative and absolute tolerance for value comparison, passed to
-        :func:``torch.allclose``.
+        :func:`torch.allclose`.
     error_prepend_str
         String to start error message with, should contain the string-formatting field
         ``"{error_type}"``.

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -133,7 +133,7 @@ def imshow(
           10th/90th percentile values map to the 10th/90th percentile intensities.
 
     zoom
-        Ratio of display pixels to image pixels. if greater than 1, must be an
+        Ratio of display pixels to image pixels. If greater than 1, must be an
         integer. If less than 1, must be ``1/d`` where ``d`` is a a divisor of the
         size of the largest image. If ``None``, we try to determine the best zoom.
     title
@@ -357,7 +357,7 @@ def animshow(
           10th/90th percentile values map to the 10th/90th percentile intensities.
 
     zoom
-        Ratio of display pixels to image pixels. if greater than 1, must be an
+        Ratio of display pixels to image pixels. If greater than 1, must be an
         integer. If less than 1, must be ``1/d`` where ``d`` is a a divisor of the
         size of the largest image. If ``None``, we try to determine the best zoom.
     title

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -468,7 +468,7 @@ def animshow(
 def pyrshow(
     pyr_coeffs: dict,
     vrange: tuple[float, float] | str = "indep1",
-    zoom: float | None = None,
+    zoom: float = 1,
     show_residuals: bool = True,
     cmap: mpl.colors.Colormap | None = None,
     plot_complex: Literal["rectangular", "polar", "logpolar"] = "rectangular",
@@ -527,7 +527,7 @@ def pyrshow(
     zoom
         Ratio of display pixels to image pixels. if greater than 1, must be an
         integer. If less than 1, must be ``1/d`` where ``d`` is a a divisor of the
-        size of the largest image. If ``None``, we try to determine the best zoom.
+        size of the largest image.
     show_residuals
         Whether to display the residual bands.
     cmap

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -472,7 +472,7 @@ def animshow(
             vid = vid.reshape((vid.shape[0], 1, *vid.shape[1:]))
         elif vid.shape[1] > 1 and vid.shape[0] > 1:
             raise ValueError(
-                "Don't know how to plot images with more than one channel and"
+                "Don't know how to plot non-rgb images with more than one channel and"
                 " batch! Use batch_idx / channel_idx to choose a subset for"
                 " plotting"
             )

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -804,7 +804,7 @@ def clean_stem_plot(
         The data to plot (as a stem plot).
     ax
         The axis to plot the data on. If ``None``, we plot on the current axis
-        (``plt.gca()``).
+        (grabbed with :func:`matplotlib.pyplot.gca`).
     title
         The title to put on the axis. If ``None``, we don't call ``ax.set_title``
         (useful if you want to avoid changing the title on an existing plot).

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -87,7 +87,7 @@ def imshow(
         * If ``str``, will put the same title on every plot.
 
         * If ``list``, all values must be ``str``, must be the same length as img,
-          assigning each title to corresponding image.
+          and each title will be assigned to corresponding plot.
 
         * If ``None``, no title will be printed and subtitle will be removed.
 
@@ -102,7 +102,8 @@ def imshow(
     cmap
         Colormap to use when showing these images. If ``None``, then behavior is
         determined by ``vrange``: if ``vmap in ["auto0", "indep0"]``, we use
-        :class:`matplotlib.cm.RdBu_r`, else we use :class:`matplotlib.cm.gray`.
+        ``"RdBu_r"``, else we use ``"gray"`` (see `matplotlib documentation
+        <https://matplotlib.org/stable/users/explain/colors/colormaps.html#colormaps>`_).
     plot_complex
         Specifies handling of complex values.
 
@@ -263,13 +264,10 @@ def animshow(
     """
     Animate video(s), avoiding interpolation.
 
-    This function animates videos correctly, making sure that each element in
-    the tensor corresponds to a pixel or an integer number of pixels, to avoid
-    aliasing (NOTE: this guarantee only holds for the saved animation (assuming
-    video compression doesn't interfere); it should generally hold in notebooks
-    as well, but will fail if, e.g., your video is 2000 pixels wide on an
-    monitor 1000 pixels wide; the notebook handles the rescaling in a way we
-    can't control).
+    This function shows images carefully, avoiding interpolation: each element in the
+    input ``image`` will correspond to a pixel or an integer number of pixels. When
+    ``zoom<1``, an integer number of input elements will be averaged into a single
+    pixel.
 
     This functions returns a matplotlib FuncAnimation object. See our documentation
     (e.g., `Quickstart
@@ -337,7 +335,7 @@ def animshow(
         * If ``str``, will put the same title on every plot.
 
         * If ``list``, all values must be ``str``, must be the same length as img,
-          assigning each title to corresponding image.
+          and each title will be assigned to corresponding plot.
 
         * If ``None``, no title will be printed and subtitle will be removed.
 
@@ -352,7 +350,8 @@ def animshow(
     cmap
         Colormap to use when showing these images. If ``None``, then behavior is
         determined by ``vrange``: if ``vmap in ["auto0", "indep0"]``, we use
-        :class:`matplotlib.cm.RdBu_r`, else we use :class:`matplotlib.cm.gray`.
+        ``"RdBu_r"``, else we use ``"gray"`` (see `matplotlib documentation
+        <https://matplotlib.org/stable/users/explain/colors/colormaps.html#colormaps>`_).
     plot_complex
         Specifies handling of complex values.
 
@@ -396,13 +395,18 @@ def animshow(
 
     Notes
     -----
-    By default, we use the ffmpeg backend, which requires that you have
-    ffmpeg installed and on your path (https://ffmpeg.org/download.html).
-    To use a different, use the matplotlib rcParams:
-    ``matplotlib.rcParams['animation.writer'] = writer``, see
-    `matplotlib documentation
-    <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_ for more
-    details.
+    - By default, we use the ffmpeg backend, which requires that you have
+      ffmpeg installed and on your path (https://ffmpeg.org/download.html).
+      To use a different, use the matplotlib rcParams:
+      ``matplotlib.rcParams['animation.writer'] = writer``, see
+      `matplotlib documentation
+      <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_ for more
+      details.
+
+    - This interpolation avoidance is only guaranteed for the saved image; it should
+      generally hold in notebooks as well, but will fail if, e.g., you plot an image
+      that's 2000 pixels wide on an monitor 1000 pixels wide; the browser handles the
+      rescaling in a way we can't control.
     """
     if not isinstance(video, list):
         video = [video]
@@ -587,7 +591,7 @@ def pyrshow(
 
 def clean_up_axes(
     ax: mpl.axes.Axes,
-    ylim: tuple[float, float] | False | None = None,
+    ylim: tuple[float, float] | None | Literal[False] = None,
     spines_to_remove: list[Literal["top", "right", "bottom", "left"]] = [
         "top",
         "right",
@@ -734,7 +738,7 @@ def clean_stem_plot(
     data: np.ndarray,
     ax: mpl.axes.Axes | None = None,
     title: str | None = "",
-    ylim: tuple | None | False = None,
+    ylim: tuple | None | Literal[False] = None,
     xvals: tuple[list[float], list[float]] | None = None,
     **kwargs: Any,
 ) -> mpl.axes.Axes:
@@ -744,7 +748,7 @@ def clean_stem_plot(
     This plots the data, baseline, cleans up the axis, and sets the
     title.
 
-    Helper function for the :func:`~plenoptic.tools.display.plot_representation()`.
+    Helper function for :func:`~plenoptic.tools.display.plot_representation()`.
 
     By default, stem plot would have a baseline that covers the entire range of the
     data. We want to be able to break that up visually (so there's a line from 0 to 9,
@@ -1101,7 +1105,7 @@ def plot_representation(
     data: np.ndarray | dict | None = None,
     ax: mpl.axes.Axes | None = None,
     figsize: tuple[float, float] | None = None,
-    ylim: tuple[float, float] | None | False = False,
+    ylim: tuple[float, float] | None | Literal[False] = False,
     batch_idx: int = 0,
     title: str = "",
     as_rgb: bool = False,

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -193,6 +193,8 @@ def imshow(
     TypeError
         If ``batch_idx`` or ``channel_idx`` takes an illegal value.
     ValueError
+        If ``zoom`` takes an illegal value.
+    ValueError
         If ``as_rgb=True`` and the input ``image`` does not have 3 or 4 channels.
     ValueError
         If ``as_rgb=False``, ``image`` has more than one channel and one more than
@@ -259,6 +261,8 @@ def imshow(
         zoom = _find_zoom(heights, widths, ax)
     elif zoom is None:
         zoom = 1
+    elif zoom <= 0:
+        raise ValueError("zoom must be positive!")
 
     return pt.imshow(
         images_to_plot,
@@ -485,6 +489,8 @@ def animshow(
         zoom = _find_zoom(heights, widths, ax)
     elif zoom is None:
         zoom = 1
+    elif zoom <= 0:
+        raise ValueError("zoom must be positive!")
 
     return pt.animshow(
         videos_to_show,

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -429,7 +429,7 @@ def animshow(
     -----
     - By default, we use the ffmpeg backend, which requires that you have
       ffmpeg installed and on your path (https://ffmpeg.org/download.html).
-      To use a different, use the matplotlib rcParams:
+      To use a different backend, use the matplotlib rcParams:
       ``matplotlib.rcParams['animation.writer'] = writer``, see
       `matplotlib documentation
       <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_ for more

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -1,7 +1,10 @@
-"""various helpful utilities for plotting or displaying information"""
+"""Various helpful utilities for plotting or displaying information."""
+# numpydoc ignore=ES01
 
 import warnings
+from typing import Any, Literal
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pyrtools as pt
@@ -11,113 +14,141 @@ from .data import to_numpy
 
 
 def imshow(
-    image,
-    vrange="indep1",
-    zoom=None,
-    title="",
-    col_wrap=None,
-    ax=None,
-    cmap=None,
-    plot_complex="rectangular",
-    batch_idx=None,
-    channel_idx=None,
-    as_rgb=False,
-    **kwargs,
-):
-    """Show image(s) correctly.
+    image: torch.Tensor | list[torch.Tensor],
+    vrange: tuple[float, float] | str = "indep1",
+    zoom: float | None = None,
+    title: str | list[str] | None = "",
+    col_wrap: int | None = None,
+    ax: mpl.axes.Axes | None = None,
+    cmap: mpl.colors.Colormap | None = None,
+    plot_complex: Literal["rectangular", "polar", "logpolar"] = "rectangular",
+    batch_idx: int | None = None,
+    channel_idx: int | None = None,
+    as_rgb: bool = False,
+    **kwargs: Any,
+) -> pt.tools.display.PyrFigure:
+    """
+    Show image(s), avoiding interpolation.
 
-    This function shows images correctly, making sure that each element in the
-    tensor corresponds to a pixel or an integer number of pixels, to avoid
-    aliasing (NOTE: this guarantee only holds for the saved image; it should
-    generally hold in notebooks as well, but will fail if, e.g., you plot an
-    image that's 2000 pixels wide on an monitor 1000 pixels wide; the notebook
-    handles the rescaling in a way we can't control).
+    This function shows images carefully, avoiding interpolation: each element in the
+    input ``image`` will correspond to a pixel or an integer number of pixels. When
+    ``zoom<1``, an integer number of input elements will be averaged into a single
+    pixel.
 
     Parameters
     ----------
-    image : torch.Tensor or list
+    image
         The images to display. Tensors should be 4d (batch, channel, height,
         width). List of tensors should be used for tensors of different height
         and width: all images will automatically be rescaled so they're
         displayed at the same height and width, thus, their heights and widths
         must be scalar multiples of each other.
-    vrange : `tuple` or `str`
+    vrange
         If a 2-tuple, specifies the image values vmin/vmax that are mapped to
         the minimum and maximum value of the colormap, respectively. If a
         string:
 
-        * `'auto0'`: all images have same vmin/vmax, which have the same absolute
-                     value, and come from the minimum or maximum across all
-                     images, whichever has the larger absolute value
-        * `'auto/auto1'`: all images have same vmin/vmax, which are the
-                          minimum/maximum values across all images
-        * `'auto2'`: all images have same vmin/vmax, which are the mean (across
-                     all images) minus/ plus 2 std dev (across all images)
-        * `'auto3'`: all images have same vmin/vmax, chosen so as to map the
-                     10th/90th percentile values to the 10th/90th percentile of
-                     the display intensity range. For example: vmin is the 10th
-                     percentile image value minus 1/8 times the difference
-                     between the 90th and 10th percentile
-        * `'indep0'`: each image has an independent vmin/vmax, which have the
-                      same absolute value, which comes from either their
-                      minimum or maximum value, whichever has the larger
-                      absolute value.
-        * `'indep1'`: each image has an independent vmin/vmax, which are their
-                      minimum/maximum values
-        * `'indep2'`: each image has an independent vmin/vmax, which is their
-                      mean minus/plus 2 std dev
-        * `'indep3'`: each image has an independent vmin/vmax, chosen so that
-                      the 10th/90th percentile values map to the 10th/90th
-                      percentile intensities.
-    zoom : `float` or `None`
-        ratio of display pixels to image pixels. if >1, must be an integer. If
-        <1, must be 1/d where d is a a divisor of the size of the largest
-        image. If None, we try to determine the best zoom.
-    title : `str`, `list`, or None, optional
-        Title for the plot. In addition to the specified title, we add a
-        subtitle giving the plotted range and dimensionality (with zoom)
-        * if `str`, will put the same title on every plot.
-        * if `list`, all values must be `str`, must be the same length as img,
-          assigning each title to corresponding image.
-        * if None, no title will be printed (and subtitle will be removed).
-    col_wrap : `int` or None, optional
-        number of axes to have in each row. If None, will fit all axes in a
-        single row.
-    ax : `matplotlib.pyplot.axis` or None, optional
-        if None, we make the appropriate figure. otherwise, we resize the axes
-        so that it's the appropriate number of pixels (done by shrinking the
-        bbox - if the bbox is already too small, this will throw an Exception!,
-        so first define a large enough figure using either make_figure or
-        plt.figure)
-    cmap : matplotlib colormap, optional
-        colormap to use when showing these images
-    plot_complex : {'rectangular', 'polar', 'logpolar'}
-        specifies handling of complex values.
+        * ``"auto0"``: All images have same vmin/vmax, which have the same
+          absolute value, and come from the minimum or maximum across all
+          images, whichever has the larger absolute value.
 
-        * `'rectangular'`: plot real and imaginary components as separate images
-        * `'polar'`: plot amplitude and phase as separate images
-        * `'logpolar'`: plot log_2 amplitude and phase as separate images
-        for any other value, we raise a warning and default to rectangular.
-    batch_idx : int or None, optional
-        Which element from the batch dimension to plot. If None, we plot all.
-    channel_idx : int or None, optional
-        Which element from the channel dimension to plot. If None, we plot all.
-        Note if this is an int, then `as_rgb=True` will fail, because we
+        * ``"auto1"``: All images have same vmin/vmax, which are the
+          minimum/maximum values across all images.
+
+        * ``"auto2"``: All images have same vmin/vmax, which are the mean (across
+          all images) minus/ plus 2 std dev (across all images).
+
+        * ``"auto3"``: All images have same vmin/vmax, chosen so as to map the 10th/90th
+          percentile values to the 10th/90th percentile of the display intensity range.
+          For example: vmin is the 10th percentile image value minus 1/8 times the
+          difference between the 90th and 10th percentile.
+
+        * ``"indep0"``: Each image has an independent vmin/vmax, which have the same
+          absolute value, which comes from either their minimum or maximum value,
+          whichever has the larger absolute value.
+
+        * ``"indep1"``: Each image has an independent vmin/vmax, which are their
+          minimum/maximum values.
+
+        * ``"indep2"``: Each image has an independent vmin/vmax, which is their
+          mean minus/plus 2 std dev.
+
+        * ``"indep3"``: Each image has an independent vmin/vmax, chosen so that the
+          10th/90th percentile values map to the 10th/90th percentile intensities.
+
+    zoom
+        Ratio of display pixels to image pixels. if greater than 1, must be an
+        integer. If less than 1, must be ``1/d`` where ``d`` is a a divisor of the
+        size of the largest image. If ``None``, we try to determine the best zoom.
+    title
+        Title for the plot. In addition to the specified title, we add a
+        subtitle giving the plotted range and dimensionality (with zoom).
+
+        * If ``str``, will put the same title on every plot.
+
+        * If ``list``, all values must be ``str``, must be the same length as img,
+          assigning each title to corresponding image.
+
+        * If ``None``, no title will be printed and subtitle will be removed.
+
+    col_wrap
+        Number of axes to have in each row. If ``None``, will fit all axes in a
+        single row.
+    ax
+        If ``None``, we make the appropriate figure. Otherwise, we resize the axes
+        so that it's the appropriate number of pixels (done by shrinking the
+        bbox - if the bbox is already too small, this will throw an Exception,
+        so first define a large enough figure).
+    cmap
+        Colormap to use when showing these images. If ``None``, then behavior is
+        determined by ``vrange``: if ``vmap in ["auto0", "indep0"]``, we use
+        :class:`matplotlib.cm.RdBu_r`, else we use :class:`matplotlib.cm.gray`.
+    plot_complex
+        Specifies handling of complex values.
+
+        * ``"rectangular"``: plot real and imaginary components as separate images.
+
+        * ``"polar"``: plot amplitude and phase as separate images.
+
+        * ``"logpolar"``: plot log (base 2) amplitude and phase as separate images.
+
+    batch_idx
+        Which element from the batch dimension to plot. If ``None``, we plot all.
+    channel_idx
+        Which element from the channel dimension to plot. If ``None``, we plot all.
+        Note if this is not ``None``, then ``as_rgb=True`` will fail, because we
         restrict the channels.
-    as_rgb : bool, optional
-        Whether to consider the channels as encoding RGB(A) values. If True, we
+    as_rgb
+        Whether to consider the channels as encoding RGB(A) values. If ``True``, we
         attempt to plot the image in color, so your tensor must have 3 (or 4 if
-        you want the alpha channel) elements in the channel dimension, or this
-        will raise an Exception. If False, we plot each channel as a separate
-        grayscale image.
-    kwargs :
-        Passed to `ax.imshow`
+        you want the alpha channel) elements in the channel dimension. If ``False``,
+        we plot each channel as a separate grayscale image.
+    **kwargs
+        Passed to :func:`matplotlib.pyplot.imshow`.
 
     Returns
     -------
-    fig : `PyrFigure`
-        figure containing the plotted images
+    fig
+        Figure containing the plotted images.
 
+    Raises
+    ------
+    TypeError
+        If ``batch_idx`` or ``channel_idx`` takes an illegal value.
+    ValueError
+        If ``as_rgb=True`` and the input ``image`` does not have 3 or 4 channels.
+    ValueError
+        If ``as_rgb=False``, ``image`` has more than one channel and one more than
+        one batch and neither ``batch_idx`` nor ``channel_idx`` is set.
+    Exception
+        If ``plot_complex`` takes an illegal value.
+
+    Notes
+    -----
+    This interpolation avoidance is only guaranteed for the saved image; it should
+    generally hold in notebooks as well, but will fail if, e.g., you plot an image
+    that's 2000 pixels wide on an monitor 1000 pixels wide; the browser handles the
+    rescaling in a way we can't control.
     """
     if not isinstance(image, list):
         image = [image]
@@ -151,9 +182,9 @@ def imshow(
             im = im.reshape((im.shape[0], 1, *im.shape[1:]))
         elif im.shape[1] > 1 and im.shape[0] > 1:
             raise ValueError(
-                "Don't know how to plot images with more than one channel and"
-                " batch! Use batch_idx / channel_idx to choose a subset for"
-                " plotting"
+                "Don't know how to plot non-rgb images with more than one channel"
+                " and batch! Use batch_idx / channel_idx to choose a subset for"
+                " plotting."
             )
         # by iterating through it twice, we make sure to peel apart the batch
         # and channel dimensions so that they each show up as a separate image.
@@ -167,8 +198,22 @@ def imshow(
             heights.extend([i_.shape[0] for i_ in i])
             widths.extend([i_.shape[1] for i_ in i])
 
-    def find_zoom(x, limit):
-        """Find zoom that works. This is only for limit < x."""
+    def find_zoom(x: float, limit: float) -> float:
+        """
+        Find zoom that works. This is only for limit < x.
+
+        Parameters
+        ----------
+        x
+            The sizes to consider.
+        limit
+            The max possible size.
+
+        Returns
+        -------
+        zoom
+            The valid zoom level.
+        """  # numpydoc ignore=ES01
         # find all non-trivial divisors of x
         divisors = [i for i in range(2, x) if not x % i]
         # find the largest zoom (equivalently, smallest divisor) such that the
@@ -200,22 +245,23 @@ def imshow(
 
 
 def animshow(
-    video,
-    framerate=2.0,
-    repeat=False,
-    vrange="indep1",
-    zoom=1,
-    title="",
-    col_wrap=None,
-    ax=None,
-    cmap=None,
-    plot_complex="rectangular",
-    batch_idx=None,
-    channel_idx=None,
-    as_rgb=False,
-    **kwargs,
-):
-    """Animate video(s) correctly.
+    video: torch.Tensor | list[torch.Tensor],
+    framerate: float = 2.0,
+    repeat: bool = False,
+    vrange: tuple[float, float] | str = "indep1",
+    zoom: float = 1,
+    title: str | list[str] | None = "",
+    col_wrap: int | None = None,
+    ax: mpl.axes.Axes | None = None,
+    cmap: mpl.colors.Colormap | None = None,
+    plot_complex: Literal["rectangular", "polar", "logpolar"] = "rectangular",
+    batch_idx: int | None = None,
+    channel_idx: int | None = None,
+    as_rgb: bool = False,
+    **kwargs: Any,
+) -> mpl.animation.FuncAnimation:
+    """
+    Animate video(s), avoiding interpolation.
 
     This function animates videos correctly, making sure that each element in
     the tensor corresponds to a pixel or an integer number of pixels, to avoid
@@ -226,115 +272,137 @@ def animshow(
     can't control).
 
     This functions returns a matplotlib FuncAnimation object. See our documentation
-    (e.g.,
-    [Quickstart](https://docs.plenoptic.org/docs/branch/main/tutorials/00_quickstart.html))
-    for examples on how to view it in a Jupyter notebook. In order to save, use
+    (e.g., `Quickstart
+    <https://docs.plenoptic.org/docs/branch/main/tutorials/00_quickstart.html>`_) for
+    examples on how to view it in a Jupyter notebook. In order to save, use
     ``anim.save(filename)``. In either case, this can take a while and you'll need the
     appropriate writer installed and on your path, e.g., ffmpeg, imagemagick, etc). See
-    [matplotlib documentation](https://matplotlib.org/stable/api/animation_api.html) for
-    more details.
+    `matplotlib documentation <https://matplotlib.org/stable/api/animation_api.html>`_
+    for more details.
 
     Parameters
     ----------
-    video : torch.Tensor or list
-        The videos to display. Tensors should be 5d (batch, channel, time,
+    video
+        The video(s) to display. Tensors should be 5d (batch, channel, time,
         height, width). List of tensors should be used for tensors of different
         height and width: all videos will automatically be rescaled so they're
         displayed at the same height and width, thus, their heights and widths
         must be scalar multiples of each other. Videos must all have the same
-        number of frames as well.
-    framerate : `float`
+        number of frames.
+    framerate
         Temporal resolution of the video, in Hz (frames per second).
-    repeat : `bool`
-        whether to loop the animation or just play it once
-    vrange : `tuple` or `str`
+    repeat
+        Whether to loop the animation or just play it once.
+    vrange
         If a 2-tuple, specifies the image values vmin/vmax that are mapped to
         the minimum and maximum value of the colormap, respectively. If a
         string:
 
-        * `'auto0'`: all images have same vmin/vmax, which have the same absolute
-                     value, and come from the minimum or maximum across all
-                     images, whichever has the larger absolute value
-        * `'auto/auto1'`: all images have same vmin/vmax, which are the
-                          minimum/maximum values across all images
-        * `'auto2'`: all images have same vmin/vmax, which are the mean (across
-                     all images) minus/ plus 2 std dev (across all images)
-        * `'auto3'`: all images have same vmin/vmax, chosen so as to map the
-                     10th/90th percentile values to the 10th/90th percentile of
-                     the display intensity range. For example: vmin is the 10th
-                     percentile image value minus 1/8 times the difference
-                     between the 90th and 10th percentile
-        * `'indep0'`: each image has an independent vmin/vmax, which have the
-                      same absolute value, which comes from either their
-                      minimum or maximum value, whichever has the larger
-                      absolute value.
-        * `'indep1'`: each image has an independent vmin/vmax, which are their
-                      minimum/maximum values
-        * `'indep2'`: each image has an independent vmin/vmax, which is their
-                      mean minus/plus 2 std dev
-        * `'indep3'`: each image has an independent vmin/vmax, chosen so that
-                      the 10th/90th percentile values map to the 10th/90th
-                      percentile intensities.
-    zoom : `float`
-        ratio of display pixels to image pixels. if >1, must be an integer. If
-        <1, must be 1/d where d is a a divisor of the size of the largest
-        image.
-    title : `str`, `list`, or None, optional
-        Title for the plot. In addition to the specified title, we add a
-        subtitle giving the plotted range and dimensionality (with zoom)
-        * if `str`, will put the same title on every plot.
-        * if `list`, all values must be `str`, must be the same length as img,
-          assigning each title to corresponding image.
-        * if None, no title will be printed (and subtitle will be removed).
-    col_wrap : `int` or None, optional
-        number of axes to have in each row. If None, will fit all axes in a
-        single row.
-    ax : `matplotlib.pyplot.axis` or None, optional
-        if None, we make the appropriate figure. otherwise, we resize the axes
-        so that it's the appropriate number of pixels (done by shrinking the
-        bbox - if the bbox is already too small, this will throw an Exception!,
-        so first define a large enough figure using either
-        pyrtools.make_figure or plt.figure)
-    cmap : matplotlib colormap, optional
-        colormap to use when showing these images
-    plot_complex : {'rectangular', 'polar', 'logpolar'}
-        specifies handling of complex values.
+        * ``"auto0"``: All images have same vmin/vmax, which have the same
+          absolute value, and come from the minimum or maximum across all
+          images, whichever has the larger absolute value.
 
-        * `'rectangular'`: plot real and imaginary components as separate images
-        * `'polar'`: plot amplitude and phase as separate images
-        * `'logpolar'`: plot log_2 amplitude and phase as separate images
-        for any other value, we raise a warning and default to rectangular.
-    batch_idx : int or None, optional
-        Which element from the batch dimension to plot. If None, we plot all.
-    channel_idx : int or None, optional
-        Which element from the channel dimension to plot. If None, we plot all.
-        Note if this is an int, then `as_rgb=True` will fail, because we
+        * ``"auto1"``: All images have same vmin/vmax, which are the
+          minimum/maximum values across all images.
+
+        * ``"auto2"``: All images have same vmin/vmax, which are the mean (across
+          all images) minus/ plus 2 std dev (across all images).
+
+        * ``"auto3"``: All images have same vmin/vmax, chosen so as to map the 10th/90th
+          percentile values to the 10th/90th percentile of the display intensity range.
+          For example: vmin is the 10th percentile image value minus 1/8 times the
+          difference between the 90th and 10th percentile.
+
+        * ``"indep0"``: Each image has an independent vmin/vmax, which have the same
+          absolute value, which comes from either their minimum or maximum value,
+          whichever has the larger absolute value.
+
+        * ``"indep1"``: Each image has an independent vmin/vmax, which are their
+          minimum/maximum values.
+
+        * ``"indep2"``: Each image has an independent vmin/vmax, which is their
+          mean minus/plus 2 std dev.
+
+        * ``"indep3"``: Each image has an independent vmin/vmax, chosen so that the
+          10th/90th percentile values map to the 10th/90th percentile intensities.
+
+    zoom
+        Ratio of display pixels to image pixels. if greater than 1, must be an
+        integer. If less than 1, must be ``1/d`` where ``d`` is a a divisor of the
+        size of the largest image. If ``None``, we try to determine the best zoom.
+    title
+        Title for the plot. In addition to the specified title, we add a
+        subtitle giving the plotted range and dimensionality (with zoom).
+
+        * If ``str``, will put the same title on every plot.
+
+        * If ``list``, all values must be ``str``, must be the same length as img,
+          assigning each title to corresponding image.
+
+        * If ``None``, no title will be printed and subtitle will be removed.
+
+    col_wrap
+        Number of axes to have in each row. If ``None``, will fit all axes in a
+        single row.
+    ax
+        If ``None``, we make the appropriate figure. Otherwise, we resize the axes
+        so that it's the appropriate number of pixels (done by shrinking the
+        bbox - if the bbox is already too small, this will throw an Exception,
+        so first define a large enough figure).
+    cmap
+        Colormap to use when showing these images. If ``None``, then behavior is
+        determined by ``vrange``: if ``vmap in ["auto0", "indep0"]``, we use
+        :class:`matplotlib.cm.RdBu_r`, else we use :class:`matplotlib.cm.gray`.
+    plot_complex
+        Specifies handling of complex values.
+
+        * ``"rectangular"``: plot real and imaginary components as separate images.
+
+        * ``"polar"``: plot amplitude and phase as separate images.
+
+        * ``"logpolar"``: plot log (base 2) amplitude and phase as separate images.
+
+    batch_idx
+        Which element from the batch dimension to plot. If ``None``, we plot all.
+    channel_idx
+        Which element from the channel dimension to plot. If ``None``, we plot all.
+        Note if this is not ``None``, then ``as_rgb=True`` will fail, because we
         restrict the channels.
-    as_rgb : bool, optional
-        Whether to consider the channels as encoding RGB(A) values. If True, we
+    as_rgb
+        Whether to consider the channels as encoding RGB(A) values. If ``True``, we
         attempt to plot the image in color, so your tensor must have 3 (or 4 if
-        you want the alpha channel) elements in the channel dimension, or this
-        will raise an Exception. If False, we plot each channel as a separate
-        grayscale image.
-    kwargs :
-        Passed to `ax.imshow`
+        you want the alpha channel) elements in the channel dimension. If ``False``,
+        we plot each channel as a separate grayscale image.
+    **kwargs
+        Passed to :func:`matplotlib.pyplot.imshow`.
 
     Returns
     -------
-    anim : matplotlib.animation.FuncAnimation
+    anim
         The animation object. In order to view, must convert to HTML
         or save.
 
+    Raises
+    ------
+    TypeError
+        If ``batch_idx`` or ``channel_idx`` takes an illegal value.
+    ValueError
+        If ``as_rgb=True`` and the input ``image`` does not have 3 or 4 channels.
+    ValueError
+        If ``as_rgb=False``, ``image`` has more than one channel and one more than
+        one batch and neither ``batch_idx`` nor ``channel_idx`` is set.
+    Exception
+        If ``plot_complex`` takes an illegal value.
+
     Notes
     -----
-
     By default, we use the ffmpeg backend, which requires that you have
     ffmpeg installed and on your path (https://ffmpeg.org/download.html).
     To use a different, use the matplotlib rcParams:
-    `matplotlib.rcParams['animation.writer'] = writer`, see
-    https://matplotlib.org/stable/api/animation_api.html#writer-classes for
-    more details.
-
+    ``matplotlib.rcParams['animation.writer'] = writer``, see
+    `matplotlib documentation
+    <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_ for more
+    details.
     """
     if not isinstance(video, list):
         video = [video]
@@ -394,85 +462,96 @@ def animshow(
 
 
 def pyrshow(
-    pyr_coeffs,
-    vrange="indep1",
-    zoom=1,
-    show_residuals=True,
-    cmap=None,
-    plot_complex="rectangular",
-    batch_idx=0,
-    channel_idx=0,
-    **kwargs,
-):
-    r"""Display steerable pyramid coefficients in orderly fashion.
+    pyr_coeffs: dict,
+    vrange: tuple[float, float] | str = "indep1",
+    zoom: float | None = None,
+    show_residuals: bool = True,
+    cmap: mpl.colors.Colormap | None = None,
+    plot_complex: Literal["rectangular", "polar", "logpolar"] = "rectangular",
+    batch_idx: int = 0,
+    channel_idx: int = 0,
+    **kwargs: Any,
+) -> pt.tools.display.PyrFigure:
+    r"""
+    Display steerable pyramid coefficients in orderly fashion.
 
-    This function uses ``imshow`` to show the coefficients of the steeable
-    pyramid, such that each scale shows up on a single row, with each scale in
-    a given column.
+    This function uses :func:`~plenoptic.tools.display.imshow` to show the coefficients
+    of the steeable pyramid, such that each scale shows up on a single row, with each
+    scale in a given column.
 
-    Note that unlike imshow, we can only show one batch or channel at a time
+    Note that unlike :func:`~plenoptic.tools.display.imshow`, we can only show one batch
+    or channel at a time.
 
     Parameters
     ----------
-    pyr_coeffs : `dict`
-        pyramid coefficients in the standard dictionary format as returned by
-        ``SteerablePyramidFreq.forward()``
-    vrange : `tuple` or `str`
+    pyr_coeffs
+        Pyramid coefficients in the standard dictionary format as returned by
+        ``SteerablePyramidFreq.forward()``.
+    vrange
         If a 2-tuple, specifies the image values vmin/vmax that are mapped to
         the minimum and maximum value of the colormap, respectively. If a
         string:
 
-        * `'auto0'`: all images have same vmin/vmax, which have the same absolute
-                     value, and come from the minimum or maximum across all
-                     images, whichever has the larger absolute value
-        * `'auto/auto1'`: all images have same vmin/vmax, which are the
-                          minimum/maximum values across all images
-        * `'auto2'`: all images have same vmin/vmax, which are the mean (across
-                     all images) minus/ plus 2 std dev (across all images)
-        * `'auto3'`: all images have same vmin/vmax, chosen so as to map the
-                     10th/90th percentile values to the 10th/90th percentile of
-                     the display intensity range. For example: vmin is the 10th
-                     percentile image value minus 1/8 times the difference
-                     between the 90th and 10th percentile
-        * `'indep0'`: each image has an independent vmin/vmax, which have the
-                      same absolute value, which comes from either their
-                      minimum or maximum value, whichever has the larger
-                      absolute value.
-        * `'indep1'`: each image has an independent vmin/vmax, which are their
-                      minimum/maximum values
-        * `'indep2'`: each image has an independent vmin/vmax, which is their
-                      mean minus/plus 2 std dev
-        * `'indep3'`: each image has an independent vmin/vmax, chosen so that
-                      the 10th/90th percentile values map to the 10th/90th
-                      percentile intensities.
-    zoom : `float`
-        ratio of display pixels to image pixels. if >1, must be an integer. If
-        <1, must be 1/d where d is a a divisor of the size of the largest
-        image.
-    show_residuals : `bool`
-        whether to display the residual bands (lowpass, highpass depending on the
-        pyramid type)
-    cmap : matplotlib colormap, optional
-        colormap to use when showing these images
-    plot_complex : {'rectangular', 'polar', 'logpolar'}
-        specifies handling of complex values.
+        * ``"auto0"``: All images have same vmin/vmax, which have the same
+          absolute value, and come from the minimum or maximum across all
+          images, whichever has the larger absolute value.
 
-        * `'rectangular'`: plot real and imaginary components as separate images
-        * `'polar'`: plot amplitude and phase as separate images
-        * `'logpolar'`: plot log_2 amplitude and phase as separate images
-        for any other value, we raise a warning and default to rectangular.
-    batch_idx : int, optional
+        * ``"auto1"``: All images have same vmin/vmax, which are the
+          minimum/maximum values across all images.
+
+        * ``"auto2"``: All images have same vmin/vmax, which are the mean (across
+          all images) minus/ plus 2 std dev (across all images).
+
+        * ``"auto3"``: All images have same vmin/vmax, chosen so as to map the 10th/90th
+          percentile values to the 10th/90th percentile of the display intensity range.
+          For example: vmin is the 10th percentile image value minus 1/8 times the
+          difference between the 90th and 10th percentile.
+
+        * ``"indep0"``: Each image has an independent vmin/vmax, which have the same
+          absolute value, which comes from either their minimum or maximum value,
+          whichever has the larger absolute value.
+
+        * ``"indep1"``: Each image has an independent vmin/vmax, which are their
+          minimum/maximum values.
+
+        * ``"indep2"``: Each image has an independent vmin/vmax, which is their
+          mean minus/plus 2 std dev.
+
+        * ``"indep3"``: Each image has an independent vmin/vmax, chosen so that the
+          10th/90th percentile values map to the 10th/90th percentile intensities.
+
+    zoom
+        Ratio of display pixels to image pixels. if greater than 1, must be an
+        integer. If less than 1, must be ``1/d`` where ``d`` is a a divisor of the
+        size of the largest image. If ``None``, we try to determine the best zoom.
+    show_residuals
+        Whether to display the residual bands.
+    cmap
+        Colormap to use when showing these images.
+    plot_complex : {'rectangular', 'polar', 'logpolar'}
+        Specifies handling of complex values.
+
+        * ``"rectangular"``: plot real and imaginary components as separate images.
+
+        * ``"polar"``: plot amplitude and phase as separate images.
+
+        * ``"logpolar"``: plot log (base 2) amplitude and phase as separate images.
+    batch_idx
         Which element from the batch dimension to plot.
-    channel_idx : int, optional
+    channel_idx
         Which element from the channel dimension to plot.
-    kwargs :
-        Passed on to ``pyrtools.pyrshow``
+    **kwargs
+        Passed on to :func:`pyrtools.tools.display.pyrshow`.
 
     Returns
     -------
-    fig: `PyrFigure`
-        the figure displaying the coefficients.
+    fig
+        The figure displaying the coefficients.
 
+    Raises
+    ------
+    TypeError
+        If ``batch_idx`` or ``channel_idx`` takes an illegal value.
     """
     pyr_coeffvis = {}
     is_complex = False
@@ -484,12 +563,12 @@ def pyrshow(
             # this removes only the first (batch) dimension
             im = im[batch_idx : batch_idx + 1].squeeze(0)
         except TypeError:
-            raise TypeError(f"batch_idx must be an int or None but got {batch_idx}")
+            raise TypeError(f"batch_idx must be an int but got {batch_idx}")
         try:
             # this removes only the first (now channel) dimension
             im = im[channel_idx : channel_idx + 1].squeeze(0)
         except TypeError:
-            raise TypeError(f"channel_idx must be an int or None but got {channel_idx}")
+            raise TypeError(f"channel_idx must be an int but got {channel_idx}")
         # because of how we've handled everything above, we know that im will
         # be (h,w).
         pyr_coeffvis[k] = im
@@ -507,32 +586,44 @@ def pyrshow(
 
 
 def clean_up_axes(
-    ax,
-    ylim=None,
-    spines_to_remove=["top", "right", "bottom"],
-    axes_to_remove=["x"],
-):
-    r"""Clean up an axis, as desired when making a stem plot of the representation
+    ax: mpl.axes.Axes,
+    ylim: tuple[float, float] | False | None = None,
+    spines_to_remove: list[Literal["top", "right", "bottom", "left"]] = [
+        "top",
+        "right",
+        "bottom",
+    ],
+    axes_to_remove: list[Literal["x", "y"]] = ["x"],
+) -> mpl.axes.Axes:
+    r"""
+    Clean up an axis, as desired when making a stem plot of the representation.
+
+    This function can:
+
+    - Remove the spines from axis (the axis lines and tick marks).
+
+    - Set axis objects themselves invisible (includes not just spines but also tick
+      labels and axis label).
+
+    - Set ylim.
 
     Parameters
     ----------
-    ax : `matplotlib.pyplot.axis`
+    ax
         The axis to clean up.
-    ylim : `tuple`, False, or None
-        If a tuple, the y-limits to use for this plot. If None, we use the
-        default, slightly adjusted so that the minimum is 0. If False,
+    ylim
+        If a tuple, the y-limits to use for this plot. If ``None``, we use the
+        default, slightly adjusted so that the minimum is 0. If ``False``,
         we do nothing.
-    spines_to_remove : `list`
-        Some combination of 'top', 'right', 'bottom', and 'left'. The spines we
-        remove from the axis.
-    axes_to_remove : `list`
-        Some combination of 'x', 'y'. The axes to set as invisible.
+    spines_to_remove
+        The spines to remove from the axis.
+    axes_to_remove
+        The axes to set as invisible.
 
     Returns
     -------
-    ax : matplotlib.pyplot.axis
-        The cleaned-up axis
-
+    ax
+        The cleaned-up axis.
     """
     if spines_to_remove is None:
         spines_to_remove = ["top", "right", "bottom"]
@@ -553,8 +644,11 @@ def clean_up_axes(
     return ax
 
 
-def update_stem(stem_container, ydata):
-    r"""Update the information in a stem plot
+def update_stem(
+    stem_container: mpl.container.StemContainer, ydata: np.ndarray | torch.Tensor
+) -> mpl.container.StemContainer:
+    r"""
+    Update the information in a stem plot.
 
     We update the information in a single stem plot to match that given
     by ``ydata``. We update the position of the markers and and the
@@ -563,21 +657,19 @@ def update_stem(stem_container, ydata):
 
     Parameters
     ----------
-    stem_container : `matplotlib.container.StemContainer`
-        Single container for the artists created in a ``plt.stem``
-        plot. It can be treated like a namedtuple ``(markerline,
-        stemlines, baseline)``. In order to get this from an axis
-        ``ax``, try ``ax.containers[0]`` (obviously if you have more
-        than one container in that axis, it may not be the first one).
-    ydata : array_like
-        The new y-data to show on the plot. Importantly, must be the
-        same length as the existing y-data.
+    stem_container
+        Single container for the artists created in a :func:`matplotlib.pyplot.stem`
+        plot. It can be treated like a namedtuple ``(markerline, stemlines, baseline)``.
+        In order to get this from an axis ``ax``, try ``ax.containers[0]`` (if you have
+        more than one container in that axis, it may not be the first one).
+    ydata
+        The new y-data to show on the plot. Importantly, must be the same length as
+        the existing y-data.
 
     Returns
     -------
-    stem_container : `matplotlib.container.StemContainer`
+    stem_container
         The StemContainer containing the updated artists.
-
     """
     stem_container.markerline.set_ydata(ydata)
     segments = stem_container.stemlines.get_segments().copy()
@@ -592,23 +684,36 @@ def update_stem(stem_container, ydata):
     return stem_container
 
 
-def rescale_ylim(axes, data):
-    r"""rescale y-limits nicely
+def rescale_ylim(axes: list[mpl.axes.Axes], data: np.ndarray | torch.Tensor):
+    r"""
+    Rescale y-limits nicely.
 
     We take the axes and set their limits to be ``(-y_max, y_max)``,
-    where ``y_max=np.abs(data).max()``
+    where ``y_max=np.abs(data).max()``.
 
     Parameters
     ----------
-    axes : `list`
-        A list of matplotlib axes to rescale
-    data : array_like or dict
-        The data to use when rescaling (or a dictiontary of those
-        values)
+    axes
+        A list of matplotlib axes to rescale.
+    data
+        The data to use when rescaling (or a dictionary of such values).
     """
     data = data.cpu()
 
-    def find_ymax(data):
+    def find_ymax(data: np.ndarray | torch.Tensor) -> float:
+        """
+        Find appropriate ymax.
+
+        Parameters
+        ----------
+        data
+            The tensor whose ymax we should grab.
+
+        Returns
+        -------
+        ymax
+            The appropriate ymax.
+        """  # numpydoc ignore=ES01
         try:
             return np.abs(data).max()
         except RuntimeError:
@@ -625,47 +730,51 @@ def rescale_ylim(axes, data):
         ax.set_ylim((-y_max, y_max))
 
 
-def clean_stem_plot(data, ax=None, title="", ylim=None, xvals=None, **kwargs):
-    r"""convenience wrapper for plotting stem plots
+def clean_stem_plot(
+    data: np.ndarray,
+    ax: mpl.axes.Axes | None = None,
+    title: str | None = "",
+    ylim: tuple | None | False = None,
+    xvals: tuple[list[float], list[float]] | None = None,
+    **kwargs: Any,
+) -> mpl.axes.Axes:
+    r"""
+    Create a simple stem plot.
 
     This plots the data, baseline, cleans up the axis, and sets the
-    title
+    title.
 
-    Should not be called by users directly, but is a helper function for
-    the various plot_representation() functions
+    Helper function for the :func:`~plenoptic.tools.display.plot_representation()`.
 
-    By default, stem plot would have a baseline that covers the entire
-    range of the data. We want to be able to break that up visually (so
-    there's a line from 0 to 9, from 10 to 19, etc), and passing xvals
-    separately allows us to do that. If you want the default stem plot
-    behavior, leave xvals as None.
+    By default, stem plot would have a baseline that covers the entire range of the
+    data. We want to be able to break that up visually (so there's a line from 0 to 9,
+    from 10 to 19, etc), and passing ``xvals`` separately allows us to do that. If you
+    want the default stem plot behavior, leave ``xvals=None``.
 
     Parameters
     ----------
-    data : `np.ndarray`
-        The data to plot (as a stem plot)
-    ax : `matplotlib.pyplot.axis` or `None`, optional
-        The axis to plot the data on. If None, we plot on the current
-        axis
-    title : str or None, optional
-        The title to put on the axis if not None. If None, we don't call
-        ``ax.set_title`` (useful if you want to avoid changing the title
-        on an existing plot)
-    ylim : tuple or None, optional
-        If not None, the y-limits to use for this plot. If None, we use the
-        default, slightly adjusted so that the minimum is 0. If False, do not
-        change y-limits.
-    xvals : `tuple` or `None`, optional
+    data
+        The data to plot (as a stem plot).
+    ax
+        The axis to plot the data on. If ``None``, we plot on the current axis
+        (``plt.gca()``).
+    title
+        The title to put on the axis. If ``None``, we don't call ``ax.set_title``
+        (useful if you want to avoid changing the title on an existing plot).
+    ylim
+        The y-limits to use for this plot. If ``None``, we use the default, slightly
+        adjusted so that the minimum is 0. If ``False``, do not change y-limits.
+    xvals
         A 2-tuple of lists, containing the start (``xvals[0]``) and stop
-        (``xvals[1]``) x values for plotting. If None, we use the
+        (``xvals[1]``) x values for plotting. If ``None``, we use the
         default stem plot behavior.
-    kwargs :
-        passed to ax.stem
+    **kwargs
+        Passed to :func:`matplotlib.pyplot.stem`.
 
     Returns
     -------
-    ax : `matplotlib.pyplot.axis`
-        The axis with the plot
+    ax
+        The axis with the plot.
 
     Examples
     --------
@@ -704,7 +813,6 @@ def clean_stem_plot(data, ax=None, title="", ylim=None, xvals=None, **kwargs):
       y = np.abs(np.random.randn(55))
       po.tools.display.clean_stem_plot(y)
       plt.show()
-
     """
     if ax is None:
         ax = plt.gca()
@@ -721,27 +829,36 @@ def clean_stem_plot(data, ax=None, title="", ylim=None, xvals=None, **kwargs):
     return ax
 
 
-def _get_artists_from_axes(axes, data):
-    """Grab artists from axes.
+def _get_artists_from_axes(
+    axes: mpl.axes.Axes | list[mpl.axes.Axes],
+    data: torch.Tensor | dict,
+) -> dict:
+    """
+    Grab artists from axes.
 
     For now, we only grab containers (stem plots), images, or lines
 
-    See the docstring of :meth:`update_plot()` for details on how `axes` and
-    `data` should be structured
+    See the docstring of :meth:`~plenoptic.tools.display.update_plot()` for details on
+    how ``axes`` and ``data`` should be structured.
 
     Parameters
     ----------
-    axes : list or matplotlib.axes.Axes
+    axes
         The axis/axes to update.
-    data : torch.Tensor or dict
+    data
         The new data to plot.
 
     Returns
     -------
-    artists : dict
-        dictionary of artists for updating plots. values are the artists to
-        use, keys are the corresponding keys for data
+    artists
+        Dictionary of artists for updating plots. Values are the artists to
+        use, keys are the corresponding keys from data.
 
+    Raises
+    ------
+    ValueError
+        If the number of artists in ``axes`` is different from the size of the
+        dimension-to-plot of ``data``.
     """
     if not hasattr(axes, "__iter__"):
         # then we only have one axis, so we may be able to update more than one
@@ -822,68 +939,79 @@ def _get_artists_from_axes(axes, data):
     return artists
 
 
-def update_plot(axes, data, model=None, batch_idx=0):
-    r"""Update the information in some axes.
+def update_plot(
+    axes: mpl.axes.Axes | list[mpl.axes.Axes],
+    data: torch.Tensor | dict,
+    model: torch.nn.Module | None = None,
+    batch_idx: int = 0,
+) -> list:
+    r"""
+    Update the information in some axes.
 
-    This is used for creating an animation over time. In order to create
-    the animation, we need to know how to update the matplotlib Artists,
-    and this provides a simple way of doing that. It assumes the plot
-    has been created by something like ``plot_representation``, which
-    initializes all the artists.
+    This is used for creating an animation over time. In order to create the animation,
+    we need to know how to update the matplotlib Artists, and this provides a simple way
+    of doing that. It assumes the plot has been created by something like
+    :func:`~plenoptic.tools.display.plot_representation`, which initializes all the
+    artists.
 
-    We can update stem plots, lines (as returned by ``plt.plot``), scatter
-    plots, or images (RGB, RGBA, or grayscale).
+    We can update stem plots, lines (as returned by :func:`matplotlib.pyplot.plot`),
+    scatter plots, or images (RGB, RGBA, or grayscale).
 
     There are two modes for this:
 
-    - single axis: axes is a single axis, which may contain multiple artists
-      (all of the same type) to update. data should be a Tensor with multiple
-      channels (one per artist in the same order) or be a dictionary whose keys
-      give the label(s) of the corresponding artist(s) and whose values are
-      Tensors.
+    - Single axis: ``axes`` is a single axis, which may contain multiple artists (all of
+      the same type) to update. ``data`` should be a :class:`torch.Tensor` with multiple
+      channels (one per artist in the same order) or be a dictionary whose keys give the
+      label(s) of the corresponding artist(s) and whose values are
+      :class:`torch.Tensor`.
 
-    - multiple axes: axes is a list of axes, each of which contains a single
-      artist to update (artists can be different types). data should be a
-      Tensor with multiple channels (one per axis in the same order) or a
-      dictionary with the same number of keys as axes, which we can iterate
-      through in order, and whose values are Tensors.
+    - Multiple axes: ``axes`` is a list of axes, each of which contains a single artist
+      to update (artists can be different types). ``data`` should be a
+      :class:`torch.Tensor` with multiple channels (one per axis in the same order) or a
+      dictionary with the same number of keys as ``axes``, which we can iterate through
+      in order, and whose values are :class:`torch.Tensor`.
 
-    In all cases, data Tensors should be 3d (if the plot we're updating is a
+    In all cases, ``data`` Tensors should be 3d (if the plot we're updating is a
     line or stem plot) or 4d (if it's an image or scatter plot).
 
     RGB(A) images are special, since we store that info along the channel
     dimension, so they only work with single-axis mode (which will only have a
     single artist, because that's how imshow works).
 
-    If you have multiple axes, each with multiple artists you want to update,
-    that's too complicated for us, and so you should write a
-    ``model.update_plot()`` function which handles that.
+    If you have multiple axes, each with multiple artists you want to update, that's too
+    complicated for us, and so you should write a ``model.update_plot()`` function which
+    handles that (see
+    :func:`plenoptic.simulate.models.portilla_simoncelli.PortillaSimoncelli.update_plot`
+    for an example).
 
-    If ``model`` is set, we try to call ``model.update_plot()`` (which
-    must also return artists). If model doesn't have an ``update_plot``
-    method, then we try to figure out how to update the axes ourselves,
-    based on the shape of the data.
+    If ``model`` is set, we try to call ``model.update_plot()`` (which must also return
+    artists). If ``model`` doesn't have an ``update_plot`` method, then we try to figure
+    out how to update the axes ourselves, based on the shape of the data.
 
     Parameters
     ----------
-    axes : `list` or `matplotlib.pyplot.axis`
-        The axis or list of axes to update. We assume that these are the axes
-        created by ``plot_representation`` and so contain stem plots in the
-        correct order.
-    data : `torch.Tensor` or `dict`
+    axes
+        The axis or list of axes to update. We assume that these are the axes created by
+        :func:`~plenoptic.tools.display.plot_representation` and so contain artists
+        in the correct order.
+    data
         The new data to plot.
-    model : `torch.nn.Module` or `None`, optional
-        A differentiable model that tells us how to plot ``data``. See
-        above for behavior if ``None``.
-    batch_idx : int, optional
-        Which index to take from the batch dimension
+    model
+        A differentiable model that tells us how to plot ``data``. See above for
+        behavior if ``None``.
+    batch_idx
+        Which index to take from the batch dimension.
 
     Returns
     -------
-    artists : `list`
+    artists
         A list of the artists used to update the information on the
-        plots
+        plots.
 
+    Raises
+    ------
+    ValueError
+        If ``data`` (or its values, if it's a ``dict``) are not 3 or 4 dimensional.
     """
     if isinstance(data, dict):
         for v in data.values():
@@ -969,29 +1097,31 @@ def update_plot(axes, data, model=None, batch_idx=0):
 
 
 def plot_representation(
-    model=None,
-    data=None,
-    ax=None,
-    figsize=None,
-    ylim=False,
-    batch_idx=0,
-    title="",
-    as_rgb=False,
-):
-    r"""Helper function for plotting model representation
+    model: torch.nn.Module | None = None,
+    data: np.ndarray | dict | None = None,
+    ax: mpl.axes.Axes | None = None,
+    figsize: tuple[float, float] | None = None,
+    ylim: tuple[float, float] | None | False = False,
+    batch_idx: int = 0,
+    title: str = "",
+    as_rgb: bool = False,
+) -> list[mpl.axes.Axes]:
+    r"""
+    Plot model representation.
 
-    We are trying to plot ``data`` on ``ax``, using
-    ``model.plot_representation`` method, if it has it, and otherwise
-    default to a function that makes sense based on the shape of ``data``.
+    We try to plot ``data`` on ``ax``, using the ``model.plot_representation`` method,
+    if it has it, and otherwise default to a function that makes sense based on the
+    shape of ``data``.
 
     All of these arguments are optional, but at least some of them need
     to be set:
 
-    - If ``model`` is ``None``, we fall-back to a type of plot based on the
-      shape of ``data``. If it looks image-like, we'll use ``plenoptic.imshow``
-      and if it looks vector-like, we'll use ``plenoptic.clean_stem_plot``. If
-      it's a dictionary, we'll assume each key, value pair gives the title and
-      data to plot on a separate sub-plot.
+    - If ``model`` is ``None``, we fall-back to a type of plot based on the shape of
+      ``data``. If it looks image-like, we'll use
+      :func:`~plenoptic.tools.display.imshow` and if it looks vector-like, we'll use
+      :func:`~plenoptic.tools.display.clean_stem_plot`. If it's a dictionary, we'll
+      assume each key, value pair gives the title and data to plot on a separate
+      sub-plot.
 
     - If ``data`` is ``None``, we can only do something if
       ``model.plot_representation`` has some default behavior when
@@ -1002,43 +1132,48 @@ def plot_representation(
     - If ``ax`` is ``None``, we create a one-subplot figure using ``figsize``.
       If ``ax`` is not ``None``, we therefore ignore ``figsize``.
 
-    - If ``ylim`` is ``None``, we call ``rescale_ylim``, which sets the axes'
-      y-limits to be ``(-y_max, y_max)``, where ``y_max=np.abs(data).max()``.
-      If it's ``False``, we do nothing.
+    - If ``ylim`` is ``None``, we call :func:`~plenoptic.tools.display.rescale_ylim`,
+      which sets the axes' y-limits to be ``(-y_max, y_max)``, where
+      ``y_max=np.abs(data).max()``. If it's ``False``, we do nothing.
 
     Parameters
     ----------
-    model : `torch.nn.Module` or None, optional
+    model
         A differentiable model that tells us how to plot ``data``. See
         above for behavior if ``None``.
-    data : `array_like`, `dict`, or `None`, optional
+    data
         The data to plot. See above for behavior if ``None``.
-    ax : matplotlib.pyplot.axis or None, optional
+    ax
         The axis to plot on. See above for behavior if ``None``.
-    figsize : `tuple`, optional
+    figsize
         The size of the figure to create. Must be ``None`` if ax is not ``None``. If
-        both figsize and ax are ``None``, then we set ``figsize=(5, 5)``
-    ylim : `tuple`, `None`, or `False`, optional
-        If not None, the y-limits to use for this plot. See above for
-        behavior if ``None``. If False, we do nothing.
-    batch_idx : `int`, optional
-        Which index to take from the batch dimension
-    title : `str`, optional
+        both figsize and ax are ``None``, then we use ``figsize=(5, 5)``.
+    ylim
+        The y-limits to use for this plot. See above for behavior if ``None``.
+        If ``False``, we do nothing. Ignored if ``data`` looks image-like.
+    batch_idx
+        Which index to take from the batch dimension.
+    title
         The title to put above this axis. If you want no title, pass
-        the empty string (``''``)
-    as_rgb : bool, optional
-        The representation can be image-like with multiple channels, and we
-        have no way to determine whether it should be represented as an RGB
-        image or not, so the user must set this flag to tell us. It will be
+        the empty string (``""``).
+    as_rgb
+        Whether to consider the channels as encoding RGB(A) values. It will be
         ignored if the representation doesn't look image-like or if the
         model has its own plot_representation_error() method. Else, it will
-        be passed to `po.imshow()`, see that methods docstring for details.
+        be passed to :func:`~plenoptic.tools.display.imshow`, see that method's
+        docstring for details.
 
     Returns
     -------
-    axes : list
+    axes
         List of created axes.
 
+    Raises
+    ------
+    ValueError
+        If both ``figsize`` and ``ax`` are not ``None``.
+    ValueError
+        If ``data`` (or its values, if it's a ``dict``) are not 3 or 4 dimensional.
     """
     if ax is None:
         if figsize is None:

--- a/src/plenoptic/tools/io.py
+++ b/src/plenoptic/tools/io.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+"""Helper functions for saving/loading."""  # numpydoc ignore=ES01
 
 import importlib
 
@@ -6,21 +6,22 @@ import torch
 
 
 def examine_saved_synthesis(file_path: str, map_location: str | None = None):
-    """Examine saved synthesis object.
+    """
+    Examine saved synthesis object.
 
     This is used for debugging, it will print out information about the versions used,
     names of the callable attributes, shapes of tensor attributes, etc.
 
     Parameters
     ----------
-    file_path :
-        The path to load the synthesis object from
-    map_location :
-        map_location argument to pass to ``torch.load``. If you save
-        stuff that was being run on a GPU and are loading onto a
+    file_path
+        The path to load the synthesis object from.
+    map_location
+        Argument to pass to :func:`torch.load` as ``map_location``. If you
+        save stuff that was being run on a GPU and are loading onto a
         CPU, you'll need this to make sure everything lines up
         properly. This should be structured like the str you would
-        pass to ``torch.device``
+        pass to :class:`torch.device`.
     """
     load_dict = torch.load(file_path, map_location=map_location, weights_only=True)
     metadata = load_dict.pop("save_metadata")

--- a/src/plenoptic/tools/optim.py
+++ b/src/plenoptic/tools/optim.py
@@ -1,4 +1,7 @@
-"""Tools related to optimization such as more objective functions."""
+"""Tools related to optimization, such as objective functions."""
+# numpydoc ignore=ES01
+
+from typing import Any
 
 import numpy as np
 import torch
@@ -6,9 +9,10 @@ from torch import Tensor
 
 
 def set_seed(seed: int | None = None) -> None:
-    """Set the seed.
+    """
+    Set the seed.
 
-    We call both ``torch.manual_seed()`` and ``np.random.seed()``.
+    We call both :func:`torch.manual_seed()` and :func:`numpy.random.seed()`.
 
     Parameters
     ----------
@@ -21,8 +25,9 @@ def set_seed(seed: int | None = None) -> None:
         np.random.seed(seed)
 
 
-def mse(synth_rep: Tensor, ref_rep: Tensor, **kwargs) -> Tensor:
-    r"""return the MSE between synth_rep and ref_rep
+def mse(synth_rep: Tensor, ref_rep: Tensor, **kwargs: Any) -> Tensor:
+    r"""
+    Calculate the MSE between ``synth_rep`` and ``ref_rep``.
 
     For two tensors, :math:`x` and :math:`y`, with :math:`n` values
     each:
@@ -31,29 +36,7 @@ def mse(synth_rep: Tensor, ref_rep: Tensor, **kwargs) -> Tensor:
 
         MSE &= \frac{1}{n}\sum_i=1^n (x_i - y_i)^2
 
-    The two images must have a float dtype
-
-    Parameters
-    ----------
-    synth_rep
-        The first tensor to compare, model representation of the
-        synthesized image
-    ref_rep
-        The second tensor to compare, model representation of the
-        reference image. must be same size as ``synth_rep``,
-    kwargs
-        Ignored, only present to absorb extra arguments
-
-    Returns
-    -------
-    loss
-        The mean-squared error between ``synth_rep`` and ``ref_rep``
-    """
-    return torch.pow(synth_rep - ref_rep, 2).mean()
-
-
-def l2_norm(synth_rep: Tensor, ref_rep: Tensor, **kwargs) -> Tensor:
-    r"""l2-norm of the difference between ref_rep and synth_rep
+    The two images must have a float dtype.
 
     Parameters
     ----------
@@ -63,7 +46,37 @@ def l2_norm(synth_rep: Tensor, ref_rep: Tensor, **kwargs) -> Tensor:
     ref_rep
         The second tensor to compare, model representation of the
         reference image. must be same size as ``synth_rep``.
-    kwargs
+    **kwargs
+        Ignored, only present to absorb extra arguments.
+
+    Returns
+    -------
+    loss
+        The mean-squared error between ``synth_rep`` and ``ref_rep``.
+    """
+    return torch.pow(synth_rep - ref_rep, 2).mean()
+
+
+def l2_norm(synth_rep: Tensor, ref_rep: Tensor, **kwargs: Any) -> Tensor:
+    r"""
+    Calculate the L2-norm of the difference between ``ref_rep`` and ``synth_rep``.
+
+    For two tensors, :math:`x` and :math:`y`, with :math:`n` values
+    each:
+
+    .. math::
+
+        L2 &= \sqrt{\sum_i=1^n (x_i - y_i)^2}
+
+    Parameters
+    ----------
+    synth_rep
+        The first tensor to compare, model representation of the
+        synthesized image.
+    ref_rep
+        The second tensor to compare, model representation of the
+        reference image. must be same size as ``synth_rep``.
+    **kwargs
         Ignored, only present to absorb extra arguments.
 
     Returns
@@ -74,12 +87,22 @@ def l2_norm(synth_rep: Tensor, ref_rep: Tensor, **kwargs) -> Tensor:
     return torch.linalg.vector_norm(ref_rep - synth_rep, ord=2)
 
 
-def relative_MSE(synth_rep: Tensor, ref_rep: Tensor, **kwargs) -> Tensor:
-    r"""Squared l2-norm of the difference between reference representation
-    and synthesized representation relative to the squared l2-norm of the
-    reference representation:
+def relative_sse(synth_rep: Tensor, ref_rep: Tensor, **kwargs: Any) -> Tensor:
+    r"""
+    Calculate the relative sum of squared errors between two tensors.
 
-    $$\frac{||x - \hat{x}||_2^2}{||x||_2^2}$$
+    This is the squared L2-norm of the difference between reference representation and
+    synthesized representation relative to the squared L2-norm of the reference
+    representation:
+
+    For two tensors, :math:`x` and :math:`y`:
+
+    .. math::
+
+        \frac{||x - y||_2^2}{||x||_2^2}
+
+    where :math:`x` is ``ref_rep``, :math:`x` is ``synth_rep``, and :math:`||x||_2` is
+    the L2-norm.
 
     Parameters
     ----------
@@ -89,14 +112,14 @@ def relative_MSE(synth_rep: Tensor, ref_rep: Tensor, **kwargs) -> Tensor:
     ref_rep
         The second tensor to compare, model representation of the
         reference image. must be same size as ``synth_rep``.
-    kwargs
-        Ignored, only present to absorb extra arguments
+    **kwargs
+        Ignored, only present to absorb extra arguments.
 
     Returns
     -------
     loss
         Ratio of the squared l2-norm of the difference between ``ref_rep`` and
-        ``synth_rep`` to the squared l2-norm of ``ref_rep``
+        ``synth_rep`` to the squared l2-norm of ``ref_rep``.
     """
     return (
         torch.linalg.vector_norm(ref_rep - synth_rep, ord=2) ** 2
@@ -107,28 +130,29 @@ def relative_MSE(synth_rep: Tensor, ref_rep: Tensor, **kwargs) -> Tensor:
 def penalize_range(
     synth_img: Tensor,
     allowed_range: tuple[float, float] = (0.0, 1.0),
-    **kwargs,
+    **kwargs: Any,
 ) -> Tensor:
-    r"""penalize values outside of allowed_range
+    r"""
+    Penalize values outside of allowed_range.
 
     instead of clamping values to exactly fall in a range, this provides
     a 'softer' way of doing it, by imposing a quadratic penalty on any
     values outside the allowed_range. All values within the
-    allowed_range have a penalty of 0
+    allowed_range have a penalty of 0.
 
     Parameters
     ----------
     synth_img
         The tensor to penalize. the synthesized image.
     allowed_range
-        2-tuple of values giving the (min, max) allowed values
-    kwargs
-        Ignored, only present to absorb extra arguments
+        2-tuple of values giving the (min, max) allowed values.
+    **kwargs
+        Ignored, only present to absorb extra arguments.
 
     Returns
     -------
     penalty
-        Penalty for values outside range
+        Penalty for values outside range.
     """
     # Using clip like this is equivalent to using boolean indexing (e.g.,
     # synth_img[synth_img < allowed_range[0]]) but much faster

--- a/src/plenoptic/tools/optim.py
+++ b/src/plenoptic/tools/optim.py
@@ -133,7 +133,7 @@ def penalize_range(
     **kwargs: Any,
 ) -> Tensor:
     r"""
-    Penalize values outside of allowed_range.
+    Calculate quadratic penalty on values outside of ``allowed_range``.
 
     Instead of clamping values to exactly fall in a range, this provides
     a 'softer' way of doing it, by imposing a quadratic penalty on any

--- a/src/plenoptic/tools/optim.py
+++ b/src/plenoptic/tools/optim.py
@@ -34,7 +34,7 @@ def mse(synth_rep: Tensor, ref_rep: Tensor, **kwargs: Any) -> Tensor:
 
     .. math::
 
-        MSE &= \frac{1}{n}\sum_i=1^n (x_i - y_i)^2
+        MSE = \frac{1}{n}\sum_{i=1}^n (x_i - y_i)^2
 
     The two images must have a float dtype.
 
@@ -66,7 +66,7 @@ def l2_norm(synth_rep: Tensor, ref_rep: Tensor, **kwargs: Any) -> Tensor:
 
     .. math::
 
-        L2 &= \sqrt{\sum_i=1^n (x_i - y_i)^2}
+        L2 = \sqrt{\sum_{i=1}^n (x_i - y_i)^2}
 
     Parameters
     ----------
@@ -135,7 +135,7 @@ def penalize_range(
     r"""
     Penalize values outside of allowed_range.
 
-    instead of clamping values to exactly fall in a range, this provides
+    Instead of clamping values to exactly fall in a range, this provides
     a 'softer' way of doing it, by imposing a quadratic penalty on any
     values outside the allowed_range. All values within the
     allowed_range have a penalty of 0.

--- a/src/plenoptic/tools/signal.py
+++ b/src/plenoptic/tools/signal.py
@@ -424,7 +424,7 @@ def autocorrelation(x: Tensor) -> Tensor:
       FT(x(t)) and FT(x(-t)). In other words, the auto-correlation is
       convolution of the signal ``x`` with itself, which corresponds to squaring
       in the frequency domain. This approach is computationally more efficient
-      than brute force (n log(n) vs n^2).
+      than brute force ($n log(n)$ vs $n^2$).
 
     - By Cauchy-Swartz, the autocorrelation attains it is maximum at the center
       location (ie. no shift) - that maximum value is the signal's variance

--- a/src/plenoptic/tools/signal.py
+++ b/src/plenoptic/tools/signal.py
@@ -424,7 +424,7 @@ def autocorrelation(x: Tensor) -> Tensor:
       FT(x(t)) and FT(x(-t)). In other words, the auto-correlation is
       convolution of the signal ``x`` with itself, which corresponds to squaring
       in the frequency domain. This approach is computationally more efficient
-      than brute force ($n log(n)$ vs $n^2$).
+      than brute force (:math:`n log(n)` vs :math:`n^2`).
 
     - By Cauchy-Swartz, the autocorrelation attains it is maximum at the center
       location (ie. no shift) - that maximum value is the signal's variance

--- a/src/plenoptic/tools/signal.py
+++ b/src/plenoptic/tools/signal.py
@@ -193,9 +193,9 @@ def steer(
     steermtx
         Matrix which maps the filters onto Fourier series components (ordered
         ``[cos0, cos1, sin1, cos2, sin2, ..., sinN]``). See
-        ``pyrtools.steer_to_harmonics_mtx`` function for more details. If
-        ``None``, assumes cosine phase harmonic components, and filter positions
-        at ``2pi*n/N``.
+        :func:`pyrtools.pyramids.steer.steer_to_harmonics_mtx` function for more
+        details. If ``None``, assumes cosine phase harmonic components, and
+        filter positions at ``2pi*n/N``.
     even_phase
         Specifies whether the harmonics are cosine or sine phase aligned about
         those positions.

--- a/src/plenoptic/tools/signal.py
+++ b/src/plenoptic/tools/signal.py
@@ -293,7 +293,7 @@ def make_disk(
     Returns
     -------
     mask
-        Tensor mask with torch.Size(img_size).
+        Tensor mask with ``torch.Size(img_size)``.
     """
     if isinstance(img_size, int):
         img_size = (img_size, img_size)

--- a/src/plenoptic/tools/stats.py
+++ b/src/plenoptic/tools/stats.py
@@ -1,3 +1,6 @@
+"""Functions for computing image statistics on multi-dimensional tensors."""
+
+# numpydoc ignore=ES01
 import torch
 from torch import Tensor
 
@@ -8,27 +11,27 @@ def variance(
     dim: int | list[int] | None = None,
     keepdim: bool = False,
 ) -> Tensor:
-    r"""Calculate sample variance.
+    r"""
+    Calculate sample variance.
 
     Note that this is the uncorrected, or sample, variance, corresponding to
-    ``torch.var(*, correction=0)``
+    ``torch.var(*, correction=0)``.
 
     Parameters
     ----------
     x
-        The input tensor
+        The input tensor.
     mean
-        Reuse a precomputed mean
+        Reuse a precomputed mean.
     dim
         The dimension or dimensions to reduce.
     keepdim
-        Whether the output tensor has dim retained or not.
+        Whether to retain the reduced dimensions (as singletons) or not.
 
     Returns
     -------
     out
         The variance tensor.
-
     """
     if dim is None:
         dim = tuple(range(x.ndim))
@@ -44,20 +47,31 @@ def skew(
     dim: int | list[int] | None = None,
     keepdim: bool = False,
 ) -> Tensor:
-    r"""Sample estimate of `x` *asymmetry* about its mean
+    r"""
+    Calculate sample estimate of *asymmetry* about input's mean.
+
+    To help with interpretation:
+
+    - Skew of normal distribution is 0.
+
+    - Negative skew, also known as left-skewed: the left tail is longer. Distribution
+      appears as a right-leaning curve.
+
+    - Positive skew, also known as right-skewed: the right tail is longer. Distribution
+      appears as a left-leaning curve.
 
     Parameters
     ----------
     x
-        The input tensor
+        The input tensor.
     mean
-        Reuse a precomputed mean
+        Reuse a precomputed mean.
     var
-        Reuse a precomputed variance
+        Reuse a precomputed variance.
     dim
         The dimension or dimensions to reduce.
     keepdim
-        Whether the output tensor has dim retained or not.
+        Whether to retain the reduced dimensions (as singletons) or not.
 
     Returns
     -------
@@ -80,13 +94,16 @@ def kurtosis(
     dim: int | list[int] | None = None,
     keepdim: bool = False,
 ) -> Tensor:
-    r"""sample estimate of `x` *tailedness* (presence of outliers)
+    r"""
+    Calculate sample estimate of *tailedness* (presence of outliers).
 
-    kurtosis of univariate noral is 3.
+    To help with interpretation:
 
-    smaller than 3: *platykurtic* (eg. uniform distribution)
+    - Kurtosis of univariate normal is 3.
 
-    greater than 3: *leptokurtic* (eg. Laplace distribution)
+    - Smaller than 3: *platykurtic* (e.g. uniform distribution).
+
+    - Greater than 3: *leptokurtic* (e.g. Laplace distribution).
 
     Parameters
     ----------
@@ -99,7 +116,7 @@ def kurtosis(
     dim
         The dimension or dimensions to reduce.
     keepdim
-        Whether the output tensor has dim retained or not.
+        Whether to retain the reduced dimensions (as singletons) or not.
 
     Returns
     -------

--- a/src/plenoptic/tools/validate.py
+++ b/src/plenoptic/tools/validate.py
@@ -30,7 +30,7 @@ def validate_input(
       ``input_tensor.ndimension()==1`` (``ValueError``).
 
     - If ``allowed_range`` is not None, check whether all values of
-     ``input_tensor`` lie within the specified range (``ValueError``).
+      ``input_tensor`` lie within the specified range (``ValueError``).
 
     Additionally, if input_tensor is not 4d, raises a ``UserWarning``.
 

--- a/src/plenoptic/tools/validate.py
+++ b/src/plenoptic/tools/validate.py
@@ -147,8 +147,8 @@ def validate_model(
     Finally, we raise a ``UserWarning``:
 
     - If ``model`` is in training mode. Note that this is different from having
-      learnable parameters, see ``pytorch docs
-      <https://pytorch.org/docs/stable/notes/autograd.html#locally-disable-grad-doc>``_.
+      learnable parameters, see `pytorch docs
+      <https://pytorch.org/docs/stable/notes/autograd.html#locally-disable-grad-doc>`_.
 
     - If ``model`` returns an output with other than 3 or 4 dimensions when given a
       tensor with shape ``image_shape``.

--- a/tests/check_docstrings.py
+++ b/tests/check_docstrings.py
@@ -71,6 +71,7 @@ links = []
 backticks = []
 unescaped = []
 missing_xref = []
+dollarsigns = []
 
 for p in paths:
     with open(p) as f:
@@ -80,6 +81,8 @@ for p in paths:
     for name, doc in docstrings:
         if re.findall(LINK_REGEX, doc):
             links.append((p, name))
+        if re.findall(r"\$", doc):
+            dollarsigns.append((p, name))
         directives = re.findall(SPHINX_DIRECTIVE_REGEX, doc)
         sphinx_link = re.findall(SPHINX_LINK_REGEX, doc)
         backtick = [
@@ -112,7 +115,7 @@ for p in paths:
             if xr := re.findall(rf"``{lib}\.[a-z0-9_\.]+(?:\(\))?``", doc):
                 missing_xref.append((p, name, xr))
 
-if backticks or links or unescaped or missing_xref:
+if backticks or links or unescaped or missing_xref or dollarsigns:
     if backticks:
         print("The following docstrings appear to contain markdown:")
         for p, name, markup in backticks:
@@ -140,4 +143,11 @@ if backticks or links or unescaped or missing_xref:
         for p, name, markup in missing_xref:
             print(f"{p}:{name} {markup}")
         print("\n")
+    if dollarsigns:
+        print(
+            "The following docstrings appear to contain latex surrounded by dollar "
+            "signs; docstrings should be rst-formatted, use :math:`x` instead of $x$"
+        )
+        for p, name in dollarsigns:
+            print(f"{p}:{name}")
     sys.exit(1)

--- a/tests/check_docstrings.py
+++ b/tests/check_docstrings.py
@@ -7,10 +7,33 @@ import sys
 
 LINK_REGEX = re.escape("](")
 # we want basically everything except a backtick
-EVERYTHING_BUT_BACKTICK = r"[A-Za-z_\(\)<>:/ -.=\[\]0-9\\^~{}|'\"]"
-BACKTICK_REGEX = rf"(`+{EVERYTHING_BUT_BACKTICK}+?`+_?)"
+EVERYTHING_BUT_BACKTICK = r"[ A-Za-z_\(\)<>:/\-.=\[\]0-9\\^~{}|'\"]"
+BACKTICK_REGEX = rf"(`+{EVERYTHING_BUT_BACKTICK.replace(' ', '')}+?`+_?)"
 SPHINX_DIRECTIVE_REGEX = rf":[:a-z]+:(`+{EVERYTHING_BUT_BACKTICK}+?_?`+)"
 SPHINX_LINK_REGEX = rf"(`+{EVERYTHING_BUT_BACKTICK}+?`+_)"
+# None/True/False surrounded by single backtick is also wrong, but will be caught by the
+# markdown check.
+COMMON_VALS = (
+    rf"{EVERYTHING_BUT_BACKTICK}([Nn]one|[Tt]rue|[Ff]alse){EVERYTHING_BUT_BACKTICK}"
+)
+LIBRARIES_XREF = [
+    "plenoptic",
+    "po",
+    "torch",
+    "numpy",
+    "np",
+    "matplotlib",
+    "mpl",
+    "plt",
+    "pyrtools",
+    "pt",
+]
+# we want to grab the references to above libraries that should be xrefs. So we don't
+# want to match: proper xrefs (which will have a ~ or ` before the library name) or urls
+# (which will have . or / before the nmae)
+XREF_EXCEPT = EVERYTHING_BUT_BACKTICK.replace("~", "").replace(".", "").replace("/", "")
+# additionally, = and ( show up in code snippets
+XREF_EXCEPT = XREF_EXCEPT.replace("=", "").replace("(", "")
 
 
 def parse_docstring(docstring):
@@ -44,6 +67,8 @@ for p in sys.argv[1:]:
 
 links = []
 backticks = []
+unescaped = []
+missing_xref = []
 
 for p in paths:
     with open(p) as f:
@@ -62,15 +87,46 @@ for p in paths:
         ]
         if backtick:
             backticks.append((p, name, backtick))
+        # See Also and Examples (the last two sections, fortunately) can both contain
+        # un-xref'ed references to other libraries or None/False/True
+        doc = doc.split("See Also")[0].split("Examples")[0]
+        if unesc := re.findall(COMMON_VALS, doc):
+            unescaped.append((p, name, unesc))
+        for lib in LIBRARIES_XREF:
+            # use negative look-behind to avoid stuff in the attribute section
+            if xr := re.findall(rf"(?<![a-z]:){XREF_EXCEPT}{lib}\.", doc):
+                if lib == "torch":
+                    xr = [x for x in xr if x != "ytorch."]
+                if not xr:
+                    continue
+                missing_xref.append((p, name, xr))
 
-if backticks or links:
+if backticks or links or unescaped or missing_xref:
     if backticks:
         print("The following docstrings appear to contain markdown:")
         for p, name, markup in backticks:
             markup = ", ".join(markup)
             print(f"{p}:{name} {markup}")
+        print("\n")
     if links:
         print("The following docstrings appear to contain markdown links:")
         for p, name in links:
             print(f"{p}:{name}")
+        print("\n")
+    if unescaped:
+        print(
+            "The following docstrings appear to contain values that should be"
+            " surounded in backticks:"
+        )
+        for p, name, markup in unescaped:
+            print(f"{p}:{name} {markup}")
+        print("\n")
+    if missing_xref:
+        print(
+            "The following docstrings appear to contain references to other functions;"
+            "should use xref:"
+        )
+        for p, name, markup in missing_xref:
+            print(f"{p}:{name} {markup}")
+        print("\n")
     sys.exit(1)

--- a/tests/check_docstrings.py
+++ b/tests/check_docstrings.py
@@ -11,10 +11,12 @@ EVERYTHING_BUT_BACKTICK = r"[ A-Za-z_\(\)<>:/\-.=\[\]0-9\\^~{}|'\"]"
 BACKTICK_REGEX = rf"(`+{EVERYTHING_BUT_BACKTICK.replace(' ', '')}+?`+_?)"
 SPHINX_DIRECTIVE_REGEX = rf":[:a-z]+:(`+{EVERYTHING_BUT_BACKTICK}+?_?`+)"
 SPHINX_LINK_REGEX = rf"(`+{EVERYTHING_BUT_BACKTICK}+?`+_)"
+# underscores are part of variable names, so we don't want to match them
+EVERYTHING_BUT_BACKTICK_ = EVERYTHING_BUT_BACKTICK.replace("_", "")
 # None/True/False surrounded by single backtick is also wrong, but will be caught by the
 # markdown check.
 COMMON_VALS = (
-    rf"{EVERYTHING_BUT_BACKTICK}([Nn]one|[Tt]rue|[Ff]alse){EVERYTHING_BUT_BACKTICK}"
+    rf"{EVERYTHING_BUT_BACKTICK_}([Nn]one|[Tt]rue|[Ff]alse){EVERYTHING_BUT_BACKTICK_}"
 )
 LIBRARIES_XREF = [
     "plenoptic",

--- a/tests/check_docstrings.py
+++ b/tests/check_docstrings.py
@@ -97,10 +97,19 @@ for p in paths:
         for lib in LIBRARIES_XREF:
             # use negative look-behind to avoid stuff in the attribute section
             if xr := re.findall(rf"(?<![a-z]:){XREF_EXCEPT}{lib}\.", doc):
+                # the url for torch has `pytorch.` (not `torch.`), which we don't want
+                # to match
                 if lib == "torch":
                     xr = [x for x in xr if x != "ytorch."]
                 if not xr:
                     continue
+                missing_xref.append((p, name, xr))
+            # we also want to raise an error if we have two backticks before these
+            # libraries, which corresponds to monospace (but no link). We *don't* want
+            # to match if it looks like an actual call, so we either can have no
+            # parentheses or only parentheses with on args in them at the end of the
+            # backticks
+            if xr := re.findall(rf"``{lib}\.[a-z0-9_\.]+(?:\(\))?``", doc):
                 missing_xref.append((p, name, xr))
 
 if backticks or links or unescaped or missing_xref:

--- a/tests/check_docstrings.py
+++ b/tests/check_docstrings.py
@@ -7,7 +7,7 @@ import sys
 
 LINK_REGEX = re.escape("](")
 # we want basically everything except a backtick
-EVERYTHING_BUT_BACKTICK = r"[A-Za-z_\(\)<>:/ -.=\[\]0-9\\^~{}'\"]"
+EVERYTHING_BUT_BACKTICK = r"[A-Za-z_\(\)<>:/ -.=\[\]0-9\\^~{}|'\"]"
 BACKTICK_REGEX = rf"(`+{EVERYTHING_BUT_BACKTICK}+?`+_?)"
 SPHINX_DIRECTIVE_REGEX = rf":[:a-z]+:(`+{EVERYTHING_BUT_BACKTICK}+?_?`+)"
 SPHINX_LINK_REGEX = rf"(`+{EVERYTHING_BUT_BACKTICK}+?`+_)"

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -563,7 +563,7 @@ class TestDisplay:
         with pytest.raises(ValueError, match="3 or 4d"):
             po.synth.metamer.animate(met)
 
-    @pytest.mark.parametrize("zoom", [None, 0.5, 1, 3, 0, -1])
+    @pytest.mark.parametrize("zoom", [None, 0.5, 1, 3, 0, -1, 1.5, 1.1])
     @pytest.mark.parametrize("func", ["imshow", "animshow"])
     def test_zoom(self, zoom, func):
         fig, ax = plt.subplots(1, 1, figsize=(5, 5))
@@ -575,6 +575,10 @@ class TestDisplay:
             func = po.animshow
         if zoom is not None and zoom <= 0:
             expectation = pytest.raises(ValueError, match="zoom must be positive")
+        elif zoom is not None and int(zoom * 32) != zoom * 32:
+            expectation = pytest.raises(
+                Exception, match=r"zoom \* signal.shape must result in integers"
+            )
         else:
             expectation = does_not_raise()
         with expectation:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -366,7 +366,8 @@ class TestDisplay:
             expectation = pytest.raises(
                 ValueError,
                 match=(
-                    "Don't know how to plot images with more than one channel and batch"
+                    "Don't know how to plot non-rgb images with more than one"
+                    "channel and batch"
                 ),
             )
         else:
@@ -391,7 +392,7 @@ class TestDisplay:
         if isinstance(batch_idx, list) or isinstance(channel_idx, list):
             # neither of these are supported
             expectation = pytest.raises(
-                TypeError, match="must be an int or None but got"
+                TypeError, match=r".* must be an int or None but got"
             )
         with expectation:
             fig = po.imshow(
@@ -427,9 +428,7 @@ class TestDisplay:
         ).to(DEVICE)
         expectation = does_not_raise()
         if not isinstance(channel_idx, int) or not isinstance(batch_idx, int):
-            expectation = pytest.raises(
-                TypeError, match="must be an int or None but got"
-            )
+            expectation = pytest.raises(TypeError, match=r".* must be an int but got")
         n_axes = 4
         if steerpyr.is_complex:
             n_axes *= 2
@@ -492,7 +491,8 @@ class TestDisplay:
             expectation = pytest.raises(
                 ValueError,
                 match=(
-                    "Don't know how to plot images with more than one channel and batch"
+                    "Don't know how to plot non-rgb images with more than one"
+                    "channel and batch"
                 ),
             )
         else:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -563,6 +563,32 @@ class TestDisplay:
         with pytest.raises(ValueError, match="3 or 4d"):
             po.synth.metamer.animate(met)
 
+    @pytest.mark.parametrize("zoom", [None, 0.5, 1, 3, 0, -1])
+    @pytest.mark.parametrize("func", ["imshow", "animshow"])
+    def test_zoom(self, zoom, func):
+        fig, ax = plt.subplots(1, 1, figsize=(5, 5))
+        if func == "imshow":
+            x = torch.rand(1, 1, 32, 32)
+            func = po.imshow
+        elif func == "animshow":
+            x = torch.rand(1, 1, 10, 32, 32)
+            func = po.animshow
+        if zoom is not None and zoom <= 0:
+            expectation = pytest.raises(ValueError, match="zoom must be positive")
+        else:
+            expectation = does_not_raise()
+        with expectation:
+            func(x, ax=ax, zoom=zoom)
+            if zoom is None:
+                zoom = 12
+            zoom_title = float(ax.get_title().split("*")[1])
+            if zoom != zoom_title:
+                raise ValueError(
+                    f"Zoom didn't work as expected, expected {zoom} but"
+                    f" got {zoom_title}!"
+                )
+            plt.close(fig)
+
 
 def template_test_synthesis_all_plot(
     synthesis_object,

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -366,7 +366,7 @@ class TestDisplay:
             expectation = pytest.raises(
                 ValueError,
                 match=(
-                    "Don't know how to plot non-rgb images with more than one"
+                    "Don't know how to plot non-rgb images with more than one "
                     "channel and batch"
                 ),
             )
@@ -491,7 +491,7 @@ class TestDisplay:
             expectation = pytest.raises(
                 ValueError,
                 match=(
-                    "Don't know how to plot non-rgb images with more than one"
+                    "Don't know how to plot non-rgb images with more than one "
                     "channel and batch"
                 ),
             )

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -67,7 +67,7 @@ class TestMetamers:
                     match=("Saved and initialized model output have different values"),
                 )
             elif fail == "loss":
-                loss = po.tools.optim.relative_MSE
+                loss = po.tools.optim.relative_sse
                 expectation = pytest.raises(
                     ValueError,
                     match=(

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -86,7 +86,7 @@ def check_parseval(im, coeff, rtol=1e-4, atol=0):
     function that checks if the pyramid is parseval, i.e. energy of coeffs is
     the same as the energy in the original image.
     Args:
-    input image: image stimulus as torch.Tensor
+    input image: image stimulus as ``torch.Tensor``
     coeff: dictionary of torch tensors corresponding to each band
     """
     total_band_energy = 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,9 @@ from plenoptic.data.fetch import fetch_data
 from test_models import TestPortillaSimoncelli
 
 
-def update_ps_synthesis_test_file(torch_version: str | None = None):
+def update_ps_synthesis_test_file(
+    torch_version: str | None = None,
+) -> po.synthesize.metamer.Metamer:
     """Create new test file for test_models.test_ps_synthesis().
 
     We cannot guarantee perfect reproducibility across pytorch versions, but we
@@ -34,7 +36,7 @@ def update_ps_synthesis_test_file(torch_version: str | None = None):
 
     Returns
     -------
-    met : po.synth.Metamer
+    met
         Metamer object for inspection
 
     """


### PR DESCRIPTION
This PR continues the work started in #349: now all docstrings should pass validation.

This also:
- adds proper cross-references to pyrtools
- corrects the steer pyr docstring (#351 wasn't right, the parity of the filter depends on the order of the pyramid)
- adds some more validation to check for missed cross-references or None/False/True that should be wrapped in double backticks
- `animshow` now supports `zoom=None`, just like `imshow`.
- adds tests for `animshow` / `imshow` `zoom` arg.