### PR TITLE
add 1.4.0 to version_switcher

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -4,10 +4,14 @@
         "url": "https://docs.plenoptic.org/docs/branch/main/"
     },
     {
-        "name": "1.3.1 (stable)",
+        "name": "1.4.0 (stable)",
+        "version": "1.4.0",
+        "url": "https://docs.plenoptic.org/docs/tags/1.4.0/",
+        "preferred": true
+    },
+    {
         "version": "1.3.1",
         "url": "https://docs.plenoptic.org/docs/tags/1.3.1/",
-        "preferred": true
     },
     {
         "version": "1.3.0",


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

Adds 1.4.0 to `version_switcher.json`, after which we'll release.

