### PR TITLE
More linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,9 +58,17 @@ repos:
       types_or: ["markdown"]
       entry: python linting/check_tutorials.py
     - id: check-docs-markdown
-      language: system
+      language: python
       # only run on docs/ folder
       name: Check for issues with markdown files in docs
       types_or: ["markdown"]
-      entry: python linting/check_markdown.py
+      entry: linting/check_markdown.py
       files: ^docs/
+      additional_dependencies: ["sphobjinv"]
+    - id: ruff notebooks
+      language: python
+      name: Convert myst-nb markdown notebooks to ipynb and run ruff on them
+      types_or: ["markdown"]
+      entry: linting/ruff_notebooks.py
+      files: ^docs/
+      additional_dependencies: ["ruff"]

--- a/docs/tutorials/advanced/Display.md
+++ b/docs/tutorials/advanced/Display.md
@@ -86,7 +86,7 @@ print(coeffs.shape)
 The first and last channels are residuals, so if we only wanted to look at the coefficients, we'd do the following:
 
 ```{code-cell} ipython3
-po.imshow(coeffs[:, 1:-1], batch_idx=0);
+po.imshow(coeffs[:, 1:-1], batch_idx=0)
 po.imshow(coeffs[:, 1:-1], batch_idx=1);
 ```
 

--- a/docs/tutorials/advanced/Synthesis_extensions.md
+++ b/docs/tutorials/advanced/Synthesis_extensions.md
@@ -10,8 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
 ```{code-cell} ipython3
 :tags: [hide-input]
+
 import warnings
 
 warnings.filterwarnings(
@@ -89,12 +91,18 @@ image = po.data.einstein()
 curie = po.data.curie()
 
 new_mad = MADCompetitionVariant(
-    image, po.metric.mse, lambda *args: 1 - po.metric.ssim(*args), "min",
+    image,
+    po.metric.mse,
+    lambda *args: 1 - po.metric.ssim(*args),
+    "min",
     metric_tradeoff_lambda=0.1,
 )
 new_mad.setup(curie)
 old_mad = po.synth.MADCompetition(
-    image, po.metric.mse, lambda *args: 1 - po.metric.ssim(*args), "min",
+    image,
+    po.metric.mse,
+    lambda *args: 1 - po.metric.ssim(*args),
+    "min",
     metric_tradeoff_lambda=0.1,
 )
 old_mad.setup(0.1)

--- a/docs/tutorials/applications/Demo_Eigendistortion.md
+++ b/docs/tutorials/applications/Demo_Eigendistortion.md
@@ -118,7 +118,9 @@ eigendist_f.synthesize(k=3, method="power", max_iter=max_iter_frontend)
 Once synthesized, we can plot the distortion on the image using {func}`display_eigendistortion_all <plenoptic.synthesize.eigendistortion.display_eigendistortion_all>`. Feel free to adjust the constant `alpha` that scales the amount of each distortion on the image.
 
 ```{code-cell} ipython3
-po.synth.eigendistortion.display_eigendistortion_all(eigendist_f, [0, -1], alpha=3, suptitle="OnOff", zoom=zoom);
+po.synth.eigendistortion.display_eigendistortion_all(
+    eigendist_f, [0, -1], alpha=3, suptitle="OnOff", zoom=zoom
+);
 ```
 
 ### VGG16: eigendistortion synthesis
@@ -176,9 +178,18 @@ Since the distortions here were synthesized using a pre-processed (normalized) i
 # create an image processing function to unnormalize the image and avg the channels to
 # grayscale
 def unnormalize(x):
-    return (x * orig_std.to(x.device) + orig_mean.to(x.device))
+    return x * orig_std.to(x.device) + orig_mean.to(x.device)
 
-po.synth.eigendistortion.display_eigendistortion_all(eigendist_v, [0, -1], alpha=[15, 100], suptitle="VGG16", zoom=zoom, as_rgb=True, process_image=unnormalize);
+
+po.synth.eigendistortion.display_eigendistortion_all(
+    eigendist_v,
+    [0, -1],
+    alpha=[15, 100],
+    suptitle="VGG16",
+    zoom=zoom,
+    as_rgb=True,
+    process_image=unnormalize,
+);
 ```
 
 ## Final thoughts

--- a/docs/tutorials/applications/Original_MAD.md
+++ b/docs/tutorials/applications/Original_MAD.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.2
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: plenoptic
   language: python
@@ -13,6 +13,7 @@ kernelspec:
 
 ```{code-cell} ipython3
 :tags: [hide-input]
+
 import warnings
 
 warnings.filterwarnings(
@@ -21,6 +22,7 @@ warnings.filterwarnings(
     category=RuntimeWarning,
 )
 ```
+
 :::{admonition} Under development
 :class: warning
 This currently contains examples of the earlier MAD synthesis, but we have yet to reproduce it using `plenoptic`.
@@ -48,10 +50,12 @@ import plenoptic as po
 # Download some data we'll need for this notebook
 import contextlib
 import os
+
 from plenoptic.data.fetch import fetch_data
+
 # the contextlib.redirect_stderr here is so that we don't print out the progressbar.
 # If you would like to see it, remove this line.
-with contextlib.redirect_stderr(open(os.devnull, 'w')):
+with contextlib.redirect_stderr(open(os.devnull, "w")):
     fetch_data("MAD_results.tar.gz")
     fetch_data("ssim_images.tar.gz")
 ```

--- a/docs/tutorials/intro/Eigendistortions.md
+++ b/docs/tutorials/intro/Eigendistortions.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.2
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: plenoptic
   language: python
@@ -13,6 +13,7 @@ kernelspec:
 
 ```{code-cell} ipython3
 :tags: [hide-input]
+
 import warnings
 
 warnings.filterwarnings(
@@ -31,9 +32,7 @@ warnings.filterwarnings(
     "ignore",
     message="Clipping input data to the valid range",
 )
-
 ```
-
 
 :::{admonition} Download
 :class: important
@@ -65,12 +64,12 @@ See the [last section of this notebook](eigendistortion-math-details) for more m
 import matplotlib.pyplot as plt
 import torch
 from torch import nn
-# this notebook runs just about as fast with GPU and CPU
-DEVICE = torch.device("cpu")
-
 
 import plenoptic as po
 from plenoptic.synthesize.eigendistortion import Eigendistortion
+
+# this notebook runs just about as fast with GPU and CPU
+DEVICE = torch.device("cpu")
 
 # so that relative sizes of axes created by po.imshow and others look right
 plt.rcParams["figure.dpi"] = 72
@@ -146,12 +145,9 @@ fig.tight_layout()
 
 To compute the eigendistortions of this model, we can instantiate an {class}`Eigendistortion <plenoptic.synthesize.eigendistortion.Eigendistortion>` object with an input tensor and a valid PyTorch model with a `forward` <!-- skip-lint --> method. After that, we simply call the method {func}`synthesize <plenoptic.synthesize.eigendistortion.Eigendistortion.synthesize>`, choosing the appropriate synthesis method. Normally our input has thousands of entries, but our input in this case is small (only n=25 entries), so we can compute the full $m \times n$ Jacobian, and all the eigenvectors of the $n \times n$ Fisher matrix, $F=J^TJ$. The {func}`synthesize <plenoptic.synthesize.eigendistortion.Eigendistortion.synthesize>` method does this for us and stores the outputs (`eigendistortions, eigenvalues, eigenindex`) of the synthesis.
 
-
 ```{code-cell} ipython3
 # instantiate Eigendistortion object using an input and model
-eig_jac = Eigendistortion(
-    x0, mdl_linear
-)
+eig_jac = Eigendistortion(x0, mdl_linear)
 # compute the entire Jacobian exactly
 eig_jac.synthesize(method="exact")
 ```
@@ -201,11 +197,11 @@ eig_pow.synthesize(method="power", max_iter=1000)
 eigdist_pow = eig_pow.eigendistortions
 
 print(f"Indices of computed eigenvectors: {eig_pow.eigenindex}\n")
-
 ```
 
 Now let's compare the eigendistortions we got from these two methods:
-```{code-cell}
+
+```{code-cell} ipython3
 eigdist_jac = eig_jac.eigendistortions
 fig, ax = plt.subplots(1, 1)
 ax.plot(eig_pow.eigenindex, eig_pow.eigenvalues, ".", markersize=15, label="Power")
@@ -256,9 +252,7 @@ Different inputs should in general have different sets of eigendistortions -- a 
 x1 = torch.randn_like(x0)
 
 eig_jac2 = Eigendistortion(x1, model=mdl_linear)
-eig_jac2.synthesize(
-    method="exact"
-)
+eig_jac2.synthesize(method="exact")
 
 # since the model is linear, the Jacobian should be the exact same as before
 print(
@@ -300,6 +294,7 @@ class TorchVision(torch.nn.Module):
     def forward(self, x):
         return self.extractor(x)[self.return_node]
 
+
 # different potential models of human visual perception of distortions
 resnet = models.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1, progress=False)
 resnet = resnet.to(DEVICE)
@@ -334,13 +329,17 @@ Let's display the eigendistortions.
 `plenoptic` includes a {func}`display_eigendistortion_all <plenoptic.synthesize.eigendistortion.display_eigendistortion_all>` function to visualize multiple eigendistortiosn together. Here, we show the original image on the bottom left, with the synthesized maximal eigendistortion in the top middle, and some constant $\alpha$ times the eigendistortion added to the image in the bottom middle. The rightmost column has a similar layout, but displays the minimal eigendistortion. Let's display the eigendistortions for the maxpool layer (pretty early in the model):
 
 ```{code-cell} ipython3
-po.synth.eigendistortion.display_eigendistortion_all(ed_resneta, [0, -1], as_rgb=True, suptitle="ResNet18 Maxpool Layer", zoom=2)
+po.synth.eigendistortion.display_eigendistortion_all(
+    ed_resneta, [0, -1], as_rgb=True, suptitle="ResNet18 Maxpool Layer", zoom=2
+)
 ```
 
 And the eigendistortions for layer 2 (about halfway through the model):
 
 ```{code-cell} ipython3
-po.synth.eigendistortion.display_eigendistortion_all(ed_resnetb, [0, -1], as_rgb=True, suptitle="ResNet18 Layer2", zoom=2);
+po.synth.eigendistortion.display_eigendistortion_all(
+    ed_resnetb, [0, -1], as_rgb=True, suptitle="ResNet18 Layer2", zoom=2
+);
 ```
 
 ### 2.5 - Which synthesized extremal eigendistortions better characterize human perception?
@@ -374,13 +373,17 @@ ed_resnetb.synthesize(method="power", max_iter=400)
 Unlike our [previous example](fisher-locally-adaptive), eigendistortions for either ResNet layer will differ depending upon the image they start with. We can see that below, where the Curie-based eigendistortions are different from the color wheel-based ones we examined earlier. First, the eigendistortions for the maxpool layer (pretty early in the model):
 
 ```{code-cell} ipython3
-po.synth.eigendistortion.display_eigendistortion_all(ed_resneta, [0, -1], as_rgb=True, suptitle="ResNet18 Maxpool Layer", zoom=2)
+po.synth.eigendistortion.display_eigendistortion_all(
+    ed_resneta, [0, -1], as_rgb=True, suptitle="ResNet18 Maxpool Layer", zoom=2
+)
 ```
 
 And the eigendistortions for layer 2 (about halfway through the model):
 
 ```{code-cell} ipython3
-po.synth.eigendistortion.display_eigendistortion_all(ed_resnetb, [0, -1], as_rgb=True, suptitle="ResNet18 Layer2", zoom=2);
+po.synth.eigendistortion.display_eigendistortion_all(
+    ed_resnetb, [0, -1], as_rgb=True, suptitle="ResNet18 Layer2", zoom=2
+);
 ```
 
 (eigendistortion-math-details)=

--- a/docs/tutorials/intro/MAD_Competition_1.md
+++ b/docs/tutorials/intro/MAD_Competition_1.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.2
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: plenoptic
   language: python
@@ -14,7 +14,7 @@ kernelspec:
 :::{admonition} Download
 :class: important
 
-Download this notebook: **{nb-download}`MAD_Simple.ipynb`**!
+Download this notebook: **{nb-download}`MAD_Competition_1.ipynb`**!
 
 :::
 
@@ -30,11 +30,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pyrtools as pt
 import torch
-# this notebook runs just about as fast with GPU and CPU
-DEVICE = torch.device("cpu")
 
 import plenoptic as po
 from plenoptic.tools import to_numpy
+
+# this notebook runs just about as fast with GPU and CPU
+DEVICE = torch.device("cpu")
 
 # so that relative sizes of axes created by po.imshow and others look right
 plt.rcParams["figure.dpi"] = 72
@@ -48,8 +49,10 @@ First we pick our metrics and run our synthesis. We create four different {class
 ```{code-cell} ipython3
 img = torch.as_tensor([0.5, 0.5], device=DEVICE, dtype=torch.float32)
 
+
 def l1_norm(x, y):
     return torch.linalg.vector_norm(x - y, ord=1)
+
 
 metrics = [po.tools.optim.l2_norm, l1_norm]
 all_mad = {}
@@ -194,6 +197,7 @@ def create_checkerboard(image_size, period, values=[0, 1]):
         .to(torch.float32)
     )
 
+
 # by setting the image to lie between 0 and 255 and be slightly within the max possible
 # range, we make the optimizatio a bit easier.
 img = 255 * create_checkerboard((64, 64), 16, [0.1, 0.9]).to(DEVICE)
@@ -206,6 +210,7 @@ Now we'll do the same process of running synthesis and checking our loss as abov
 ```{code-cell} ipython3
 def l1_norm(x, y):
     return torch.linalg.vector_norm(x - y, ord=1)
+
 
 metrics = [po.tools.optim.l2_norm, l1_norm]
 tradeoffs = {

--- a/docs/tutorials/intro/MAD_Competition_2.md
+++ b/docs/tutorials/intro/MAD_Competition_2.md
@@ -4,14 +4,16 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.2
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: plenoptic
   language: python
   name: python3
 ---
+
 ```{code-cell} ipython3
 :tags: [hide-input]
+
 import warnings
 
 warnings.filterwarnings(
@@ -24,7 +26,7 @@ warnings.filterwarnings(
 :::{admonition} Download
 :class: important
 
-Download this notebook: **{nb-download}`MAD_Competition.ipynb`**!
+Download this notebook: **{nb-download}`MAD_Competition_2.ipynb`**!
 
 :::
 
@@ -55,8 +57,9 @@ That's the general idea, now let's explore how to use the {class}`MADCompetition
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
-import plenoptic as po
 import torch
+
+import plenoptic as po
 
 # use GPU if available
 if torch.cuda.device_count() > 1:
@@ -87,6 +90,7 @@ on Image Processing](https://www.cns.nyu.edu/pub/lcv/wang03-preprint.pdf)) and m
 ```{code-cell} ipython3
 def model1(*args):
     return 1 - po.metric.ssim(*args, weighted=True, pad="reflect")
+
 
 model2 = po.metric.mse
 ```
@@ -156,7 +160,6 @@ mad_mse_min.setup(0.04)
 mad_mse_min.synthesize(max_iter=400, stop_criterion=1e-6)
 fig = po.synth.mad_competition.plot_synthesis_status(mad_mse_min)
 ```
-
 
 ```{code-cell} ipython3
 mad_mse_max = po.synth.MADCompetition(

--- a/docs/tutorials/intro/Metamer.md
+++ b/docs/tutorials/intro/Metamer.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.2
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: plenoptic
   language: python
@@ -13,6 +13,7 @@ kernelspec:
 
 ```{code-cell} ipython3
 :tags: [hide-input]
+
 import warnings
 
 warnings.filterwarnings(
@@ -45,10 +46,11 @@ import imageio
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-# this notebook runs just about as fast with GPU and CPU
-DEVICE = torch.device("cpu")
 
 import plenoptic as po
+
+# this notebook runs just about as fast with GPU and CPU
+DEVICE = torch.device("cpu")
 
 # so that relative sizes of axes created by po.imshow and others look right
 plt.rcParams["figure.dpi"] = 72

--- a/docs/tutorials/models/Portilla-Simoncelli.md
+++ b/docs/tutorials/models/Portilla-Simoncelli.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.2
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: plenoptic
   language: python
@@ -13,6 +13,7 @@ kernelspec:
 
 ```{code-cell} ipython3
 :tags: [hide-input]
+
 import warnings
 
 import pooch
@@ -137,7 +138,6 @@ display_images(im_files, "Articial textures")
 im_files = [DATA_PATH / f"fig{num}.jpg" for num in hand_drawn]
 display_images(im_files, "Hand-drawn / computer-generated textures")
 ```
-
 
 ## 2. How to generate Portilla-Simoncelli Metamers
 

--- a/docs/tutorials/models/Steerable_Pyramid.md
+++ b/docs/tutorials/models/Steerable_Pyramid.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.2
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: plenoptic
   language: python
@@ -20,15 +20,15 @@ Download this notebook: **{nb-download}`Steerable_Pyramid.ipynb`**!
 
 # Steerable Pyramid
 
-
 This tutorial walks through the basic features of the torch implementation of the Steerable Pyramid included in `plenoptic`, {class}`SteerablePyramidFreq <plenoptic.simulate.canonical_computations.steerable_pyramid_freq.SteerablePyramidFreq>`, and as such describes some basic signal processing that may be useful when building models that process images. We use the steerable pyramid construction in the frequency domain, which provides perfect reconstruction (as long as the input has an even height and width, i.e., `256x256` not `255x255`) and allows for any number of orientation bands. For more details on steerable pyramids and how they are built, see the [pyrtools tutorial](inv:pyrtools:std:doc#tutorials/03_steerable_pyramids).
 
 Here we will specifically focus on the specifics of the torch version and how it may be used in concert with other differentiable torch models.
 
 ```{code-cell} ipython3
-import matplotlib.pyplot as plt
-import os
 import contextlib
+import os
+
+import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -377,9 +377,10 @@ for i in range(len(pyr_coeffs_downsample.keys())):
 We are now ready to demonstrate how the steerable pyramid can be used as a fixed frontend for further stages of (learnable) processing!
 
 ```{code-cell} ipython3
-# First we define/download the dataset. The with block here effectively suppresses stderr,
-# so we don't print out the progressbar. If you would like to see it, remove this line.
-with contextlib.redirect_stderr(open(os.devnull, 'w')):
+# First we define/download the dataset. The with block here effectively suppresses
+# stderr, so we don't print out the progressbar. If you would like to see it, remove
+# this line.
+with contextlib.redirect_stderr(open(os.devnull, "w")):
     train_set = torchvision.datasets.FashionMNIST(
         # change this line to wherever you'd like to download the FashionMNIST dataset
         root="../data",

--- a/linting/check_markdown.py
+++ b/linting/check_markdown.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import pathlib
 import re
 import sys
@@ -23,6 +25,7 @@ except TypeError:
     print(
         "sphinx objects.inv file not found, will not check for missing cross-references"
     )
+
 
 paths = []
 for p in sys.argv[1:]:

--- a/linting/check_tutorials.py
+++ b/linting/check_tutorials.py
@@ -30,3 +30,4 @@ if fails:
     print("The following markdown notebooks are missing a download notebook button!")
     for p in fails:
         print(p)
+    sys.exit(1)

--- a/linting/ruff_notebooks.py
+++ b/linting/ruff_notebooks.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import os
+import pathlib
+import subprocess
+import sys
+
+paths = []
+for p in sys.argv[1:]:
+    p = pathlib.Path(p)
+    if p.is_dir():
+        p = list(p.glob("**/*.md"))
+    elif p.suffix == ".md":
+        p = [p]
+    else:
+        p = []
+    paths.extend(p)
+
+
+exitcode = 0
+os.makedirs("nb_tmp", exist_ok=True)
+for p in paths:
+    with open(p) as f:
+        md = f.read()
+    if not md.startswith("---\njupytext"):
+        # then this isn't a markdown notebook
+        continue
+    ipynb_path = f"nb_tmp{os.sep}{p.stem}.ipynb"
+    subprocess.run(
+        ["jupytext", p, "-o", ipynb_path, "--from", "myst"], capture_output=True
+    )
+    proc = subprocess.run(
+        ["ruff", "format", "--config=pyproject.toml", ipynb_path], capture_output=True
+    )
+    stdout = "\n".join(proc.stdout.decode().split("\n")).strip()
+    if stdout != "1 file left unchanged":
+        exitcode = 1
+        print(stdout)
+    proc = subprocess.run(
+        ["ruff", "check", "--config=pyproject.toml", "--fix", ipynb_path],
+        capture_output=True,
+    )
+    stdout = "\n".join(proc.stdout.decode().split("\n")).strip()
+    if stdout != "All checks passed!":
+        exitcode = 1
+        print(stdout)
+    if exitcode:
+        subprocess.run(
+            ["jupytext", ipynb_path, "-o", p, "--to", "myst"], capture_output=True
+        )
+
+sys.exit(exitcode)

--- a/src/plenoptic/metric/classes.py
+++ b/src/plenoptic/metric/classes.py
@@ -19,8 +19,8 @@ class NLP(torch.nn.Module):
     on the image and returns a 3d tensor with the flattened activations.
 
     NOTE: synthesis using this class will not be the exact same as
-    synthesis using the :func:`~plenoptic.metric.perceptual_distance.nlpd` function
-    (by default), because the ``nlpd`` function uses the root-mean square of the
+    synthesis using the :func:`~plenoptic.metric.perceptual_distance.nlpd` function,
+    because the ``nlpd`` function uses the root-mean square of the
     L2 distance (i.e., ``torch.sqrt(torch.mean(x-y)**2))`` as the distance metric
     between representations.
 

--- a/src/plenoptic/metric/perceptual_distance.py
+++ b/src/plenoptic/metric/perceptual_distance.py
@@ -46,7 +46,7 @@ def _ssim_parts(
         images should have values between 0 and 1. Otherwise, the result may be
         inaccurate, and we will raise a warning (but will still compute it).
     pad
-        If not False, how to pad the image for the convolutions computing the
+        If not ``False``, how to pad the image for the convolutions computing the
         local average of each image. See :func:`torch.nn.functional.pad` for how
         these work.
     func_name
@@ -210,7 +210,7 @@ def ssim(
         in [1]_ or the weighted version (``True``) as used in [4]_. See Notes
         section for the weight.
     pad :
-        If not False, how to pad the image for the convolutions computing the
+        If not ``False``, how to pad the image for the convolutions computing the
         local average of each image. See :func:`torch.nn.functional.pad` for how
         these work.
 
@@ -430,7 +430,7 @@ def ms_ssim(
     power_factors
         Power exponents for the mean values of maps, for different scales (from
         fine to coarse). The length of this array determines the number of scales.
-        If None, set to ``[0.0448, 0.2856, 0.3001, 0.2363, 0.1333]``, which is what
+        If ``None``, set to ``[0.0448, 0.2856, 0.3001, 0.2363, 0.1333]``, which is what
         psychophysical experiments in [1]_ found.
 
     Returns

--- a/src/plenoptic/simulate/canonical_computations/filters.py
+++ b/src/plenoptic/simulate/canonical_computations/filters.py
@@ -118,7 +118,7 @@ def circular_gaussian2d(
         not ``None``, all out channels will have the same value. If not a scalar and
         ``out_channels`` is not ``None``, ``len(std)`` must equal ``out_channels``.
     out_channels
-        Number of output channels. If None, inferred from shape of ``std``.
+        Number of output channels. If ``None``, inferred from shape of ``std``.
 
     Returns
     -------
@@ -278,7 +278,7 @@ def _validate_filter_args(
         not ``None``, all out channels will have the same value. If not a scalar and
         ``out_channels`` is not ``None``, ``len(std)`` must equal ``out_channels``.
     out_channels
-        Number of output channels. If None, inferred from ``len(std)``.
+        Number of output channels. If ``None``, inferred from ``len(std)``.
     std_name, out_channels_name
         Names of these variables to raise more informative error messages (when e.g.,
         calling from ``CenterSurround``, which uses this function to validate different

--- a/src/plenoptic/simulate/models/naive.py
+++ b/src/plenoptic/simulate/models/naive.py
@@ -81,7 +81,7 @@ class Linear(nn.Module):
     pad_mode
         Mode with which to pad image using :func:`torch.nn.functional.pad()`.
     default_filters
-        Initialize the filters to a low-pass and a band-pass. If False, filters are
+        Initialize the filters to a low-pass and a band-pass. If ``False``, filters are
         randomly initialized.
 
     Raises
@@ -187,7 +187,7 @@ class Gaussian(nn.Module):
     pad_mode
         Padding mode argument to pass to :func:`torch.nn.functional.pad`.
     out_channels
-        Number of filters. If None, inferred from shape of ``std``.
+        Number of filters. If ``None``, inferred from shape of ``std``.
     cache_filt
         Whether or not to cache the filter. Avoids regenerating filt with each
         forward pass.
@@ -328,7 +328,7 @@ class CenterSurround(nn.Module):
     surround_std
         Standard deviation of circular Gaussian for surround.
     out_channels
-        Number of filters. If None, inferred from shape of ``center_std``.
+        Number of filters. If ``None``, inferred from shape of ``center_std``.
     pad_mode
         Padding for convolution.
     cache_filt

--- a/src/plenoptic/synthesize/eigendistortion.py
+++ b/src/plenoptic/synthesize/eigendistortion.py
@@ -788,8 +788,7 @@ def display_eigendistortion(
         Axis handle on which to plot.
     plot_complex
         Parameter for :func:`~plenoptic.tools.display.imshow` determining how to handle
-        complex values. Defaults to ``'rectangular'``, which plots real and complex
-        components as separate images. See that method's docstring for details.
+        complex values. See that method's docstring for details.
     **kwargs
         Additional arguments for :func:`~plenoptic.tools.display.imshow`.
 
@@ -862,8 +861,7 @@ def display_eigendistortion_all(
         distortion(s) (to avoid matplotlib clipping), else if ``None`` do nothing.
     plot_complex
         Parameter for :func:`~plenoptic.tools.display.imshow` determining how to handle
-        complex values. Defaults to ``'rectangular'``, which plots real and complex
-        components as separate images. See that method's docstring for details.
+        complex values. See that method's docstring for details.
     as_rgb
         Whether to consider the channels as encoding RGB(A) values. If ``True``, we
         attempt to plot the image in color, so your tensor must have 3 (or 4 if

--- a/src/plenoptic/synthesize/mad_competition.py
+++ b/src/plenoptic/synthesize/mad_competition.py
@@ -150,9 +150,9 @@ class MADCompetition(OptimizedSynthesis):
         initial_noise
             :attr:`mad_image` is initialized to ``self.image + initial_noise *
             torch.randn_like(self.image)``, so this gives the standard deviation of the
-            Gaussian noise. If None, we use a value of 0.1.
+            Gaussian noise. If ``None``, we use a value of 0.1.
         optimizer
-            The un-initialized optimizer object to use. If None, we use Adam.
+            The un-initialized optimizer object to use. If ``None``, we use Adam.
         optimizer_kwargs
             The keyword arguments to pass to the optimizer on initialization. If
             ``None``, we use ``{"lr": .01}`` and, if optimizer is ``None``,
@@ -284,9 +284,9 @@ class MADCompetition(OptimizedSynthesis):
             (unless we hit the stop criterion).
         store_progress
             Whether we should store the MAD image in progress during synthesis. If
-            False, we don't save anything. If True, we save every iteration. If an int,
-            we save every ``store_progress`` iterations (note then that 0 is the same as
-            False and 1 the same as True).
+            ``False``, we don't save anything. If True, we save every iteration. If an
+            int, we save every ``store_progress`` iterations (note then that ``0`` is
+            the same as ``False`` and ``1`` the same as ``True``).
         stop_criterion
             If the loss over the past ``stop_iters_to_check`` has changed
             less than ``stop_criterion``, we terminate synthesis.
@@ -350,10 +350,10 @@ class MADCompetition(OptimizedSynthesis):
         ----------
         mad_image
             Proposed ``mad_image``, :math:`\hat{x}` in the above equation. If
-            None, use ``self.mad_image``.
+            ``None``, use ``self.mad_image``.
         image
             Proposed ``image``, :math:`x` in the above equation. If
-            None, use ``self.image``.
+            ``None``, use ``self.image``.
 
         Returns
         -------
@@ -769,12 +769,12 @@ def plot_loss(
     mad
         MADCompetition object whose loss we want to plot.
     iteration
-        Which iteration to display. If None, we show the most recent one.
+        Which iteration to display. If ``None``, we show the most recent one.
         Negative values are also allowed.
     axes
         Pre-existing axes for plot. If a list of axes, must be the two axes to
         use for this plot. If a single axis, we'll split it in half
-        horizontally. If None, we call :func:`matplotlib.pyplot.gca()`.
+        horizontally. If ``None``, we call :func:`matplotlib.pyplot.gca()`.
     **kwargs
         Passed to :func:`matplotlib.pyplot.semilogy`.
 
@@ -847,7 +847,7 @@ def display_mad_image(
         of display pixels to image pixels. If ``None``, we
         attempt to find the best value ourselves.
     iteration
-        Which iteration to display. If None, we show the most recent one.
+        Which iteration to display. If ``None``, we show the most recent one.
         Negative values are also allowed.
     ax
         Pre-existing axes for plot. If ``None``, we call :func:`matplotlib.pyplot.gca`.
@@ -917,7 +917,7 @@ def plot_pixel_values(
         Which iteration to display. If ``None``, we show the most recent one.
         Negative values are also allowed.
     ylim
-        If tuple, the ylimit to set for this axis. If False, we leave
+        If tuple, the ylimit to set for this axis. If ``False``, we leave
         it untouched.
     ax
         Pre-existing axes for plot. If ``None``, we call
@@ -1319,7 +1319,7 @@ def animate(
     batch_idx
         Which index to take from the batch dimension.
     channel_idx
-        Which index to take from the channel dimension. If None, we use all
+        Which index to take from the channel dimension. If ``None``, we use all
         channels (assumed use-case is RGB(A) image).
     zoom
         How much to zoom in / enlarge the synthesized image, the ratio

--- a/src/plenoptic/synthesize/mad_competition.py
+++ b/src/plenoptic/synthesize/mad_competition.py
@@ -769,8 +769,8 @@ def plot_loss(
     mad
         MADCompetition object whose loss we want to plot.
     iteration
-        Which iteration to display. If None, the default, we show
-        the most recent one. Negative values are also allowed.
+        Which iteration to display. If None, we show the most recent one.
+        Negative values are also allowed.
     axes
         Pre-existing axes for plot. If a list of axes, must be the two axes to
         use for this plot. If a single axis, we'll split it in half
@@ -827,9 +827,6 @@ def display_mad_image(
     """
     Display MAD image.
 
-    You can specify what iteration to view by using the ``iteration`` arg.
-    The default, ``None``, shows the final one.
-
     We use :func:`~plenoptic.tools.display.imshow` to display the synthesized image and
     attempt to automatically find the most reasonable zoom value. You can override this
     value using the zoom arg, but remember that :func:`~plenoptic.tools.display.imshow`
@@ -850,8 +847,8 @@ def display_mad_image(
         of display pixels to image pixels. If ``None``, we
         attempt to find the best value ourselves.
     iteration
-        Which iteration to display. If None, the default, we show
-        the most recent one. Negative values are also allowed.
+        Which iteration to display. If None, we show the most recent one.
+        Negative values are also allowed.
     ax
         Pre-existing axes for plot. If ``None``, we call :func:`matplotlib.pyplot.gca`.
     title :
@@ -917,8 +914,8 @@ def plot_pixel_values(
         Which index to take from the channel dimension. If ``None``, we use all
         channels (assumed use-case is RGB(A) images).
     iteration
-        Which iteration to display. If ``None``, the default, we show
-        the most recent one. Negative values are also allowed.
+        Which iteration to display. If ``None``, we show the most recent one.
+        Negative values are also allowed.
     ylim
         If tuple, the ylimit to set for this axis. If False, we leave
         it untouched.
@@ -1053,7 +1050,7 @@ def _setup_synthesis_fig(
     Creates figure with enough axes for the all the plots you want. Will
     also create index in ``axes_idx`` for them if you haven't done so already.
 
-    By default, all axes will be on the same row and have the same width. If
+    If ``fig=None``, all axes will be on the same row and have the same width. If
     you want them to be on different rows, will need to initialize ``fig`` yourself
     and pass that in. For changing width, change the corresponding ``*_width`` arg,
     which gives width relative to other axes. So if you want the axis for the
@@ -1164,13 +1161,9 @@ def plot_synthesis_status(
     r"""
     Make a plot showing synthesis status.
 
-    We create several subplots to analyze this. By default, we create two
-    subplots on a new figure: the first one contains the MAD image and the
-    second contains the loss.
-
-    The plots to include are specified by including their name in the
-    ``included_plots`` list. All plots can be created separately using the
-    method with the same name.
+    We create several subplots to analyze this. The plots to include are
+    specified by including their name in the ``included_plots`` list. All plots
+    can be created separately using the method with the same name.
 
     Parameters
     ----------
@@ -1211,10 +1204,10 @@ def plot_synthesis_status(
         Which plots to include. Must be some subset of ``'display_mad_image',
         'plot_loss', 'plot_pixel_values'``.
     width_ratios
-        By default, ``plot_loss`` will have double the width of the other plots. To
-        change that, specify their relative widths using the keys: ['display_mad_image',
-        'plot_loss', 'plot_pixel_values'] and floats specifying their relative width.
-        If keys are not included, revert to default behavior.
+        If ``width_ratios`` is an empty dictionary, ``plot_loss`` will have
+        double the width of the other plots. To change that, specify their
+        relative widths using the keys: ['display_mad_image', 'plot_loss',
+        'plot_pixel_values'] and floats specifying their relative width.
 
     Returns
     -------
@@ -1352,10 +1345,10 @@ def animate(
         Which plots to include. Must be some subset of ``'display_mad_image',
         'plot_loss', 'plot_pixel_values'``.
     width_ratios
-        By default, ``plot_loss`` will have double the width of the other plots. To
-        change that, specify their relative widths using the keys: ['display_mad_image',
-        'plot_loss', 'plot_pixel_values'] and floats specifying their relative width.
-        If keys are not included, revert to default behavior.
+        If ``width_ratios`` is an empty dictionary, ``plot_loss`` will have
+        double the width of the other plots. To change that, specify their
+        relative widths using the keys: ['display_mad_image', 'plot_loss',
+        'plot_pixel_values'] and floats specifying their relative width.
 
     Returns
     -------
@@ -1374,15 +1367,13 @@ def animate(
 
     Notes
     -----
-    By default, we use the ffmpeg backend, which requires that you have
+    Unless specified, we use the ffmpeg backend, which requires that you have
     ffmpeg installed and on your path (https://ffmpeg.org/download.html).
     To use a different, use the matplotlib rcParams:
     ``matplotlib.rcParams['animation.writer'] = writer``, see
     `matplotlib documentation
     <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_ for more
     details.
-
-    For displaying in a jupyter notebook, ffmpeg appears to be required.
     """
     if not mad.store_progress:
         raise ValueError(

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -1323,9 +1323,6 @@ def display_metamer(
     """
     Display metamer.
 
-    You can specify what iteration to view by using the ``iteration`` arg.
-    The default, ``None``, shows the final one.
-
     We use :func:`~plenoptic.tools.display.imshow` to display the metamer and attempt to
     automatically find the most reasonable zoom value. You can override this
     value using the zoom arg, but remember that :func:`~plenoptic.tools.display.imshow`
@@ -1346,8 +1343,8 @@ def display_metamer(
         to image pixels. If ``None``, we attempt to find the best
         value ourselves.
     iteration
-        Which iteration to display. If ``None``, we show
-        the most recent one. Negative values are also allowed.
+        Which iteration to display. If ``None``, we show the most recent one.
+        Negative values are also allowed.
     ax
         Pre-existing axes for plot. If ``None``, we call :func:`matplotlib.pyplot.gca`.
     **kwargs
@@ -1646,7 +1643,7 @@ def _setup_synthesis_fig(
     Creates figure with enough axes for the all the plots you want. Will
     also create index in ``axes_idx`` for them if you haven't done so already.
 
-    By default, all axes will be on the same row and have the same width.
+    If ``fig=None``, all axes will be on the same row and have the same width.
     If you want them to be on different rows, will need to initialize ``fig``
     yourself and pass that in. For changing width, change the corresponding
     ``*_width`` arg, which gives width relative to other axes. So if you want
@@ -1770,17 +1767,9 @@ def plot_synthesis_status(
     r"""
     Make a plot showing synthesis status.
 
-    We create several subplots to analyze this. By default, we create three
-    subplots on a new figure: the first one contains the synthesized metamer,
-    the second contains the loss, and the third contains the representation
-    error.
-
-    There is an optional additional plot: ``plot_pixel_values``, a histogram of
-    pixel values of the metamer and target image.
-
-    The plots to include are specified by including their name in the
-    ``included_plots`` list. All plots can be created separately using the
-    method with the same name.
+    We create several subplots to analyze this. The plots to include are
+    specified by including their name in the ``included_plots`` list. All plots
+    can be created separately using the method with the same name.
 
     Parameters
     ----------
@@ -1833,11 +1822,10 @@ def plot_synthesis_status(
         Which plots to include. Must be some subset of ``'display_metamer',
         'plot_loss', 'plot_representation_error', 'plot_pixel_values'``.
     width_ratios
-        By default, all plots will have the same width. To change
-        that, specify their relative widths using the keys: ``'display_metamer',
-        'plot_loss', 'plot_representation_error', 'plot_pixel_values'`` and floats
-        specifying their relative width. Any not included will be assumed to be
-        1.
+        If ``width_ratios`` is an empty dictionary, ``plot_loss`` will have
+        double the width of the other plots. To change that, specify their
+        relative widths using the keys: ['display_mad_image', 'plot_loss',
+        'plot_pixel_values'] and floats specifying their relative width.
 
     Returns
     -------
@@ -2041,11 +2029,10 @@ def animate(
         Which plots to include. Must be some subset of ``'display_metamer',
         'plot_loss', 'plot_representation_error', 'plot_pixel_values'``.
     width_ratios
-        By default, all plots axes will have the same width. To change
-        that, specify their relative widths using the keys: ``'display_metamer',
-        'plot_loss', 'plot_representation_error', 'plot_pixel_values'`` and floats
-        specifying their relative width. Any not included will be assumed to be
-        1.
+        If ``width_ratios`` is an empty dictionary, ``plot_loss`` will have
+        double the width of the other plots. To change that, specify their
+        relative widths using the keys: ['display_mad_image', 'plot_loss',
+        'plot_pixel_values'] and floats specifying their relative width.
 
     Returns
     -------
@@ -2064,12 +2051,13 @@ def animate(
 
     Notes
     -----
-    By default, we use the ffmpeg backend, which requires that you have ffmpeg installed
-    and on your path (https://ffmpeg.org/download.html). To use a different, use the
-    matplotlib rcParams: ``matplotlib.rcParams['animation.writer'] = writer``, see
-    `matplotlib documentation
-    <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_ for more
-    details.
+    Unless specified, we use the ffmpeg backend, which requires that you have
+    ffmpeg installed and on your path (https://ffmpeg.org/download.html). To use
+    a different, use the matplotlib rcParams:
+    ``matplotlib.rcParams['animation.writer'] = writer``, see `matplotlib
+    documentation
+    <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_ for
+    more details.
     """
     if not metamer.store_progress:
         raise ValueError(

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -247,7 +247,7 @@ class Metamer(OptimizedSynthesis):
             (unless we hit the stop criterion).
         store_progress
             Whether we should store the metamer image in progress during
-            synthesis. If False, we don't save anything. If True, we save every
+            synthesis. If ``False``, we don't save anything. If True, we save every
             iteration. If an int, we save every ``store_progress`` iterations
             (note then that 0 is the same as False and 1 the same as True).
         stop_criterion
@@ -869,7 +869,7 @@ class MetamerCTF(Metamer):
             (unless we hit the stop criterion).
         store_progress
             Whether we should store the metamer image in progress on every
-            iteration. If False, we don't save anything. If True, we save every
+            iteration. If ``False``, we don't save anything. If True, we save every
             iteration. If an int, we save every ``store_progress`` iterations
             (note then that 0 is the same as False and 1 the same as True).
         stop_criterion
@@ -1508,7 +1508,7 @@ def plot_pixel_values(
         Which iteration to display. If ``None``, we show
         the most recent one. Negative values are also allowed.
     ylim
-        If tuple, the ylimit to set for this axis. If False, we leave
+        If tuple, the ylimit to set for this axis. If ``False``, we leave
         it untouched.
     ax
         Pre-existing axes for plot. If ``None``, we call
@@ -1985,7 +1985,7 @@ def animate(
           ``np.abs(representation_error).max()`` (for the initial
           representation_error).
 
-        * If False, don't modify limits.
+        * If ``False``, don't modify limits.
 
         * If a string, must be ``"rescale"`` or of the form ``"rescaleN"``,
           where N can be any integer. If ``"rescaleN"``, we rescale the

--- a/src/plenoptic/tools/convergence.py
+++ b/src/plenoptic/tools/convergence.py
@@ -92,7 +92,7 @@ def coarse_to_fine_enough(synth: "MetamerCTF", i: int, ctf_iters_to_check: int) 
         The current iteration (0-indexed).
     ctf_iters_to_check
         Minimum number of iterations coarse-to-fine must run at each scale.
-        If self.coarse_to_fine is False, then this is ignored.
+        If self.coarse_to_fine is ``False``, then this is ignored.
 
     Returns
     -------

--- a/src/plenoptic/tools/data.py
+++ b/src/plenoptic/tools/data.py
@@ -291,10 +291,6 @@ def polar_angle(
     increasing in user-defined direction from the X-axis, ranging from -pi to pi),
     relative to given phase, about the given origin pixel.
 
-    Note that by default, the angle increases in a clockwise direction, which is NOT the
-    standard mathematical convention. Use the ``direction`` argument to change that
-    behavior.
-
     Parameters
     ----------
     size

--- a/src/plenoptic/tools/data.py
+++ b/src/plenoptic/tools/data.py
@@ -89,7 +89,7 @@ def load_images(paths: str | list[str], as_gray: bool = True) -> Tensor:
         directory with lots of non-image files). This is NOT recursive.
     as_gray
         Whether to convert the images into grayscale or not after
-        loading them. If False, we do nothing. If True, we call
+        loading them. If ``False``, we do nothing. If ``True``, we call
         skimage.color.rgb2gray on them, which will result in a single
         channel.
 
@@ -243,7 +243,7 @@ def polar_radius(
         The center of the image. if an int, we assume the origin is at
         ``(origin, origin)``. if a tuple, must be a 2-tuple of ints
         specifying the origin (where ``(0, 0)`` is the upper left).  if
-        None, we assume the origin lies at the center of the matrix,
+        ``None``, we assume the origin lies at the center of the matrix,
         ``(size+1)/2``.
     device
         The device to create this tensor on.
@@ -301,8 +301,8 @@ def polar_angle(
     origin
         The center of the image. if an int, we assume the origin is at
         ``(origin, origin)``. if a tuple, must be a 2-tuple of ints specifying the
-        origin (where ``(0, 0)`` is the upper left). If None, we assume the origin lies
-        at the center of the matrix, ``(size+1)/2``.
+        origin (where ``(0, 0)`` is the upper left). If ``None``, we assume the origin
+        lies at the center of the matrix, ``(size+1)/2``.
     direction
         Whether the angle increases in a clockwise or counter-clockwise direction from
         the x-axis. The standard mathematical convention is to increase

--- a/src/plenoptic/tools/display.py
+++ b/src/plenoptic/tools/display.py
@@ -427,13 +427,13 @@ def animshow(
 
     Notes
     -----
-    - By default, we use the ffmpeg backend, which requires that you have
-      ffmpeg installed and on your path (https://ffmpeg.org/download.html).
-      To use a different backend, use the matplotlib rcParams:
-      ``matplotlib.rcParams['animation.writer'] = writer``, see
-      `matplotlib documentation
-      <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_ for more
-      details.
+    - Unless specified, we use the ffmpeg backend, which requires that you have
+      ffmpeg installed and on your path (https://ffmpeg.org/download.html). To
+      use a different, use the matplotlib rcParams:
+      ``matplotlib.rcParams['animation.writer'] = writer``, see `matplotlib
+      documentation
+      <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_
+      for more details.
 
     - This interpolation avoidance is only guaranteed for the saved image; it should
       generally hold in notebooks as well, but will fail if, e.g., you plot an image
@@ -659,9 +659,9 @@ def clean_up_axes(
     ax
         The axis to clean up.
     ylim
-        If a tuple, the y-limits to use for this plot. If ``None``, we use the
-        default, slightly adjusted so that the minimum is 0. If ``False``,
-        we do nothing.
+        If a tuple, the y-limits to use for this plot. If ``None``, we use
+        the original limits, slightly adjusted so that the minimum is 0. If
+        ``False``, we do not change y-limits.
     spines_to_remove
         The spines to remove from the axis.
     axes_to_remove
@@ -793,10 +793,9 @@ def clean_stem_plot(
 
     Helper function for :func:`~plenoptic.tools.display.plot_representation()`.
 
-    By default, stem plot would have a baseline that covers the entire range of the
-    data. We want to be able to break that up visually (so there's a line from 0 to 9,
-    from 10 to 19, etc), and passing ``xvals`` separately allows us to do that. If you
-    want the default stem plot behavior, leave ``xvals=None``.
+    If ``xvals=None``, stem plot will have a baseline that covers the entire range
+    of the data. In order to break that up visually (so there's a line from 0 to 9,
+    from 10 to 19, etc) pass ``xvals`` separately.
 
     Parameters
     ----------
@@ -809,12 +808,13 @@ def clean_stem_plot(
         The title to put on the axis. If ``None``, we don't call ``ax.set_title``
         (useful if you want to avoid changing the title on an existing plot).
     ylim
-        The y-limits to use for this plot. If ``None``, we use the default, slightly
-        adjusted so that the minimum is 0. If ``False``, do not change y-limits.
+        If a tuple, the y-limits to use for this plot. If ``None``, we use
+        the original limits, slightly adjusted so that the minimum is 0. If
+        ``False``, we do not change y-limits.
     xvals
         A 2-tuple of lists, containing the start (``xvals[0]``) and stop
-        (``xvals[1]``) x values for plotting. If ``None``, we use the
-        default stem plot behavior.
+        (``xvals[1]``) x values for plotting. If ``None``, baseline will cover
+        full range.
     **kwargs
         Passed to :func:`matplotlib.pyplot.stem`.
 
@@ -829,37 +829,34 @@ def clean_stem_plot(
     break up the plot, as we see below.
 
     .. plot::
-      :include-source:
 
-      import plenoptic as po
-      import numpy as np
-      import matplotlib.pyplot as plt
-      # if ylim=None, as in this example, the minimum y-valuewill get
-      # set to 0, so we want to make sure our values are all positive
-      y = np.abs(np.random.randn(55))
-      y[15:20] = np.nan
-      y[35:40] = np.nan
-      # we want to draw the baseline from 0 to 14, 20 to 34, and 40 to
-      # 54, everywhere that we have non-NaN values for y
-      xvals = ([0, 20, 40], [14, 34, 54])
-      po.tools.display.clean_stem_plot(y,  xvals=xvals)
-      plt.show()
+      >>> import plenoptic as po
+      >>> import numpy as np
+      >>> import matplotlib.pyplot as plt
+      >>> # if ylim=None, as in this example, the minimum y-valuewill get
+      >>> # set to 0, so we want to make sure our values are all positive
+      >>> y = np.abs(np.random.randn(55))
+      >>> y[15:20] = np.nan
+      >>> y[35:40] = np.nan
+      >>> # we want to draw the baseline from 0 to 14, 20 to 34, and 40 to
+      >>> # 54, everywhere that we have non-NaN values for y
+      >>> xvals = ([0, 20, 40], [14, 34, 54])
+      >>> po.tools.display.clean_stem_plot(y, xvals=xvals)
+      <Axes: >
 
-    If we don't care about breaking up the x-axis, you can simply use
-    the default xvals (``None``). In this case, this function will just
-    clean up the plot a little bit
+    If we don't care about breaking up the x-axis, you can set ``xvals=None``.
+    In this case, this function will just clean up the plot a little bit.
 
     .. plot::
-      :include-source:
 
-      import plenoptic as po
-      import numpy as np
-      import matplotlib.pyplot as plt
-      # if ylim=None, as in this example, the minimum y-valuewill get
-      # set to 0, so we want to make sure our values are all positive
-      y = np.abs(np.random.randn(55))
-      po.tools.display.clean_stem_plot(y)
-      plt.show()
+      >>> import plenoptic as po
+      >>> import numpy as np
+      >>> import matplotlib.pyplot as plt
+      >>> # if ylim=None, as in this example, the minimum y-valuewill get
+      >>> # set to 0, so we want to make sure our values are all positive
+      >>> y = np.abs(np.random.randn(55))
+      >>> po.tools.display.clean_stem_plot(y)
+      <Axes: >
     """
     if ax is None:
         ax = plt.gca()
@@ -1157,7 +1154,7 @@ def plot_representation(
     Plot model representation.
 
     We try to plot ``data`` on ``ax``, using the ``model.plot_representation`` method,
-    if it has it, and otherwise default to a function that makes sense based on the
+    if it has it, and otherwise use a function that makes sense based on the
     shape of ``data``.
 
     All of these arguments are optional, but at least some of them need
@@ -1171,7 +1168,7 @@ def plot_representation(
       sub-plot.
 
     - If ``data`` is ``None``, we can only do something if
-      ``model.plot_representation`` has some default behavior when
+      ``model.plot_representation`` has some behavior when
       ``data=None``; this is probably to plot its own ``representation``
       attribute. Thus, this will raise an Exception if both ``model`` and
       ``data`` are ``None``, because we have no idea what to plot then.

--- a/src/plenoptic/tools/optim.py
+++ b/src/plenoptic/tools/optim.py
@@ -17,7 +17,7 @@ def set_seed(seed: int | None = None) -> None:
     Parameters
     ----------
     seed
-        The seed to set. If None, do nothing.
+        The seed to set. If ``None``, do nothing.
     """
     if seed is not None:
         # random initialization

--- a/src/plenoptic/tools/validate.py
+++ b/src/plenoptic/tools/validate.py
@@ -26,10 +26,10 @@ def validate_input(
 
     - Checks if input_tensor has a float or complex dtype (``TypeError``).
 
-    - If ``no_batch`` is True, check whether ``input_tensor.shape[0] == 1`` or
+    - If ``no_batch`` is ``True``, check whether ``input_tensor.shape[0] == 1`` or
       ``input_tensor.ndimension()==1`` (``ValueError``).
 
-    - If ``allowed_range`` is not None, check whether all values of
+    - If ``allowed_range`` is not ``None``, check whether all values of
       ``input_tensor`` lie within the specified range (``ValueError``).
 
     Additionally, if input_tensor is not 4d, raises a ``UserWarning``.
@@ -39,10 +39,10 @@ def validate_input(
     input_tensor
         The tensor to validate.
     no_batch
-        If True, raise a ValueError if the batch dimension of ``input_tensor``
+        If ``True``, raise a ValueError if the batch dimension of ``input_tensor``
         is greater than 1.
     allowed_range
-        If not None, ensure that all values of ``input_tensor`` lie within
+        If not ``None``, ensure that all values of ``input_tensor`` lie within
         allowed_range.
 
     Raises
@@ -299,7 +299,7 @@ def validate_coarse_to_fine(
     image_shape
         Some models (e.g., the steerable pyramid) can only accept inputs of a
         certain shape. If that's the case for ``model``, use this to
-        specify the expected shape. If None, we use an image of shape
+        specify the expected shape. If ``None``, we use an image of shape
         ``(1,1,16,16)``.
     device
         Which device to place the test image on.
@@ -394,7 +394,7 @@ def validate_metric(
     image_shape
         Some models (e.g., the steerable pyramid) can only accept inputs of a
         certain shape. If that's the case for ``model``, use this to
-        specify the expected shape. If None, we use an image of shape
+        specify the expected shape. If ``None``, we use an image of shape
         ``(1,1,16,16)``.
     image_dtype
         What dtype to validate against.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -567,7 +567,7 @@ def remove_redundant_and_normalize(
     are computed automatically (because of how the computation works) and then
     discarded (e.g., symmetries in autocorrelation). This function removes both.
 
-    Additionally, if use_true_correlations=False, we normalize the
+    Additionally, if ``use_true_correlations=False``, we normalize the
     correlations. The matlab PS code did not do so, so that, e.g., the center
     value of the autocorrelations was the corresponding variance (rather than
     being normalized to 1). Originally, we supported both normalized and

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,7 +32,7 @@ def update_ps_synthesis_test_file(
     ----------
     torch_version
         The version of pytorch for which we should grab the corresponding test
-        file. If None, we use the installed version.
+        file. If ``None``, we use the installed version.
 
     Returns
     -------


### PR DESCRIPTION
Several additional linting / formatting here:
- Ruff does not support myst-nb directly (https://github.com/astral-sh/ruff/issues/8800), so to work around that, I added a small script which converts them to ipynb, runs `ruff format` and `ruff check` and converts back to .md, exiting with an error status if any change happened.
- Realized that I need to specify the requirements of the ruff file for this (and for the linting that checks for internal references), and how to do so. To make this work, those rules need to be specified as `language: python` (instead of `system`) and the scripts need to be executable (`chmod +x`) with a `#!` at the top to define the executable.
- Realized I was missing some True/False/Nones in docstrings (I want them all to be monospaced), because I wasn't matching words followed immediately by commas.
- Raise an error if the word "default" (not in an arg name) is found in a docstring, since it's unnecessary and hard to keep up-to-date