### PR TITLE
Update pooch version, remove filterwarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "scikit-image>=0.15.0",
     "einops>=0.3.0",
     "importlib-resources>=6.0",
-    "pooch>=1.2.0",
+    # for updated tarfile behavior, https://github.com/plenoptic-org/plenoptic/issues/336
+    "pooch>=1.9.0",
     "lazy_loader",
 ]
 
@@ -103,10 +104,6 @@ doctest_optionflags = "NORMALIZE_WHITESPACE NUMBER ELLIPSIS"
 # last matching option is performed."
 filterwarnings = [
     "error",
-    # pooch issue with python>=3.12, fixed in
-    # https://github.com/fatiando/pooch/pull/458 but not in release as of April
-    # 2025.
-    "ignore:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning",
     # seems to be necessary to solve https://github.com/pytest-dev/pytest-cov/issues/693
     "ignore:Failed to generate report:",
 ]


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

See #336: pooch finally made their release that fixes the tarfile behavior for more recent python versions. This removes the pytest filterwarning and increases the minimum pooch version.

**Link any related issues, discussions, PRs**

Closes #336 

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
