### PR TITLE
Change `PortillaSimoncelli` default `spatial_corr_width` from 9 to 7

### DIFF
--- a/docs/user_guide/models_and_metrics/portilla_simoncelli/advanced_usage/ps_extensions.md
+++ b/docs/user_guide/models_and_metrics/portilla_simoncelli/advanced_usage/ps_extensions.md
@@ -123,11 +123,11 @@ class PortillaSimoncelliMask(po.simul.PortillaSimoncelli):
         im_shape,
         n_scales=4,
         n_orientations=4,
-        spatial_corr_width=9,
+        spatial_corr_width=7,
         mask=None,
         target=None,
     ):
-        super().__init__(im_shape, n_scales=4, n_orientations=4, spatial_corr_width=9)
+        super().__init__(im_shape, n_scales=4, n_orientations=4, spatial_corr_width=7)
         self.mask = mask
         self.target = target
 

--- a/docs/user_guide/models_and_metrics/portilla_simoncelli/getting_started/ps_basic_synthesis.md
+++ b/docs/user_guide/models_and_metrics/portilla_simoncelli/getting_started/ps_basic_synthesis.md
@@ -89,13 +89,13 @@ Now let's create an instance of the PortillaSimoncelli model with the following 
 
 - `n_scales=4`, The number of scales in the steerable pyramid underlying the model.
 - `n_orientations=3`, The number of orientations in the steerable pyramid.
-- `spatial_corr_width=9`, The size of the window used to calculate the correlations across steerable pyramid bands.
+- `spatial_corr_width=7`, The size of the window used to calculate the correlations across steerable pyramid bands.
 
 Running the model on an image will return a tensor of numbers summarizing the "texturiness" of that image, which we refer to as the model's representation. These statistics are measurements of different properties that the authors considered relevant to a texture's appearance (where a texture is defined above), and capture some of the repeating properties of these types of images.
 
 ```{code-cell} ipython3
 model = po.simul.PortillaSimoncelli(
-    img.shape[-2:], n_scales=4, n_orientations=3, spatial_corr_width=9
+    img.shape[-2:], n_scales=4, n_orientations=3, spatial_corr_width=7
 )
 representation = model(img)
 print(

--- a/docs/user_guide/models_and_metrics/portilla_simoncelli/understanding/ps_understand_stats.md
+++ b/docs/user_guide/models_and_metrics/portilla_simoncelli/understanding/ps_understand_stats.md
@@ -127,7 +127,7 @@ class PortillaSimoncelliRemove(po.simul.PortillaSimoncelli):
         im_shape,
         remove_keys,
     ):
-        super().__init__(im_shape, n_scales=4, n_orientations=4, spatial_corr_width=9)
+        super().__init__(im_shape, n_scales=4, n_orientations=4, spatial_corr_width=7)
         self.remove_keys = remove_keys
 
     def forward(self, image, scales=None):

--- a/linting/check_docstrings.py
+++ b/linting/check_docstrings.py
@@ -86,10 +86,15 @@ for p in paths:
             dollarsigns.append((p, name))
         directives = re.findall(SPHINX_DIRECTIVE_REGEX, doc)
         sphinx_link = re.findall(SPHINX_LINK_REGEX, doc)
-        # if the word default is preceded / followed by an underscore, then the
-        # argument has "default" in its name, so don't match that (using
-        # negative look-ahead/behind)
-        default = re.findall("(?<!_)[Dd]efault(?!_)", doc)
+        # if the word default is preceded / followed by an underscore, then the argument
+        # has "default" in its name, so don't match that (using negative
+        # look-ahead/behind). the only allowable place to put default is in a
+        # versionchanged note. For now, we'll say that default has to be the first word
+        # in such a note, so that we know it is preceded by a version number (which is
+        # 5 digits long) and the versionchanged tag
+        default = re.findall(
+            r"(?<!versionchanged:: [0-9\.]{5}) (?<!_)[Dd]efault(?!_)", doc
+        )
         if default:
             defaults.append((p, name))
         backtick = [

--- a/src/plenoptic/data/fetch.py
+++ b/src/plenoptic/data/fetch.py
@@ -45,12 +45,12 @@ REGISTRY = {
     "load_image_test.tar.gz": "8a2b92dc0d442695c45b1e908ef0a04cae35c5f21b774a93b9fc6b675423b526",  # noqa: E501
     "berardino_onoff.pt": "2174a40005489b9c94acc91213b2f6d57a75f262caf118cb1980658eadbfd047",  # noqa: E501
     "berardino_vgg16.pt": "5e0d10f4a367244879cd8a61c453992370ab801db1f66e10caa1ee2ecfab8ca4",  # noqa: E501
-    "ps_regression.tar.gz": "1d9a22969c4d1fa7a5b287f2eaa84e9179cd72ba3748764f4616d1fc01199046",  # noqa: E501
+    "ps_regression.tar.gz": "dcb92f7df6344e7f6760c16ece4395245d43703bf6783629272549674f753faf",  # noqa: E501
     "example_metamer_gaussian-old.pt": "adef079df878a9e0319cb5ad59791435f9b7eec695e1d8f21019c8e11b891d85",  # noqa: E501
     "example_metamer_gaussian.pt": "02e12c7c2a93e2e5a83f6d7aa8320368c00641deacfba3359b02fedc9a0dc0f1",  # noqa: E501
     "example_metamer_gaussian-cuda.pt": "edd80e63bd776b679f714acee62fefa9885a257c66e2699423887aeab7c03794",  # noqa: E501
-    "example_metamerCTF_ps.pt": "6a9e04a8aeaacc1c45bfde23a657529431cf5100b68fc49206b778a79b7b1023",  # noqa: E501
-    "example_metamerCTF_ps-cuda.pt": "9f9c67494ee8531db40a91c29c4e1c33e1ef38d399e3f2746fa6bd0373b80003",  # noqa: E501
+    "example_metamerCTF_ps.pt": "6005e4fcf8f36443af1ebc9338319e201876f0640b62ceba062f3a2a33a93f28",  # noqa: E501
+    "example_metamerCTF_ps-cuda.pt": "2f454a29e46cade7ced9268e15878712cc23827d9e5b849e0367e08ee49b79df",  # noqa: E501
 }
 
 OSF_TEMPLATE = "https://osf.io/download/{}"
@@ -84,12 +84,12 @@ REGISTRY_URLS = {
     "load_image_test.tar.gz": OSF_TEMPLATE.format("avpzq"),
     "berardino_onoff.pt": OSF_TEMPLATE.format("uqfa8"),
     "berardino_vgg16.pt": OSF_TEMPLATE.format("6r87b"),
-    "ps_regression.tar.gz": OSF_TEMPLATE.format("7t4fj/?revision=14"),
+    "ps_regression.tar.gz": OSF_TEMPLATE.format("7t4fj/?revision=15"),
     "example_metamer_gaussian-old.pt": OSF_TEMPLATE.format("7e48u/?revision=5"),
     "example_metamer_gaussian.pt": OSF_TEMPLATE.format("7e48u/?revision=6"),
     "example_metamer_gaussian-cuda.pt": OSF_TEMPLATE.format("jzhe7/?revision=3"),
-    "example_metamerCTF_ps.pt": OSF_TEMPLATE.format("4zr37/?revision=8"),
-    "example_metamerCTF_ps-cuda.pt": OSF_TEMPLATE.format("627sp/?revision=3"),
+    "example_metamerCTF_ps.pt": OSF_TEMPLATE.format("4zr37/?revision=9"),
+    "example_metamerCTF_ps-cuda.pt": OSF_TEMPLATE.format("627sp/?revision=4"),
 }
 
 #: List of files that can be downloaded using :func:`~plenoptic.data.fetch.fetch_data`

--- a/src/plenoptic/simulate/models/portilla_simoncelli.py
+++ b/src/plenoptic/simulate/models/portilla_simoncelli.py
@@ -61,7 +61,7 @@ class PortillaSimoncelli(nn.Module):
     See the paper and notebook for more description.
 
     .. versionchanged:: 2.0.0
-       ``spatial_corr_width`` default value changed from 9 to 7, in order to match
+       Default ``spatial_corr_width`` value changed from 9 to 7, in order to match
        the value used to generate the figures in the Portilla and Simoncelli, 2000
        [2]_, paper.
 

--- a/src/plenoptic/simulate/models/portilla_simoncelli.py
+++ b/src/plenoptic/simulate/models/portilla_simoncelli.py
@@ -61,7 +61,7 @@ class PortillaSimoncelli(nn.Module):
     See the paper and notebook for more description.
 
     .. versionchanged:: 2.0.0
-       :attr:`spatial_corr_width` default value changed from 9 to 7, in order to match
+       ``spatial_corr_width`` default value changed from 9 to 7, in order to match
        the value used to generate the figures in the Portilla and Simoncelli, 2000
        [2]_, paper.
 

--- a/src/plenoptic/simulate/models/portilla_simoncelli.py
+++ b/src/plenoptic/simulate/models/portilla_simoncelli.py
@@ -60,6 +60,11 @@ class PortillaSimoncelli(nn.Module):
     variance, skew, and kurtosis) of the image and down-sampled versions of that image.
     See the paper and notebook for more description.
 
+    .. versionchanged:: 2.0.0
+       :attr:`spatial_corr_width` default value changed from 9 to 7, in order to match
+       the value used to generate the figures in the Portilla and Simoncelli, 2000
+       [2]_, paper.
+
     Parameters
     ----------
     image_shape
@@ -158,7 +163,7 @@ class PortillaSimoncelli(nn.Module):
         image_shape: tuple[int, int],
         n_scales: int = 4,
         n_orientations: int = 4,
-        spatial_corr_width: int = 9,
+        spatial_corr_width: int = 7,
     ):
         super().__init__()
 

--- a/src/plenoptic/simulate/models/portilla_simoncelli.py
+++ b/src/plenoptic/simulate/models/portilla_simoncelli.py
@@ -111,7 +111,7 @@ class PortillaSimoncelli(nn.Module):
        >>> img = po.data.reptile_skin()
        >>> ps_model = po.simul.PortillaSimoncelli(img.shape[2:])
        >>> ps_model(img)
-       tensor([[[0.4172, 0.0547, ..., 0.0048]]])
+       tensor([[[ 4.1716e-01, 5.4735e-02, ..., 4.7756e-03]]])
 
     Visualize texture statistics:
 
@@ -452,7 +452,7 @@ class PortillaSimoncelli(nn.Module):
         >>> portilla_simoncelli_model = po.simul.PortillaSimoncelli(img.shape[2:])
         >>> representation_tensor = portilla_simoncelli_model(img)
         >>> representation_tensor.shape
-        torch.Size([1, 1, 1046])
+        torch.Size([1, 1, 710])
         """
         # pyr_dict is the dictionary of complex-valued tensors returned by the
         # steerable pyramid. pyr_coeffs is a list (length n_scales) of 5d
@@ -618,12 +618,12 @@ class PortillaSimoncelli(nn.Module):
         >>> portilla_simoncelli_model = po.simul.PortillaSimoncelli(img.shape[2:])
         >>> representation_tensor = portilla_simoncelli_model(img)
         >>> representation_tensor.shape
-        torch.Size([1, 1, 1046])
+        torch.Size([1, 1, 710])
         >>> limited_representation_tensor = portilla_simoncelli_model.remove_scales(
         ...     representation_tensor, scales_to_keep=[0]
         ... )
         >>> limited_representation_tensor.shape
-        torch.Size([1, 1, 261])
+        torch.Size([1, 1, 181])
         """
         # this is necessary because object is the dtype of
         # self._representation_scales
@@ -732,7 +732,7 @@ class PortillaSimoncelli(nn.Module):
         >>> # Shape is (batch, channel, spatial_corr_width, spatial_corr_width,
         >>> # n_orientations, n_scales)
         >>> representation_dict["auto_correlation_magnitude"].shape
-        torch.Size([1, 1, 9, 9, 4, 3])
+        torch.Size([1, 1, 7, 7, 4, 3])
         >>> # Shape is (batch, channel, n_scales+1)
         >>> representation_dict["skew_reconstructed"].shape
         torch.Size([1, 1, 4])
@@ -742,7 +742,7 @@ class PortillaSimoncelli(nn.Module):
         >>> # Shape is (batch, channel, spatial_corr_width, spatial_corr_width,
         >>> # n_scales+1)
         >>> representation_dict["auto_correlation_reconstructed"].shape
-        torch.Size([1, 1, 9, 9, 4])
+        torch.Size([1, 1, 7, 7, 4])
         >>> # Shape is (batch, channel, n_scales+1)
         >>> representation_dict["std_reconstructed"].shape
         torch.Size([1, 1, 4])

--- a/src/plenoptic/synthesize/metamer.py
+++ b/src/plenoptic/synthesize/metamer.py
@@ -1510,7 +1510,7 @@ class MetamerCTF(Metamer):
         >>> # this isn't enough to run synthesis to completion, just an example
         >>> met.synthesize(5)
         >>> met.losses
-        tensor([0.0821, ..., 0.0805])
+        tensor([0.1062, ..., 0.1038])
 
         You can examine scales_timing attribute to see when MetamerCTF started and
         stopped optimizing each scale:
@@ -1539,7 +1539,7 @@ class MetamerCTF(Metamer):
         >>> progress.keys()
         dict_keys(['losses', ..., 'saved_metamer', 'store_progress_iteration'])
         >>> progress["losses"]
-        tensor(0.0850)
+        tensor(0.1109)
 
         Set ``change_scale_criterion`` and ``ctf_iters_to_check`` to change
         scale-switching behavior.
@@ -1548,7 +1548,7 @@ class MetamerCTF(Metamer):
         >>> # this isn't enough to run synthesis to completion, just an example
         >>> met.synthesize(5, change_scale_criterion=None, ctf_iters_to_check=2)
         >>> met.losses
-        tensor([0.0863, ..., 0.0569])
+        tensor([0.1119, ..., 0.0687])
         >>> met.scales_timing
         {'pixel_statistics': [0, 1],
          'residual_lowpass': [2, 3],
@@ -1973,7 +1973,7 @@ class MetamerCTF(Metamer):
         tensor([])
         >>> met.load(po.data.fetch_data("example_metamerCTF_ps.pt"))
         >>> print(met.metamer)
-        tensor([[[[0.3016, ...]]]], dtype=torch.float64, requires_grad=True)
+        tensor([[[[0.1421, ...]]]], dtype=torch.float64, requires_grad=True)
 
         If the saved ``MetamerCTF`` object lived on a CUDA device and you do not have
         CUDA on the loading machine, use ``map_location`` to change device:
@@ -1989,7 +1989,7 @@ class MetamerCTF(Metamer):
         ...     po.data.fetch_data("example_metamerCTF_ps-cuda.pt"), map_location="cpu"
         ... )
         >>> print(met.metamer)
-        tensor([[[[0.3016, ...]]]], dtype=torch.float64, requires_grad=True)
+        tensor([[[[0.1421, ...]]]], dtype=torch.float64, requires_grad=True)
 
         Loading and saving must both be done with ``MetamerCTF``:
 

--- a/src/plenoptic/tools/optim.py
+++ b/src/plenoptic/tools/optim.py
@@ -439,9 +439,9 @@ def portilla_simoncelli_loss_factory(
     >>> model = po.simul.PortillaSimoncelli(img.shape[-2:])
     >>> loss = po.tools.optim.portilla_simoncelli_loss_factory(model, img)
     >>> loss(model(img), model(img2))
-    tensor(31.9155)
+    tensor(30.9390)
     >>> po.tools.optim.l2_norm(model(img), model(img2))
-    tensor(31.5433)
+    tensor(30.5549)
 
     Use the loss function for metamer synthesis.
 
@@ -469,7 +469,7 @@ def portilla_simoncelli_loss_factory(
     ...     model, img, reweighting_dict
     ... )
     >>> loss(model(img), model(img2))
-    tensor(35.9753)
+    tensor(35.1118)
 
     Use ``reweighting_dict`` to include min/max in the loss and increase the importance
     of the standard deviations of the magnitude bands.
@@ -485,7 +485,7 @@ def portilla_simoncelli_loss_factory(
     ...     model, img, reweighting_dict
     ... )
     >>> loss(model(img), model(img2))
-    tensor(251.5188)
+    tensor(251.3967)
     """
     if reweighting_dict is None:
         reweighting_dict = {}

--- a/src/plenoptic/tools/optim.py
+++ b/src/plenoptic/tools/optim.py
@@ -484,8 +484,8 @@ def portilla_simoncelli_loss_factory(
     >>> loss = po.tools.optim.portilla_simoncelli_loss_factory(
     ...     model, img, reweighting_dict
     ... )
-    >>> loss(model(img), model(img2))
-    tensor(251.3967)
+    >>> loss(model(img), model(img2)).item()
+    251.396...
     """
     if reweighting_dict is None:
         reweighting_dict = {}

--- a/src/plenoptic/tools/optim.py
+++ b/src/plenoptic/tools/optim.py
@@ -477,15 +477,15 @@ def portilla_simoncelli_loss_factory(
     >>> import plenoptic as po
     >>> import torch
     >>> po.tools.set_seed(0)
-    >>> img = po.data.einstein()
+    >>> img = po.data.einstein().to(torch.float64)
     >>> img2 = torch.rand_like(img)
     >>> model = po.simul.PortillaSimoncelli(img.shape[-2:])
     >>> reweighting_dict = {"pixel_statistics": 1, "magnitude_std": 100}
     >>> loss = po.tools.optim.portilla_simoncelli_loss_factory(
     ...     model, img, reweighting_dict
     ... )
-    >>> loss(model(img), model(img2)).item()
-    251.396...
+    >>> loss(model(img), model(img2))
+    tensor(253.2572, dtype=torch.float64)
     """
     if reweighting_dict is None:
         reweighting_dict = {}

--- a/tests/test_uploaded_files.py
+++ b/tests/test_uploaded_files.py
@@ -72,7 +72,7 @@ class PortillaSimoncelliRemove(po.simul.PortillaSimoncelli):
         im_shape,
         remove_keys,
     ):
-        super().__init__(im_shape, n_scales=4, n_orientations=4, spatial_corr_width=9)
+        super().__init__(im_shape, n_scales=4, n_orientations=4, spatial_corr_width=7)
         self.remove_keys = remove_keys
 
     def forward(self, image, scales=None):
@@ -134,11 +134,11 @@ class PortillaSimoncelliMask(po.simul.PortillaSimoncelli):
         im_shape,
         n_scales=4,
         n_orientations=4,
-        spatial_corr_width=9,
+        spatial_corr_width=7,
         mask=None,
         target=None,
     ):
-        super().__init__(im_shape, n_scales=4, n_orientations=4, spatial_corr_width=9)
+        super().__init__(im_shape, n_scales=4, n_orientations=4, spatial_corr_width=7)
         self.mask = mask
         self.target = target
 


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

This  PR changes the default `spatial_corr_width` argument for the `PortillaSimoncelli` model to 7 (from our current value of 9), which matches the value used in the original paper to generate the figures. See #387 for discussion.

**Link any related issues, discussions, PRs**

Closes #387

**Describe changes**

- Changes default value
- Adds `versionchanged` to docstring informing users of this change
- Updates docs and `test_uploaded_files.py` to use 7 instead of 9
- The only place where I'm specifically still using 9 is the existing `test_models::TestPortillaSimoncelli::test_ps_synthesis` test, which is a regression test of PS metamer synthesis using `MetamerCTF` and `Adam`. The more up-to-date regression tests, in `test_uploaded_files.py` are the ones we use in the docs and have been updated.

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
