### PR TITLE
Adds Pytest teardown to close figures

### DIFF
--- a/linting/check_apidocs.py
+++ b/linting/check_apidocs.py
@@ -6,7 +6,13 @@ import sys
 
 # These are the files whose contents we don't want in the api docs. that's __init__.py
 # and those whose contents are meant for internal use
-EXCLUDE_MODULES = ["__init__.py", "autodiff.py", "synthesis.py", "classes.py"]
+EXCLUDE_MODULES = [
+    "__init__.py",
+    "autodiff.py",
+    "synthesis.py",
+    "classes.py",
+    "conftest.py",
+]
 
 src_modules = pathlib.Path("src/plenoptic").glob("**/*.py")
 src_modules = [m for m in src_modules if m.name not in EXCLUDE_MODULES]

--- a/src/plenoptic/conftest.py
+++ b/src/plenoptic/conftest.py
@@ -1,0 +1,27 @@
+"""
+Configuration for pytest to apply to all doctests.
+
+Realized this was the solution when reading docs about doctest_namespace fixture
+(https://docs.pytest.org/en/stable/how-to/doctest.html#doctest-namespace), which says
+that: "Note that like the normal conftest.py, the fixtures are discovered in the
+directory tree conftest is in. Meaning that if you put your doctest with your source
+code, the relevant conftest.py needs to be in the same directory tree. Fixtures will not
+be discovered in a sibling directory tree!" Thus, this has to live here in order to
+affect doctests.
+"""
+
+import matplotlib.pyplot as plt
+import pytest
+
+
+# following https://github.com/scverse/scanpy/issues/1662
+@pytest.fixture(autouse=True)
+def close_figures_on_teardown():
+    """
+    Close figures when exiting from doctests.
+
+    Note that this won't close between tests in a given docstring, but it will close
+    between docstrings.
+    """  # numpydoc ignore=YD01
+    yield
+    plt.close("all")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -18,6 +18,13 @@ mpl.rcParams["animation.writer"] = "html"
 mpl.use("agg")
 
 
+# following https://github.com/scverse/scanpy/issues/1662
+@pytest.fixture(autouse=True)
+def close_figures_on_teardown():
+    yield
+    plt.close("all")
+
+
 class TestDisplay:
     def test_update_plot_line(self):
         x = np.linspace(0, 100)
@@ -32,7 +39,6 @@ class TestDisplay:
         _, ax_y = ax.lines[0].get_data()
         if not np.allclose(ax_y, y2):
             raise Exception("Didn't update line correctly!")
-        plt.close(fig)
 
     @pytest.mark.parametrize("how", ["dict", "tensor"])
     def test_update_plot_line_multi_axes(self, how):
@@ -57,7 +63,6 @@ class TestDisplay:
 
             if not np.allclose(ax_y, po.to_numpy(y_check)):
                 raise Exception("Didn't update line correctly!")
-        plt.close(fig)
 
     @pytest.mark.parametrize(
         "model", ["frontend.LinearNonlinear.nograd"], indirect=True
@@ -77,7 +82,6 @@ class TestDisplay:
                 data=model(einstein_img), ax=ax, figsize=figsize
             )
             fig = axes[0].figure
-        plt.close(fig)
 
     @pytest.mark.parametrize("how", ["dict-single", "dict-multi", "tensor"])
     def test_update_plot_line_multi_channel(self, how):
@@ -110,7 +114,6 @@ class TestDisplay:
                 y_check = {0: y2[0], 1: y1[1]}[i]
             if not np.allclose(ax_y, po.to_numpy(y_check)):
                 raise Exception("Didn't update line correctly!")
-        plt.close(fig)
 
     def test_update_plot_stem(self):
         x = np.linspace(0, 100)
@@ -125,7 +128,6 @@ class TestDisplay:
         ax_y = ax.containers[0].markerline.get_ydata()
         if not np.allclose(ax_y, y2):
             raise Exception("Didn't update stems correctly!")
-        plt.close(fig)
 
     @pytest.mark.parametrize("how", ["dict", "tensor"])
     def test_update_plot_stem_multi_axes(self, how):
@@ -150,7 +152,6 @@ class TestDisplay:
 
             if not np.allclose(ax_y, po.to_numpy(y_check)):
                 raise Exception("Didn't update stem correctly!")
-        plt.close(fig)
 
     @pytest.mark.parametrize("how", ["dict-single", "dict-multi", "tensor"])
     def test_update_plot_stem_multi_channel(self, how):
@@ -183,7 +184,6 @@ class TestDisplay:
                 y_check = {0: y2[0], 1: y1[1]}[i]
             if not np.allclose(ax_y, po.to_numpy(y_check)):
                 raise Exception("Didn't update stem correctly!")
-        plt.close(fig)
 
     def test_update_plot_image(self):
         y1 = np.random.rand(1, 1, 100, 100)
@@ -195,7 +195,6 @@ class TestDisplay:
         ax_y = ax.images[0].get_array().data
         if not np.allclose(ax_y, y2):
             raise Exception("Didn't update image correctly!")
-        plt.close(fig)
 
     @pytest.mark.parametrize("how", ["dict", "tensor"])
     def test_update_plot_image_multi_axes(self, how):
@@ -218,7 +217,6 @@ class TestDisplay:
 
             if not np.allclose(ax_y, po.to_numpy(y_check)):
                 raise Exception("Didn't update image correctly!")
-        plt.close(fig)
 
     def test_update_plot_scatter(self):
         x1 = np.random.rand(100)
@@ -235,7 +233,6 @@ class TestDisplay:
         ax_data = ax.collections[0].get_offsets()
         if not np.allclose(ax_data, po.to_numpy(data)):
             raise Exception("Didn't update points of the scatter plot correctly!")
-        plt.close(fig)
 
     @pytest.mark.parametrize("how", ["dict", "tensor"])
     def test_update_plot_scatter_multi_axes(self, how):
@@ -273,7 +270,6 @@ class TestDisplay:
 
             if not np.allclose(ax_data, po.to_numpy(data_check)):
                 raise Exception("Didn't update points of the scatter plot correctly!")
-        plt.close(fig)
 
     @pytest.mark.parametrize("how", ["dict-single", "dict-multi", "tensor"])
     def test_update_plot_scatter_multi_channel(self, how):
@@ -367,7 +363,6 @@ class TestDisplay:
                 _, ax_data = ax.lines[0].get_data()
             if not np.allclose(ax_data, po.to_numpy(data[i])):
                 raise Exception("Didn't update points of the scatter plot correctly!")
-        plt.close(fig)
 
     @pytest.mark.parametrize("as_rgb", [True, False])
     @pytest.mark.parametrize("channel_idx", [None, 0, [0, 1]])
@@ -454,7 +449,6 @@ class TestDisplay:
                 f"Created {len(fig.axes)} axes, but expected {n_axes}!"
                 " Probably plotting color as grayscale or vice versa"
             )
-            plt.close(fig)
 
     @pytest.mark.parametrize("channel_idx", [None, 0, [0, 1]])
     @pytest.mark.parametrize("batch_idx", [None, 0, [0, 1]])
@@ -498,7 +492,6 @@ class TestDisplay:
             axes = [ax for ax in fig.axes if ax.images]
             if len(axes) != n_axes:
                 raise Exception(f"Created {len(fig.axes)} axes, but expected {n_axes}!")
-            plt.close(fig)
 
     def test_display_test_signals(self, basic_stim):
         po.plot.imshow(basic_stim)
@@ -580,7 +573,6 @@ class TestDisplay:
                 f"Created {len(fig.axes)} axes, but expected {n_axes}!"
                 " Probably plotting color as grayscale or vice versa"
             )
-            plt.close(fig)
 
     def test_update_plot_shape_fail(self, einstein_img):
         # update_plot expects 3 or 4d data -- this checks that update_plot
@@ -639,7 +631,6 @@ class TestDisplay:
                     f"Zoom didn't work as expected, expected {zoom} but"
                     f" got {zoom_title}!"
                 )
-            plt.close(fig)
 
 
 def template_test_synthesis_all_plot(
@@ -704,7 +695,6 @@ def template_test_synthesis_all_plot(
         **plot_kwargs,
         width_ratios=width_ratios,
     )
-    plt.close(fig)
 
 
 def template_test_synthesis_custom_fig(synthesis_object, func, fig_creation, tmp_path):
@@ -754,7 +744,6 @@ def template_test_synthesis_custom_fig(synthesis_object, func, fig_creation, tmp
             included_plots=included_plots,
             **plot_kwargs,
         ).save(path)
-    plt.close(fig)
 
 
 class TestMADDisplay:
@@ -899,7 +888,6 @@ class TestMADDisplay:
         elif func == "image":
             func = po.plot.mad_imshow_all
         fig = func(*all_mad)
-        plt.close(fig)
 
     @pytest.mark.parametrize("func", ["plot", "animate"])
     # metamer_representation_error is an allowed value for metamer, but not MAD.
@@ -924,7 +912,6 @@ class TestMADDisplay:
             kwargs["axes_idx"] = {val: 0, "mad_loss": 1}
         with pytest.raises(ValueError, match=f"{variable} contained value"):
             func(synthesized_mad, **kwargs)
-        plt.close()
 
     @pytest.mark.parametrize("iteration", [None, 0, -1, -10, 10, 2, 3, 4])
     @pytest.mark.parametrize("batch_idx", [0, 1])
@@ -956,7 +943,6 @@ class TestMADDisplay:
                 included_plots=included_plots,
             )
             axes_img = fig.axes[0].images[0].get_array().data
-            plt.close(fig)
             img = synthesized_mad_store_progress.saved_mad_image[mad_iter, batch_idx]
             img = einops.rearrange(po.to_numpy(img), "c h w -> h w c").squeeze()
             # rgb images are clipped while plotting
@@ -1182,7 +1168,6 @@ class TestMetamerDisplay:
             kwargs["axes_idx"] = {val: 0, "metamer_loss": 1}
         with pytest.raises(ValueError, match=f"{variable} contained value"):
             func(synthesized_met, **kwargs)
-        plt.close()
 
     @pytest.mark.parametrize("iteration", [None, 0, -1, -10, 10, 2, 3, 4])
     @pytest.mark.parametrize("batch_idx", [0, 1])
@@ -1211,7 +1196,6 @@ class TestMetamerDisplay:
                 included_plots=included_plots,
             )
             axes_img = fig.axes[0].images[0].get_array().data
-            plt.close(fig)
             img = synthesized_met_store_progress.saved_metamer[met_iter, batch_idx]
             img = einops.rearrange(po.to_numpy(img), "c h w -> h w c").squeeze()
             # rgb images are clipped while plotting

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -81,7 +81,7 @@ class TestDisplay:
             axes = po.plot.plot_representation(
                 data=model(einstein_img), ax=ax, figsize=figsize
             )
-            fig = axes[0].figure
+            axes[0].figure
 
     @pytest.mark.parametrize("how", ["dict-single", "dict-multi", "tensor"])
     def test_update_plot_line_multi_channel(self, how):
@@ -887,7 +887,7 @@ class TestMADDisplay:
             func = po.plot.mad_loss_all
         elif func == "image":
             func = po.plot.mad_imshow_all
-        fig = func(*all_mad)
+        func(*all_mad)
 
     @pytest.mark.parametrize("func", ["plot", "animate"])
     # metamer_representation_error is an allowed value for metamer, but not MAD.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -102,6 +102,7 @@ def close_figures_on_teardown():
     yield
     plt.close("all")
 
+
 class TestNonLinearities:
     def test_rectangular_to_polar_dict(self, basic_stim):
         spc = po.process.SteerablePyramidFreq(
@@ -1009,7 +1010,9 @@ class TestPortillaSimoncelli:
 
     @pytest.mark.parametrize("figsize", [None, (5, 5), (5.0, 5.0), (10, 5)])
     @pytest.mark.parametrize("ax", [False, True])
-    def test_plot_representation_figsize(self, figsize, ax, einstein_img, close_figures_on_teardown):
+    def test_plot_representation_figsize(
+        self, figsize, ax, einstein_img, close_figures_on_teardown
+    ):
         expectation = does_not_raise()
         if ax:
             fig, ax = plt.subplots(1, 1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -96,6 +96,12 @@ def test_validate_model(model):
     po.validate.validate_model(model, device=DEVICE, image_shape=(1, 1, 256, 256))
 
 
+# following https://github.com/scverse/scanpy/issues/1662
+@pytest.fixture
+def close_figures_on_teardown():
+    yield
+    plt.close("all")
+
 class TestNonLinearities:
     def test_rectangular_to_polar_dict(self, basic_stim):
         spc = po.process.SteerablePyramidFreq(
@@ -249,9 +255,8 @@ class TestFrontEnd:
             )
 
     @pytest.mark.parametrize("model", all_models, indirect=True)
-    def test_frontend_display_filters(self, model):
+    def test_frontend_display_filters(self, model, close_figures_on_teardown):
         fig = model.display_filters()
-        plt.close(fig)
 
     @pytest.mark.parametrize("mdl", all_models)
     def test_kernel_size(self, mdl, einstein_img):
@@ -989,6 +994,7 @@ class TestPortillaSimoncelli:
         n_orientations,
         spatial_corr_width,
         einstein_img,
+        close_figures_on_teardown,
     ):
         model = po.models.PortillaSimoncelli(
             einstein_img.shape[-2:],
@@ -1000,11 +1006,10 @@ class TestPortillaSimoncelli:
             model(einstein_img.repeat((*batch_channel, 1, 1))),
             title="Representation",
         )
-        plt.close(fig)
 
     @pytest.mark.parametrize("figsize", [None, (5, 5), (5.0, 5.0), (10, 5)])
     @pytest.mark.parametrize("ax", [False, True])
-    def test_plot_representation_figsize(self, figsize, ax, einstein_img):
+    def test_plot_representation_figsize(self, figsize, ax, einstein_img, close_figures_on_teardown):
         expectation = does_not_raise()
         if ax:
             fig, ax = plt.subplots(1, 1)
@@ -1022,9 +1027,8 @@ class TestPortillaSimoncelli:
                 figsize=figsize,
                 ax=ax,
             )
-        plt.close(fig)
 
-    def test_update_plot(self, einstein_img):
+    def test_update_plot(self, einstein_img, close_figures_on_teardown):
         model = po.models.PortillaSimoncelli(
             einstein_img.shape[-2:],
         ).to(DEVICE)
@@ -1035,7 +1039,6 @@ class TestPortillaSimoncelli:
         updated_y = artists[0].get_ydata()
         if np.equal(orig_y, updated_y).all():
             raise ValueError("Update plot didn't run successfully!")
-        plt.close(fig)
 
     @pytest.mark.parametrize("batch_channel", [(1, 1), (1, 3), (2, 1), (2, 3)])
     @pytest.mark.parametrize("n_scales", [1, 2, 3, 4])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -102,6 +102,7 @@ def close_figures_on_teardown():
     yield
     plt.close("all")
 
+
 class TestNonLinearities:
     def test_rectangular_to_polar_dict(self, basic_stim):
         spc = po.process.SteerablePyramidFreq(
@@ -256,7 +257,7 @@ class TestFrontEnd:
 
     @pytest.mark.parametrize("model", all_models, indirect=True)
     def test_frontend_display_filters(self, model, close_figures_on_teardown):
-        fig = model.display_filters()
+        model.display_filters()
 
     @pytest.mark.parametrize("mdl", all_models)
     def test_kernel_size(self, mdl, einstein_img):
@@ -1009,7 +1010,9 @@ class TestPortillaSimoncelli:
 
     @pytest.mark.parametrize("figsize", [None, (5, 5), (5.0, 5.0), (10, 5)])
     @pytest.mark.parametrize("ax", [False, True])
-    def test_plot_representation_figsize(self, figsize, ax, einstein_img, close_figures_on_teardown):
+    def test_plot_representation_figsize(
+        self, figsize, ax, einstein_img, close_figures_on_teardown
+    ):
         expectation = does_not_raise()
         if ax:
             fig, ax = plt.subplots(1, 1)


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

This PR adds [pytest fixtures](https://docs.pytest.org/en/stable/how-to/fixtures.html#teardown-cleanup-aka-fixture-finalization) so we can use them as a teardown to run after tests that create plots. This way we can close tests correctly (no matter how the test ends) and automatically (so we don't have to remember to add it to each test).

Also figured this out for doctests, where the proper thing to do is to add a `conftest.py` to the same directory tree as the doctests, i.e., the `src/` folder. (See [docs](https://docs.pytest.org/en/stable/how-to/doctest.html#doctest-namespace-fixture)).

I have added the teardown:
- to all doctests (with autouse)
- to all tests in `tests/test_display` (with autouse)
- to a select few tests in `tests/test_models` (without autouse, needs to be individually activated)

I could've just put it in `test/conftest.py` and automatically applied it to all tests, but the overwhelming majority of our tests don't create matplotlib figures, so that seems like overkill.

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
