### PR TITLE
Fix version_switcher.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,16 @@ jobs:
         print_all: false
         timeout: 5
         retry_count: 3
+  validate_switcher_json:
+    runs-on: ubuntu-latest
+    name: Validate version_switcher.json
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - run: |
+        cat docs/_static/version_switcher.json | jq
+
 
   check:
     if: always()

--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -11,7 +11,7 @@
     },
     {
         "version": "1.3.1",
-        "url": "https://docs.plenoptic.org/docs/tags/1.3.1/",
+        "url": "https://docs.plenoptic.org/docs/tags/1.3.1/"
     },
     {
         "version": "1.3.0",


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

`version_switcher.json`, updated in #429, was improperly formatted and so the docs build is now failing (since it grabs it from main, didn't fail in the relevant PR). This fixes that and adds a validation step (using [jq](https://en.wikipedia.org/wiki/Jq_(programming_language))).

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
