### PR TITLE
Remove matplotlib inline backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,12 @@ repos:
       types_or: ["markdown"]
       entry: python linting/check_apidocs.py
       files: ^docs/tutorials
+    - id: check-inline
+      language: python
+      name: Check for matplotlib inline directive in md notebooks
+      types_or: ["markdown"]
+      files: ^docs/
+      entry: linting/check_mpl_inline.py
 
 - repo: https://github.com/codespell-project/codespell
   # Configuration for codespell is in pyproject.toml

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -32,7 +32,6 @@ import plenoptic as po
 # so that relative sizes of axes created by po.imshow and others look right
 plt.rcParams["figure.dpi"] = 72
 
-%matplotlib inline
 
 plt.rcParams["animation.html"] = "html5"
 # use single-threaded ffmpeg for animation writer

--- a/docs/user_guide/advanced/Display.md
+++ b/docs/user_guide/advanced/Display.md
@@ -45,7 +45,6 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 %load_ext autoreload
 %autoreload 2
-%matplotlib inline
 ```
 
 ```{code-cell} ipython3

--- a/docs/user_guide/models_and_metrics/Steerable_Pyramid.md
+++ b/docs/user_guide/models_and_metrics/Steerable_Pyramid.md
@@ -64,7 +64,6 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 # so that relative sizes of axes created by po.imshow and others look right
 plt.rcParams["figure.dpi"] = 72
 
-%matplotlib inline
 
 plt.rcParams["animation.html"] = "html5"
 # use single-threaded ffmpeg for animation writer

--- a/docs/user_guide/reproduce/Original_MAD.md
+++ b/docs/user_guide/reproduce/Original_MAD.md
@@ -42,8 +42,6 @@ Goal here is to reproduce original MAD Competition results, as generated using t
 ```{code-cell} ipython3
 import plenoptic as po
 
-%matplotlib inline
-
 %load_ext autoreload
 %autoreload 2
 

--- a/linting/check_mpl_inline.py
+++ b/linting/check_mpl_inline.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+
+error_files = []
+for p in sys.argv[1:]:
+    txt = pathlib.Path(p).read_text()
+    if "%matplotlib inline" in txt:
+        error_files.append(p)
+
+if error_files:
+    print("matplotlib inline directive found in following files:")
+    for f in error_files:
+        print(f"\t{f}")
+    sys.exit(1)


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

While looking at the built `tags/1.3.1` documentation earlier today, realized that images were not rendering in the Steerable Pyramid page. After looking into this more, found it several other pages and realized all the pages where this happened were those that had `%matplotlib inline` in them. 

(I have since fixed the 1.3.1 docs, so the issue is no longer present)

In the changes between 1.3.0 and 1.3.1, I had added `;` to the end of many plotting lines in the notebooks, to suppress duplicate plots (e.g., [the wavelet plot in this section of 1.3.0 docs](https://docs.plenoptic.org/docs/tags/1.3.0/tutorials/models/03_Steerable_Pyramid.html#Visualizing-Wavelets)). In notebooks that did *not* have `%matplotlib inline`, this led to the correct behavior, but in those that did, this completely suppressed the plots. (I also switched to using `myst-nb` instead of .ipynb notebook files with nblink, but I don't think that's related.)

I think switching to pydata-sphinx-theme avoids this issue, as it does not appear to be an issue in main ([e.g.,](https://docs.plenoptic.org/docs/branch/main/user_guide/models_and_metrics/Steerable_Pyramid.html#visualizing-wavelets)). However, to be safe, this PR removes those lines and adds a small `linting` script to pre-commit to raise an error if any are added.

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, modifying `docs/api.rst` (adding both the appropriate autosummary and, if a new file, a line in the hidden toctree) and `docs/api_modules.rst` (if a new file) to include it if necessary.
