### PR TITLE
Fix apidocs linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,9 +81,8 @@ repos:
     - id: check-api-docs
       language: system
       name: Ensure all public functions / classes are included in API docs
-      types_or: ["markdown"]
       entry: python linting/check_apidocs.py
-      files: ^docs/tutorials
+      always_run: true
     - id: check-inline
       language: python
       name: Check for matplotlib inline directive in md notebooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,7 @@ repos:
       name: Ensure all public functions / classes are included in API docs
       entry: python linting/check_apidocs.py
       always_run: true
+      pass_filenames: false
     - id: check-inline
       language: python
       name: Check for matplotlib inline directive in md notebooks

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 See our [documentation site](https://docs.plenoptic.org) for more details,
 including how to get started!
 
-> [!WARNING] 
+> [!WARNING]
 > Breaking API Changes!
 >
 > Plenoptic 2.0 introduces breaking changes to the API and will not work with code written to work with earlier versions! See the [documentation](https://docs.plenoptic.org/docs/branch/main/reference/migration_guide.html) for details, including a script to update your code.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ See our [documentation site](https://docs.plenoptic.org) for more details,
 including how to get started!
 
 > [!WARNING] Breaking API Changes!
->
 > Plenoptic 2.0 introduces breaking changes to the API and will not work with code written to work with earlier versions! See the [documentation](https://docs.plenoptic.org/docs/branch/main/reference/migration_guide.html) for details, including a script to update your code.
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@
 See our [documentation site](https://docs.plenoptic.org) for more details,
 including how to get started!
 
-> [!WARNING] Breaking API Changes!
+> [!WARNING] 
+> Breaking API Changes!
+>
 > Plenoptic 2.0 introduces breaking changes to the API and will not work with code written to work with earlier versions! See the [documentation](https://docs.plenoptic.org/docs/branch/main/reference/migration_guide.html) for details, including a script to update your code.
 
 ### Installation

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -13,7 +13,7 @@ If you are unfamiliar with python environment management, we recommend [](conda)
 
 `plenoptic` is built on top of [pytorch](https://pytorch.org/), which we use for automatic differentiation. `plenoptic` is thus compatible with any valid pytorch model (see [](models-doc) for more details).
 
-`plenoptic` is also built on top of [pyrtools](https://pyrtools.readthedocs.io/en/latest/). `pyrtools` includes `numpy` implementations of the {ref}`pyramids-api` [image pyramids](https://docs.plenoptic.org/docs/branch/main/api/components.html) found in plenoptic, as well as other image-processing tools.
+`plenoptic` is also built on top of [pyrtools](https://pyrtools.readthedocs.io/en/latest/). `pyrtools` includes `numpy` implementations of the [image pyramids](pyramids-api) found in plenoptic, as well as other image-processing tools.
 
 (conda)=
 ## Installing with conda

--- a/linting/check_apidocs.py
+++ b/linting/check_apidocs.py
@@ -2,7 +2,6 @@
 
 import pathlib
 import re
-import subprocess
 import sys
 
 # These are the files whose contents we don't want in the api docs. that's __init__.py
@@ -15,20 +14,42 @@ src_modules = [m for m in src_modules if m.name not in EXCLUDE_MODULES]
 # underscore)
 src_pattern = re.compile(r"^(?:def|class) ([A-Za-z].*)\(", flags=re.MULTILINE)
 
-# generate all the stub files
-rst_files = [str(f) for f in pathlib.Path("docs/api").glob("*rst")]
-subprocess.run(["sphinx-autogen", *rst_files])
 
 match_dict = {}
-stub_files = pathlib.Path("docs/api/generated").glob("*.rst")
-for f in stub_files:
-    name = f.stem.split(".")
-    mod = ".".join(name[:-1])
-    obj = name[-1]
-    if mod not in match_dict:
-        match_dict[mod] = [obj]
-    else:
-        match_dict[mod].append(obj)
+autosummary_files = pathlib.Path("docs/api").glob("*.rst")
+for f in autosummary_files:
+    if f.stem == "index":
+        continue
+    txt = f.read_text().splitlines()
+    current_module = ""
+    autosummary_idx = None
+    for i, line in enumerate(txt):
+        if "currentmodule" in line:
+            current_module = line.split("::")[-1].strip()
+        elif "autosummary" in line:
+            if line != ".. autosummary::":
+                raise ValueError(
+                    "Don't know how to handle autosummary with indentation!"
+                )
+            autosummary_idx = i
+        elif line:
+            # first lines after autosummary will be :toctree: and maybe :signatures:
+            if autosummary_idx is None or line.strip()[0] == ":":
+                continue
+            elif line[0] != " ":
+                autosummary_idx = None
+            else:
+                if line[:3] != "   ":
+                    raise ValueError("Unsure how to think about this indenting!")
+                line = line.strip().replace("~", "")
+                object = f"{current_module}.{line}"
+                mod = ".".join(object.split(".")[:-1])
+                object = object.split(".")[-1]
+                if mod in match_dict:
+                    match_dict[mod].append(object)
+                else:
+                    match_dict[mod] = [object]
+
 
 src_not_api = []
 for module in src_modules:


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

During #418, realized that I had forgotten to add `validate_penalty` to the public api docs, which should be caught by my `linting/check_apidocs.py`. realized that it needs to be set to run every time, without passing it any file names. This required changing how the code works, so it doesn't need to run sphinx to generate the autodoc stub files (which would require plenoptic to be installed). 

instead we do some really basic parsing of the autosummary files in `docs/api` to grab the function names.

Additionally, corrects the formatting for readme warning.


**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
