### PR TITLE
Fix pypi icon

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -159,6 +159,7 @@ html_theme_options = {
             "name": "PyPI",
             "url": "https://pypi.org/project/plenoptic",
             "icon": "fa-custom fa-pypi",
+            "type": "fontawesome",
         },
     ],
     "logo": {
@@ -189,7 +190,7 @@ html_theme_options = {
 # Path for static files (custom stylesheets or JavaScript)
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
-html_js_files = ["custom-icon.js"]
+html_js_files = [("custom-icon.js", {"defer": "defer"})]
 
 # -- Options for HTMLHelp output ---------------------------------------------
 


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

Talking with Edoardo, I realized the pypi icon wasn't rendering in the online documentation (it's supposed to be in the top-right, next to the Github one), even though it was rendering locally.

Looking back into the pydata-sphinx theme, I came across [this part of their user guide](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/header-links.html#svg-image-icons), which included a couple extra steps I hadn't followed in order to make the custom icons work. In particular, adding the `defer` attribute, which is required starting in with `pydata-sphinx-theme>=0.17` (my local version is `0.16.1`).

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
