### PR TITLE
increase precision for flaky test

### DIFF
--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -540,13 +540,13 @@ class TestEigendistortionSynthesis:
 
 class TestAutodiffFunctions:
     @pytest.fixture(scope="class")
-    def state(self, einstein_img):
+    def state(self, einstein_img_double):
         """variables to be reused across tests in this class"""
 
-        k = 2  # num vectors with which to compute vjp, jvp, Fv
-        einstein_img = einstein_img[
-            ..., 100 : 100 + 16, 100 : 100 + 16
-        ]  # reduce image size
+        # num vectors with which to compute vjp, jvp, Fv
+        k = 2
+        # reduce image size
+        einstein_img = einstein_img_double[..., 100 : 100 + 16, 100 : 100 + 16]
 
         # eigendistortion object
         ed = Eigendistortion(einstein_img, get_model("frontend.OnOff.nograd"))

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -594,7 +594,9 @@ class TestAutodiffFunctions:
     def test_fisher_vec_prod(self, state):
         x, y, x_dim, y_dim, k = state
 
-        V, _ = torch.linalg.qr(torch.ones((x_dim, k), device=DEVICE), "reduced")
+        V, _ = torch.linalg.qr(
+            torch.ones((x_dim, k), device=DEVICE, dtype=x.dtype), "reduced"
+        )
         U = V.clone()
         Jv = autodiff._jacobian_vector_product(y, x, V)
         Fv = autodiff._vector_jacobian_product(y, x, Jv)

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 
 import plenoptic.synthesize.autodiff as autodiff
-from conftest import DEVICE, ColorModel, get_model
+from conftest import DEVICE, ColorModel
 from plenoptic.metric import mse
 from plenoptic.simulate import Gaussian, OnOff
 from plenoptic.simulate import LinearNonlinear as LNL
@@ -548,8 +548,13 @@ class TestAutodiffFunctions:
         # reduce image size
         einstein_img = einstein_img_double[..., 100 : 100 + 16, 100 : 100 + 16]
 
+        model = OnOff((31, 31), pretrained=True, cache_filt=True)
+        remove_grad(model)
+        model.to(einstein_img.dtype).to(DEVICE)
+        model.eval()
+
         # eigendistortion object
-        ed = Eigendistortion(einstein_img, get_model("frontend.OnOff.nograd"))
+        ed = Eigendistortion(einstein_img, model)
 
         x, y = ed._image_flat, ed._representation_flat
 


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

Recently, `test_fisher_vec_prod` in `test_eigendistortion.py` has started occasionally failing on Jenkins (most recently in #425). It never happens on CPU and doesn't happen every time on the GPU. This is the simplest possible fix: let's just increase the precision of the tensors we're doing the computation on, and hopefully that works.

**Link any related issues, discussions, PRs**

Closes issue #407 ?

**Describe changes**

- Change all tests in `TestAutodiffFunctions` to use double precision.

**Benchmarking**

If your test involves improvements to the efficiency of any part of the code base, please include some benchmarking results, to show the performance before (i.e., in the `main` branch) and after. See [PR #377](https://github.com/plenoptic-org/plenoptic/pull/377) for an example.

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
