### PR TITLE
Hotfix: fix osf download url

### DIFF
--- a/src/plenoptic/data/fetch.py
+++ b/src/plenoptic/data/fetch.py
@@ -75,7 +75,7 @@ REGISTRY_URLS = {
     "load_image_test.tar.gz": OSF_TEMPLATE.format("avpzq"),
     "berardino_onoff.pt": OSF_TEMPLATE.format("uqfa8"),
     "berardino_vgg16.pt": OSF_TEMPLATE.format("6r87b"),
-    "ps_regression.tar.gz": OSF_TEMPLATE.format("7t4fj"),
+    "ps_regression.tar.gz": OSF_TEMPLATE.format("7t4fj/?revision=8"),
 }
 
 #: List of files that can be downloaded using :func:`fetch_data`


### PR DESCRIPTION
OSF changed their download link from `https://osf.io/#####/download` to `https://osf.io/download/#####`, so this fixes that.

This also specifies a version for the `ps_regression.tar.gz`, because this PR should test against version 8, whereas the other open PR (#377) should test against version 9.

See [announcement](https://www.cos.io/blog/coming-soon-a-new-look-for-osf).

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
