### PR TITLE
First basic example of batch of images using imshow

### DIFF
--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -234,6 +234,19 @@ def imshow(
     generally hold in notebooks as well, but will fail if, e.g., you plot an image
     that's 2000 pixels wide on an monitor 1000 pixels wide; the browser handles the
     rescaling in a way we can't control.
+
+    Examples
+    --------
+
+    .. plot::
+      :context: reset
+
+      >>> import plenoptic as po
+      >>> img_dir = po.data.fetch_data("test_images.tar.gz") / "256"
+      >>> titles = ["color_wheel", "curie", "einstein", "metal", "nuts"]
+      >>> imgs = po.load_images(img_dir)
+      >>> po.plot.imshow(imgs, title=titles)
+      <PyrFigure size ... with 5 Axes>
     """
     if not isinstance(image, list):
         image = [image]

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -249,14 +249,9 @@ def imshow(
       >>> po.plot.imshow(einstein)
       <PyrFigure size ... with 1 Axes>
 
-    For a batch of images, imshow will plot every image:
-
-    .. plot::
-      :context: close-figs
-
-      >>> import plenoptic as po
-      >>> po.plot.imshow([po.data.einstein(), po.data.curie()])
-      <PyrFigure size ... with 2 Axes>
+    For an image tensor with multiple elements along the batch dimension and a
+    single channel element, this function will plot each batch independently as
+    grayscale images:
 
     .. plot::
       :context: close-figs
@@ -269,7 +264,19 @@ def imshow(
       >>> po.plot.imshow(imgs)
       <PyrFigure size ... with 2 Axes>
 
-    Specifying batch_idx will limit the output to a single image:
+    A list of 4d tensors will be concatenated along the batch dimension before plotting.
+    Thus, the following example is the same as above:
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> po.plot.imshow([po.data.einstein(), po.data.curie()])
+      <PyrFigure size ... with 2 Axes>
+
+    You may use the ``title`` argument for any number of images, either as a string
+    applied to all images or as a list the length of images. Additionally, ``col_wrap``
+    specifies the number of images per row.
 
     .. plot::
       :context: close-figs
@@ -279,21 +286,26 @@ def imshow(
       >>> imgs = torch.cat([po.data.einstein(), po.data.curie()])
       >>> print(imgs.shape)
       torch.Size([2, 1, 256, 256])
-      >>> batch_idx = 1
-      >>> po.plot.imshow(imgs, batch_idx=batch_idx)
-      <PyrFigure size ... with 1 Axes>
+      >>> po.plot.imshow(imgs, title=["einstein", "curie"], col_wrap=1)
+      <PyrFigure size ... with 2 Axes>
 
-    The vrange flag will normalize image values independently or across all images.
-    Note the image ranges for each method.
+    Specifying ``batch_idx`` will plot the corresponding element in
+    the batch dimension (i.e., ``imgs[batch_idx]``)
 
     .. plot::
       :context: close-figs
 
       >>> import plenoptic as po
       >>> import torch
-      >>> imgs = torch.cat([po.data.einstein(), po.data.einstein() * 2])
-      >>> po.plot.imshow(imgs, vrange="indep1")
-      <PyrFigure size ... with 2 Axes>
+      >>> imgs = torch.cat([po.data.einstein(), po.data.curie()])
+      >>> print(imgs.shape)
+      torch.Size([2, 1, 256, 256])
+      >>> po.plot.imshow(imgs, batch_idx=1)
+      <PyrFigure size ... with 1 Axes>
+
+    The vrange argument allows control over the min and max values of the color range.
+    In addition to a 2-tuple of labels, plenoptic includes several special strings:
+    ``"auto1"`` sets all images to have the same range.
 
     .. plot::
       :context: close-figs
@@ -304,14 +316,20 @@ def imshow(
       >>> po.plot.imshow(imgs, vrange="auto1")
       <PyrFigure size ... with 2 Axes>
 
-    Using zoom will up- or downscale the number of display pixels:
+    Meanwhile, ``"indep1"`` sets each image's range independently. Note the different
+    ranges in the titles!
 
     .. plot::
       :context: close-figs
 
       >>> import plenoptic as po
-      >>> po.plot.imshow(po.data.einstein())
-      <PyrFigure size ... with 1 Axes>
+      >>> import torch
+      >>> imgs = torch.cat([po.data.einstein(), po.data.einstein() * 2])
+      >>> po.plot.imshow(imgs, vrange="indep1")
+      <PyrFigure size ... with 2 Axes>
+
+    The ``zoom`` argument allows users to set the ratio of display to image pixels,
+    increasing or decreasing the size of the resulting plot:
 
     .. plot::
       :context: close-figs
@@ -320,7 +338,18 @@ def imshow(
       >>> po.plot.imshow(po.data.einstein(), zoom=0.5)
       <PyrFigure size ... with 1 Axes>
 
-    You can use the plot_complex flag for complex values:
+    If ``zoom<1`` and the value is not a divisor of the largest image size, it will
+    result in an error:
+
+    >>> import plenoptic as po
+    >>> print(po.data.einstein().shape)
+    torch.Size([1, 1, 256, 256])
+    >>> po.plot.imshow(po.data.einstein(), zoom=0.7)
+    Traceback (most recent call last):
+    Exception: zoom * signal.shape must result in integers!
+
+    You can use the ``plot_complex`` argument to control how complex tensors are
+    plotted:
 
     .. plot::
       :context: close-figs
@@ -329,28 +358,46 @@ def imshow(
       >>> import torch
       >>> img = po.data.einstein()
       >>> fft_img = torch.fft.fft2(img)
-      >>> po.plot.imshow([img, fft_img], plot_complex="polar")
+      >>> po.plot.imshow([img, fft_img], plot_complex="logpolar")
       <PyrFigure size ... with 3 Axes>
 
-    Value errors can occur if the as_rgb flag and image dimensions are misaligned:
+    To plot an RGB image, you must set ``as_rgb=True`` to plot a color image:
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> color_wheel = po.data.color_wheel()
+      >>> print(color_wheel.shape)
+      torch.Size([1, 3, 600, 600])
+      >>> po.plot.imshow(color_wheel, as_rgb=True)
+      <PyrFigure size ... with 1 Axes>
+
+    Otherwise, images with multiple channels will have each channel plotted as a
+    separate grayscale image:
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> color_wheel = po.data.color_wheel()
+      >>> print(color_wheel.shape)
+      torch.Size([1, 3, 600, 600])
+      >>> po.plot.imshow(color_wheel)
+      <PyrFigure size ... with 3 Axes>
+
+    Value errors can occur if ``as_rgb=True`` and the input image doesn't have the
+    required number of channels:
 
     >>> import plenoptic as po
     >>> einstein = po.data.einstein()
-    >>> einstein.shape
+    >>> print(einstein.shape)
     torch.Size([1, 1, 256, 256])
     >>> po.plot.imshow(einstein, as_rgb=True)
     Traceback (most recent call last):
     ValueError: If as_rgb is True, then channel must have 3 or 4 elements!
 
-    >>> import plenoptic as po
-    >>> img = torch.cat([po.data.color_wheel(), po.data.color_wheel()])
-    >>> print(img.shape)
-    torch.Size([2, 3, 600, 600])
-    >>> po.plot.imshow(img)
-    Traceback (most recent call last):
-    ValueError: Don't know how to plot non-rgb images with more than one channel and ...
-
-    Images will automatically rescaled to be displayed at the same height and widths
+    Images will be automatically rescaled to be displayed at the same heights and widths
     if sizes are scalar multiples of each other:
 
     .. plot::

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -259,7 +259,7 @@ def imshow(
       >>> titles = ["color_wheel", "curie", "einstein", "metal", "nuts"]
       >>> imgs = po.load_images(img_dir)
       >>> print(imgs.shape)
-      torch.Size([5, 3, 256, 256])
+      torch.Size([5, 1, 256, 256])
       >>> po.plot.imshow(imgs, title=titles)
       <PyrFigure size ... with 5 Axes>
 
@@ -271,8 +271,33 @@ def imshow(
       >>> titles = ["color_wheel", "curie", "einstein", "metal", "nuts"]
       >>> imgs = po.load_images(img_dir)
       >>> batch_idx = 2
-      >>> po.plot.imshow(imgs, title=titles[2], batch_idx=batch_idx)
+      >>> po.plot.imshow(imgs, title=titles[batch_idx], batch_idx=batch_idx)
       <PyrFigure size ... >
+
+    The vrange flag will normalize image values independently or across all images.
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> img_dir = po.data.fetch_data("test_images.tar.gz") / "256"
+      >>> titles = ["color_wheel", "curie", "einstein", "metal", "nuts"]
+      >>> imgs = po.load_images(img_dir)
+      >>> po.plot.imshow(imgs, title=titles, vrange="auto2")
+      <PyrFigure size ... with 5 Axes>
+
+    Value errors can occur if the as_rgb flag and image dimensions are misaligned.
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> einstein = po.data.einstein()
+      >>> einstein.shape
+      torch.Size([1, 1, 256, 256])
+      >>> po.plot.imshow(einstein, as_rgb=True)
+      Traceback (most recent call last):
+      ValueError: If as_rgb is True, then channel must have 3 or 4 elements!
     """
     if not isinstance(image, list):
         image = [image]

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -256,9 +256,9 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
       >>> import torch
-      >>> imgs = torch.cat([po.data.einstein(), po.data.curie()])
+      >>> curie = po.data.curie()
+      >>> imgs = torch.cat([einstein, curie])
       >>> print(imgs.shape)
       torch.Size([2, 1, 256, 256])
       >>> po.plot.imshow(imgs)
@@ -270,8 +270,7 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
-      >>> po.plot.imshow([po.data.einstein(), po.data.curie()])
+      >>> po.plot.imshow([einstein, curie])
       <PyrFigure size ... with 2 Axes>
 
     You may use the ``title`` argument for any number of images, either as a string
@@ -281,11 +280,6 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
-      >>> import torch
-      >>> imgs = torch.cat([po.data.einstein(), po.data.curie()])
-      >>> print(imgs.shape)
-      torch.Size([2, 1, 256, 256])
       >>> po.plot.imshow(imgs, title=["einstein", "curie"], col_wrap=1)
       <PyrFigure size ... with 2 Axes>
 
@@ -295,25 +289,20 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
-      >>> import torch
-      >>> imgs = torch.cat([po.data.einstein(), po.data.curie()])
       >>> print(imgs.shape)
       torch.Size([2, 1, 256, 256])
       >>> po.plot.imshow(imgs, batch_idx=1)
       <PyrFigure size ... with 1 Axes>
 
     The vrange argument allows control over the min and max values of the color range.
-    In addition to a 2-tuple of labels, plenoptic includes several special strings:
+    In addition to a 2-tuple of floats, this functions accepts several special strings:
     ``"auto1"`` sets all images to have the same range.
 
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
-      >>> import torch
-      >>> imgs = torch.cat([po.data.einstein(), po.data.einstein() * 2])
-      >>> po.plot.imshow(imgs, vrange="auto1")
+      >>> einsteins_scaled = torch.cat([einstein, einstein * 2])
+      >>> po.plot.imshow(einsteins_scaled, vrange="auto1")
       <PyrFigure size ... with 2 Axes>
 
     Meanwhile, ``"indep1"`` sets each image's range independently. Note the different
@@ -322,10 +311,7 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
-      >>> import torch
-      >>> imgs = torch.cat([po.data.einstein(), po.data.einstein() * 2])
-      >>> po.plot.imshow(imgs, vrange="indep1")
+      >>> po.plot.imshow(einsteins_scaled, vrange="indep1")
       <PyrFigure size ... with 2 Axes>
 
     The ``zoom`` argument allows users to set the ratio of display to image pixels,
@@ -334,17 +320,15 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
-      >>> po.plot.imshow(po.data.einstein(), zoom=0.5)
+      >>> po.plot.imshow(einstein, zoom=0.5)
       <PyrFigure size ... with 1 Axes>
 
-    If ``zoom<1`` and the value is not a divisor of the largest image size, it will
-    result in an error:
+    If ``zoom<1`` and the value is not a divisor of the largest image size, this
+    function will raise an error:
 
-    >>> import plenoptic as po
-    >>> print(po.data.einstein().shape)
+    >>> print(einstein.shape)
     torch.Size([1, 1, 256, 256])
-    >>> po.plot.imshow(po.data.einstein(), zoom=0.7)
+    >>> po.plot.imshow(einstein, zoom=0.7)
     Traceback (most recent call last):
     Exception: zoom * signal.shape must result in integers!
 
@@ -354,11 +338,8 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
-      >>> import torch
-      >>> img = po.data.einstein()
-      >>> fft_img = torch.fft.fft2(img)
-      >>> po.plot.imshow([img, fft_img], plot_complex="logpolar")
+      >>> einstein_fft = torch.fft.fft2(einstein)
+      >>> po.plot.imshow([einstein, einstein_fft], plot_complex="logpolar")
       <PyrFigure size ... with 3 Axes>
 
     To plot an RGB image, you must set ``as_rgb=True`` to plot a color image:
@@ -366,11 +347,10 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
       >>> color_wheel = po.data.color_wheel()
       >>> print(color_wheel.shape)
       torch.Size([1, 3, 600, 600])
-      >>> po.plot.imshow(color_wheel, as_rgb=True)
+      >>> po.plot.imshow(color_wheel, as_rgb=True, zoom=0.5)
       <PyrFigure size ... with 1 Axes>
 
     Otherwise, images with multiple channels will have each channel plotted as a
@@ -379,18 +359,12 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
-      >>> color_wheel = po.data.color_wheel()
-      >>> print(color_wheel.shape)
-      torch.Size([1, 3, 600, 600])
-      >>> po.plot.imshow(color_wheel)
+      >>> po.plot.imshow(color_wheel, zoom=0.5, title=["R", "G", "B"])
       <PyrFigure size ... with 3 Axes>
 
-    Value errors can occur if ``as_rgb=True`` and the input image doesn't have the
-    required number of channels:
+    This function will raise a ``ValueError`` if ``as_rgb=True`` and the input image
+    doesn't have the required number of channels:
 
-    >>> import plenoptic as po
-    >>> einstein = po.data.einstein()
     >>> print(einstein.shape)
     torch.Size([1, 1, 256, 256])
     >>> po.plot.imshow(einstein, as_rgb=True)
@@ -403,10 +377,8 @@ def imshow(
     .. plot::
       :context: close-figs
 
-      >>> import plenoptic as po
-      >>> img = po.data.einstein()
-      >>> crop_img = po.process.center_crop(img, 32)
-      >>> po.plot.imshow([img, crop_img])
+      >>> einstein_cropped = po.process.center_crop(einstein, 32)
+      >>> po.plot.imshow([einstein, einstein_cropped])
       <PyrFigure size ... with 2 Axes>
     """
     if not isinstance(image, list):

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -237,7 +237,7 @@ def imshow(
 
     Examples
     --------
-    Plot a single grayscale image.
+    Plot a single grayscale image:
 
     .. plot::
       :context: reset
@@ -247,57 +247,120 @@ def imshow(
       >>> einstein.shape
       torch.Size([1, 1, 256, 256])
       >>> po.plot.imshow(einstein)
-      <PyrFigure size ... >
+      <PyrFigure size ... with 1 Axes>
 
-    For a batch of images, imshow will plot every image unless batch_idx is specified.
+    For a batch of images, imshow will plot every image:
 
     .. plot::
       :context: close-figs
 
       >>> import plenoptic as po
-      >>> img_dir = po.data.fetch_data("test_images.tar.gz") / "256"
-      >>> titles = ["color_wheel", "curie", "einstein", "metal", "nuts"]
-      >>> imgs = po.load_images(img_dir)
+      >>> po.plot.imshow([po.data.einstein(), po.data.curie()])
+      <PyrFigure size ... with 2 Axes>
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> import torch
+      >>> imgs = torch.cat([po.data.einstein(), po.data.curie()])
       >>> print(imgs.shape)
-      torch.Size([5, 1, 256, 256])
-      >>> po.plot.imshow(imgs, title=titles)
-      <PyrFigure size ... with 5 Axes>
+      torch.Size([2, 1, 256, 256])
+      >>> po.plot.imshow(imgs)
+      <PyrFigure size ... with 2 Axes>
+
+    Specifying batch_idx will limit the output to a single image:
 
     .. plot::
       :context: close-figs
 
       >>> import plenoptic as po
-      >>> img_dir = po.data.fetch_data("test_images.tar.gz") / "256"
-      >>> titles = ["color_wheel", "curie", "einstein", "metal", "nuts"]
-      >>> imgs = po.load_images(img_dir)
-      >>> batch_idx = 2
-      >>> po.plot.imshow(imgs, title=titles[batch_idx], batch_idx=batch_idx)
-      <PyrFigure size ... >
+      >>> import torch
+      >>> imgs = torch.cat([po.data.einstein(), po.data.curie()])
+      >>> print(imgs.shape)
+      torch.Size([2, 1, 256, 256])
+      >>> batch_idx = 1
+      >>> po.plot.imshow(imgs, batch_idx=batch_idx)
+      <PyrFigure size ... with 1 Axes>
 
     The vrange flag will normalize image values independently or across all images.
+    Note the image ranges for each method.
 
     .. plot::
       :context: close-figs
 
       >>> import plenoptic as po
-      >>> img_dir = po.data.fetch_data("test_images.tar.gz") / "256"
-      >>> titles = ["color_wheel", "curie", "einstein", "metal", "nuts"]
-      >>> imgs = po.load_images(img_dir)
-      >>> po.plot.imshow(imgs, title=titles, vrange="auto2")
-      <PyrFigure size ... with 5 Axes>
-
-    Value errors can occur if the as_rgb flag and image dimensions are misaligned.
+      >>> import torch
+      >>> imgs = torch.cat([po.data.einstein(), po.data.einstein() * 2])
+      >>> po.plot.imshow(imgs, vrange="indep1")
+      <PyrFigure size ... with 2 Axes>
 
     .. plot::
       :context: close-figs
 
       >>> import plenoptic as po
-      >>> einstein = po.data.einstein()
-      >>> einstein.shape
-      torch.Size([1, 1, 256, 256])
-      >>> po.plot.imshow(einstein, as_rgb=True)
-      Traceback (most recent call last):
-      ValueError: If as_rgb is True, then channel must have 3 or 4 elements!
+      >>> import torch
+      >>> imgs = torch.cat([po.data.einstein(), po.data.einstein() * 2])
+      >>> po.plot.imshow(imgs, vrange="auto1")
+      <PyrFigure size ... with 2 Axes>
+
+    Using zoom will up- or downscale the number of display pixels:
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> po.plot.imshow(po.data.einstein())
+      <PyrFigure size ... with 1 Axes>
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> po.plot.imshow(po.data.einstein(), zoom=0.5)
+      <PyrFigure size ... with 1 Axes>
+
+    You can use the plot_complex flag for complex values:
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> import torch
+      >>> img = po.data.einstein()
+      >>> fft_img = torch.fft.fft2(img)
+      >>> po.plot.imshow([img, fft_img], plot_complex="polar")
+      <PyrFigure size ... with 3 Axes>
+
+    Value errors can occur if the as_rgb flag and image dimensions are misaligned:
+
+    >>> import plenoptic as po
+    >>> einstein = po.data.einstein()
+    >>> einstein.shape
+    torch.Size([1, 1, 256, 256])
+    >>> po.plot.imshow(einstein, as_rgb=True)
+    Traceback (most recent call last):
+    ValueError: If as_rgb is True, then channel must have 3 or 4 elements!
+
+    >>> import plenoptic as po
+    >>> img = torch.cat([po.data.color_wheel(), po.data.color_wheel()])
+    >>> print(img.shape)
+    torch.Size([2, 3, 600, 600])
+    >>> po.plot.imshow(img)
+    Traceback (most recent call last):
+    ValueError: Don't know how to plot non-rgb images with more than one channel and ...
+
+    Images will automatically rescaled to be displayed at the same height and widths
+    if sizes are scalar multiples of each other:
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> img = po.data.einstein()
+      >>> crop_img = po.process.center_crop(img, 32)
+      >>> po.plot.imshow([img, crop_img])
+      <PyrFigure size ... with 2 Axes>
     """
     if not isinstance(image, list):
         image = [image]

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -275,7 +275,7 @@ def imshow(
 
     You may use the ``title`` argument for any number of images, either as a string
     applied to all images or as a list the length of images. Additionally, ``col_wrap``
-    specifies the number of images per row.
+    specifies the number of images per row:
 
     .. plot::
       :context: close-figs
@@ -284,7 +284,7 @@ def imshow(
       <PyrFigure size ... with 2 Axes>
 
     Specifying ``batch_idx`` will plot the corresponding element in
-    the batch dimension (i.e., ``imgs[batch_idx]``)
+    the batch dimension (i.e., ``imgs[batch_idx]``):
 
     .. plot::
       :context: close-figs
@@ -295,8 +295,9 @@ def imshow(
       <PyrFigure size ... with 1 Axes>
 
     The vrange argument allows control over the min and max values of the color range.
-    In addition to a 2-tuple of floats, this functions accepts several special strings:
-    ``"auto1"`` sets all images to have the same range.
+    In addition to a 2-tuple of floats, this functions accepts several special strings
+    (see docstring for details). For example, ``"auto1"`` sets all images to have the
+    same range:
 
     .. plot::
       :context: close-figs
@@ -323,8 +324,8 @@ def imshow(
       >>> po.plot.imshow(einstein, zoom=0.5)
       <PyrFigure size ... with 1 Axes>
 
-    If ``zoom<1`` and the value is not a divisor of the largest image size, this
-    function will raise an error:
+    Note that if ``zoom<1`` and the value is not a divisor of the largest image size,
+    this function will raise an error:
 
     >>> print(einstein.shape)
     torch.Size([1, 1, 256, 256])
@@ -342,7 +343,7 @@ def imshow(
       >>> po.plot.imshow([einstein, einstein_fft], plot_complex="logpolar")
       <PyrFigure size ... with 3 Axes>
 
-    To plot an RGB image, you must set ``as_rgb=True`` to plot a color image:
+    To plot a RGB(A) image in color, you must set ``as_rgb=True``:
 
     .. plot::
       :context: close-figs

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -237,16 +237,42 @@ def imshow(
 
     Examples
     --------
+    Plot a single grayscale image.
 
     .. plot::
       :context: reset
 
       >>> import plenoptic as po
+      >>> einstein = po.data.einstein()
+      >>> einstein.shape
+      torch.Size([1, 1, 256, 256])
+      >>> po.plot.imshow(einstein)
+      <PyrFigure size ... >
+
+    For a batch of images, imshow will plot every image unless batch_idx is specified.
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
       >>> img_dir = po.data.fetch_data("test_images.tar.gz") / "256"
       >>> titles = ["color_wheel", "curie", "einstein", "metal", "nuts"]
       >>> imgs = po.load_images(img_dir)
+      >>> print(imgs.shape)
+      torch.Size([5, 3, 256, 256])
       >>> po.plot.imshow(imgs, title=titles)
       <PyrFigure size ... with 5 Axes>
+
+    .. plot::
+      :context: close-figs
+
+      >>> import plenoptic as po
+      >>> img_dir = po.data.fetch_data("test_images.tar.gz") / "256"
+      >>> titles = ["color_wheel", "curie", "einstein", "metal", "nuts"]
+      >>> imgs = po.load_images(img_dir)
+      >>> batch_idx = 2
+      >>> po.plot.imshow(imgs, title=titles[2], batch_idx=batch_idx)
+      <PyrFigure size ... >
     """
     if not isinstance(image, list):
         image = [image]


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

> This PR adds a basic doctest example in imshow to display a batch of grayscale images.

**Outstanding questions / particular feedback**

> - Test case for adding examples to docstrings, will continue adding more.

**Describe changes**

In a list, describe the changes you made. This should be more granular than the description at the beginning of the PR. These descriptions can be short, but this would also be the place to describe why something seemingly unrelated was included. e.g.,

> - added plot of 5 images with imshow
> - duplicate of example from load_images for testing
> - will add more examples within imshow and other display functions

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
