### PR TITLE
Fix doctest issue, adds basic `__repr__` for synthesis objects

### DIFF
--- a/src/plenoptic/_synthesize/eigendistortion.py
+++ b/src/plenoptic/_synthesize/eigendistortion.py
@@ -74,8 +74,6 @@ class Eigendistortion(_Synthesis):
            https://www.cns.nyu.edu/~lcv/eigendistortions/
     """
 
-    __module__ = "plenoptic"
-
     def __init__(self, image: Tensor, model: torch.nn.Module):
         super().__init__()
         validate_input(image, no_batch=True)

--- a/src/plenoptic/_synthesize/eigendistortion.py
+++ b/src/plenoptic/_synthesize/eigendistortion.py
@@ -654,6 +654,10 @@ class Eigendistortion(_Synthesis):
         # it here
         self._init_representation(self.image)
 
+    def __repr__(self) -> str:
+        # numpydoc ignore=GL08
+        return super()._repr_format(["image", "model"])
+
     @property
     def model(self) -> torch.nn.Module:
         """The model for which the eigendistortions are synthesized."""

--- a/src/plenoptic/_synthesize/mad_competition.py
+++ b/src/plenoptic/_synthesize/mad_competition.py
@@ -850,6 +850,20 @@ class MADCompetition(_OptimizedSynthesis):
         if len(self._saved_mad_image) and self._saved_mad_image[0].device.type != "cpu":
             self._saved_mad_image = [mad.to("cpu") for mad in self._saved_mad_image]
 
+    def __repr__(self) -> str:
+        # numpydoc ignore=GL08
+        return super()._repr_format(
+            [
+                "image",
+                "optimized_metric",
+                "reference_metric",
+                "minmax",
+                "metric_tradeoff_lambda",
+                "penalty_function",
+                "penalty_lambda",
+            ]
+        )
+
     @property
     def mad_image(self) -> Tensor:
         """Maximally-differentiating image, the parameter we are optimizing."""

--- a/src/plenoptic/_synthesize/mad_competition.py
+++ b/src/plenoptic/_synthesize/mad_competition.py
@@ -86,8 +86,6 @@ class MADCompetition(_OptimizedSynthesis):
            https://dx.doi.org/10.1167/8.12.8
     """
 
-    __module__ = "plenoptic"
-
     def __init__(
         self,
         image: Tensor,

--- a/src/plenoptic/_synthesize/metamer.py
+++ b/src/plenoptic/_synthesize/metamer.py
@@ -1148,6 +1148,12 @@ class Metamer(_OptimizedSynthesis):
         if len(self._saved_metamer) and self._saved_metamer[0].device.type != "cpu":
             self._saved_metamer = [met.to("cpu") for met in self._saved_metamer]
 
+    def __repr__(self) -> str:
+        # numpydoc ignore=GL08
+        return super()._repr_format(
+            ["image", "model", "loss_function", "penalty_function", "penalty_lambda"]
+        )
+
     @property
     def loss_function(self) -> Callable[[Tensor, Tensor], Tensor]:
         """Callable which specifies how close metamer representation is to target."""
@@ -2033,6 +2039,19 @@ class MetamerCTF(Metamer):
             tensor_equality_atol=tensor_equality_atol,
             tensor_equality_rtol=tensor_equality_rtol,
             **pickle_load_args,
+        )
+
+    def __repr__(self) -> str:
+        # numpydoc ignore=GL08
+        return super()._repr_format(
+            [
+                "image",
+                "model",
+                "loss_function",
+                "penalty_function",
+                "penalty_lambda",
+                "coarse_to_fine",
+            ]
         )
 
     @property

--- a/src/plenoptic/_synthesize/metamer.py
+++ b/src/plenoptic/_synthesize/metamer.py
@@ -2013,7 +2013,7 @@ class MetamerCTF(Metamer):
         >>> met = po.Metamer(img, model)
         >>> met.load(po.data.fetch_data("example_metamerCTF_ps.pt"))
         Traceback (most recent call last):
-        ValueError: Saved object was a plenoptic._synthesize.metamer.Metamer...
+        ValueError: Saved object was a plenoptic.MetamerCTF...
 
         If the loading ``MetamerCTF`` object was not initialized with same values
         as the saved object, an error will be raised:

--- a/src/plenoptic/_synthesize/metamer.py
+++ b/src/plenoptic/_synthesize/metamer.py
@@ -90,8 +90,6 @@ class Metamer(_OptimizedSynthesis):
       <Figure size ...>
     """
 
-    __module__ = "plenoptic"
-
     def __init__(
         self,
         image: Tensor,
@@ -1355,8 +1353,6 @@ class MetamerCTF(Metamer):
     Traceback (most recent call last):
     AttributeError: model has no scales attribute ...
     """
-
-    __module__ = "plenoptic"
 
     def __init__(
         self,

--- a/src/plenoptic/_synthesize/synthesis.py
+++ b/src/plenoptic/_synthesize/synthesis.py
@@ -596,6 +596,41 @@ class _Synthesis(abc.ABC):
                 elif attr is not None:
                     setattr(self, k, move(attr, k))
 
+    def _repr_format(self, attrs: list[str]) -> str:
+        """
+        Help format __repr__ output.
+
+        Representation starts with name of the class and then loops through specified
+        attributes in order. Each tensor is displayed as ``{attr.shape}
+        ({attr.dtype})``, everything else we try to grab ``attr.__name__ and``, if that
+        doesn't exist, fall back on ``repr(attr)``, indenting after newlines it contains
+        (intended use is for torch.nn.Module objects)
+
+        Parameters
+        ----------
+        attrs
+            Attributes to display.
+
+        Returns
+        -------
+        repr
+            String representation.
+        """
+        repr_str = f"{self.__class__.__name__}(\n"
+        tab = "  "
+        for name in attrs:
+            val = eval(f"self.{name}")
+            if isinstance(val, torch.Tensor):
+                repr_str += f"{tab}{name}: {val.shape} ({val.dtype}),\n"
+            else:
+                try:
+                    repr_str += f"{tab}{name}: {val.__name__},\n"
+                except AttributeError:
+                    obj_rep = repr(val).replace("\n", f"\n{tab}")
+                    repr_str += f"{tab}{name}: {obj_rep},\n"
+        repr_str += ")"
+        return repr_str
+
 
 class _OptimizedSynthesis(_Synthesis):
     r"""

--- a/src/plenoptic/_synthesize/synthesis.py
+++ b/src/plenoptic/_synthesize/synthesis.py
@@ -50,7 +50,11 @@ def _get_name(x: object) -> str:
     except AttributeError:
         # if we're here, then it's an object
         cls = x.__class__
-        name = f"{cls.__module__}.{cls.__name__}"
+        # for synthesis objects, return them as plenoptic.OBJ_NAME
+        if "_synthesize" in cls.__module__:
+            name = f"plenoptic.{cls.__name__}"
+        else:
+            name = f"{cls.__module__}.{cls.__name__}"
     return name
 
 
@@ -265,9 +269,9 @@ class _Synthesis(abc.ABC):
         )
         metadata = tmp_dict.pop("save_metadata")
         if metadata["synthesis_object"] != _get_name(self):
-            # in PR #418 (release 2.0.0), updated __module__ of synthesis objects from
-            # plenoptic.synthesize to the top-level one. this removes .synthesize and
-            # the three synthesis modules that were used before
+            # in PR #418 (release 2.0.0), updated moved synthesis objects from
+            # plenoptic.synthesize to publicly live under the top-most one. this removes
+            # .synthesize and the three synthesis modules that were used before.
             obj_name = metadata["synthesis_object"].replace(".synthesize", "")
             for mod_name in [".metamer", ".mad_competition", ".eigendistortion"]:
                 obj_name = obj_name.replace(mod_name, "")

--- a/src/plenoptic/_synthesize/synthesis.py
+++ b/src/plenoptic/_synthesize/synthesis.py
@@ -653,7 +653,7 @@ class _Synthesis(abc.ABC):
 
         Representation starts with name of the class and then loops through specified
         attributes in order. Each tensor is displayed as ``{attr.shape}
-        ({attr.dtype})``, everything else we try to grab ``attr.__name__ and``, if that
+        ({attr.dtype})``, everything else we try to grab ``attr.__name__`` and, if that
         doesn't exist, fall back on ``repr(attr)``, indenting after newlines it contains
         (intended use is for torch.nn.Module objects)
 

--- a/src/plenoptic/_synthesize/synthesis.py
+++ b/src/plenoptic/_synthesize/synthesis.py
@@ -51,7 +51,7 @@ def _get_name(x: object) -> str:
         # if we're here, then it's an object
         cls = x.__class__
         # for synthesis objects, return them as plenoptic.OBJ_NAME
-        if "_synthesize" in cls.__module__:
+        if cls.__module__.startswith("plenoptic.") and "_synthesize" in cls.__module__:
             name = f"plenoptic.{cls.__name__}"
         else:
             name = f"{cls.__module__}.{cls.__name__}"

--- a/src/plenoptic/_synthesize/synthesis.py
+++ b/src/plenoptic/_synthesize/synthesis.py
@@ -621,13 +621,13 @@ class _Synthesis(abc.ABC):
         for name in attrs:
             val = eval(f"self.{name}")
             if isinstance(val, torch.Tensor):
-                repr_str += f"{tab}{name}: {val.shape} ({val.dtype}),\n"
+                repr_str += f"{tab}{name} = {val.shape} ({val.dtype}),\n"
             else:
                 try:
-                    repr_str += f"{tab}{name}: {val.__name__},\n"
+                    repr_str += f"{tab}{name} = {val.__name__},\n"
                 except AttributeError:
                     obj_rep = repr(val).replace("\n", f"\n{tab}")
-                    repr_str += f"{tab}{name}: {obj_rep},\n"
+                    repr_str += f"{tab}{name} = {obj_rep},\n"
         repr_str += ")"
         return repr_str
 

--- a/src/plenoptic/data/_fetch.py
+++ b/src/plenoptic/data/_fetch.py
@@ -49,8 +49,8 @@ REGISTRY = {
     "example_metamer_gaussian-old.pt": "adef079df878a9e0319cb5ad59791435f9b7eec695e1d8f21019c8e11b891d85",  # noqa: E501
     "example_metamer_gaussian.pt": "02e12c7c2a93e2e5a83f6d7aa8320368c00641deacfba3359b02fedc9a0dc0f1",  # noqa: E501
     "example_metamer_gaussian-cuda.pt": "edd80e63bd776b679f714acee62fefa9885a257c66e2699423887aeab7c03794",  # noqa: E501
-    "example_metamerCTF_ps.pt": "6005e4fcf8f36443af1ebc9338319e201876f0640b62ceba062f3a2a33a93f28",  # noqa: E501
-    "example_metamerCTF_ps-cuda.pt": "2f454a29e46cade7ced9268e15878712cc23827d9e5b849e0367e08ee49b79df",  # noqa: E501
+    "example_metamerCTF_ps.pt": "060362bb4146649511cf0b8c069450811f1ef842e3763014fbb00808966067d2",  # noqa: E501
+    "example_metamerCTF_ps-cuda.pt": "443dbdec5dbc2a7ffb26fc8076981142d14ab9cee36b294f4d890020a4838816",  # noqa: E501
     "example_mad.pt": "583c60eab6cfb5c5b031af4960db41cc0db767492871182be06da224cd133767",  # noqa: E501
     "example_mad-cuda.pt": "fd7e1372397bb57cc31a13ca4886ee73ffd405df64e0bb7d291977ba1b460b77",  # noqa: E501
     "example_eigendistortion_color.pt": "63147c5ed9588a64b6af4f181a8d0532d3de5639b20ae79c4706ec488c1854dc",  # noqa: E501
@@ -91,8 +91,8 @@ REGISTRY_URLS = {
     "example_metamer_gaussian-old.pt": OSF_TEMPLATE.format("7e48u/?revision=5"),
     "example_metamer_gaussian.pt": OSF_TEMPLATE.format("7e48u/?revision=6"),
     "example_metamer_gaussian-cuda.pt": OSF_TEMPLATE.format("jzhe7/?revision=3"),
-    "example_metamerCTF_ps.pt": OSF_TEMPLATE.format("4zr37/?revision=9"),
-    "example_metamerCTF_ps-cuda.pt": OSF_TEMPLATE.format("627sp/?revision=4"),
+    "example_metamerCTF_ps.pt": OSF_TEMPLATE.format("4zr37/?revision=10"),
+    "example_metamerCTF_ps-cuda.pt": OSF_TEMPLATE.format("627sp/?revision=5"),
     "example_eigendistortion_color.pt": OSF_TEMPLATE.format("jc63h/?revision=3"),
     "example_mad.pt": OSF_TEMPLATE.format("ersfy/?revision=4"),
     "example_mad-cuda.pt": OSF_TEMPLATE.format("qjdbc/?revision=3"),

--- a/src/plenoptic/models/frontend.py
+++ b/src/plenoptic/models/frontend.py
@@ -99,8 +99,6 @@ class LinearNonlinear(nn.Module):
     >>> ln_model = po.models.LinearNonlinear(31, pretrained=True, cache_filt=True)
     """
 
-    __module__ = "plenoptic.models"
-
     def __init__(
         self,
         kernel_size: int | tuple[int, int],
@@ -283,8 +281,6 @@ class LuminanceGainControl(nn.Module):
     >>> import plenoptic as po
     >>> lg_model = po.models.LuminanceGainControl(31, pretrained=True, cache_filt=True)
     """
-
-    __module__ = "plenoptic.models"
 
     def __init__(
         self,
@@ -504,8 +500,6 @@ class LuminanceContrastGainControl(nn.Module):
     ...     31, pretrained=True, cache_filt=True
     ... )
     """
-
-    __module__ = "plenoptic.models"
 
     def __init__(
         self,
@@ -744,8 +738,6 @@ class OnOff(nn.Module):
     >>> import plenoptic as po
     >>> onoff_model = po.models.OnOff(31, pretrained=True, cache_filt=True)
     """
-
-    __module__ = "plenoptic.models"
 
     def __init__(
         self,

--- a/src/plenoptic/models/naive.py
+++ b/src/plenoptic/models/naive.py
@@ -38,8 +38,6 @@ class Identity(torch.nn.Module):
     Identity()
     """
 
-    __module__ = "plenoptic.models"
-
     def __init__(self):
         super().__init__()
 
@@ -112,8 +110,6 @@ class Linear(nn.Module):
       (conv): Conv2d(1, 2, kernel_size=(5, 5), stride=(1, 1), bias=False)
     )
     """
-
-    __module__ = "plenoptic.models"
 
     def __init__(
         self,
@@ -218,8 +214,6 @@ class Gaussian(nn.Module):
     >>> gaussian_model
     Gaussian()
     """
-
-    __module__ = "plenoptic.models"
 
     def __init__(
         self,
@@ -373,8 +367,6 @@ class CenterSurround(nn.Module):
     >>> cs_model
     CenterSurround()
     """
-
-    __module__ = "plenoptic.models"
 
     def __init__(
         self,

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -165,8 +165,6 @@ class PortillaSimoncelli(nn.Module):
       <Figure size ...>
     """
 
-    __module__ = "plenoptic.models"
-
     def __init__(
         self,
         image_shape: tuple[int, int],

--- a/src/plenoptic/process/laplacian_pyramid.py
+++ b/src/plenoptic/process/laplacian_pyramid.py
@@ -54,8 +54,6 @@ class LaplacianPyramid(nn.Module):
     >>> lpyr = po.process.LaplacianPyramid(n_scales=4, scale_filter=True)
     """
 
-    __module__ = "plenoptic.process"
-
     def __init__(self, n_scales: int = 5, scale_filter: bool = False):
         super().__init__()
         self.n_scales = n_scales

--- a/src/plenoptic/process/steerable_pyramid_freq.py
+++ b/src/plenoptic/process/steerable_pyramid_freq.py
@@ -155,8 +155,6 @@ class SteerablePyramidFreq(nn.Module):
     >>> spyr = po.process.SteerablePyramidFreq((256, 256))
     """
 
-    __module__ = "plenoptic.process"
-
     def __init__(
         self,
         image_shape: tuple[int, int],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,24 +15,6 @@ UPDATED_API.update(_api_change.PLOT_FUNCS)
 NEW_FUNCS = _api_change.NEW
 
 
-def test_dunder_module():
-    # test that all objects have __module__ that match the way they're called
-    for mod in dir(plenoptic):
-        obj = eval(f"plenoptic.{mod}")
-        if inspect.isclass(obj) and obj.__module__ != "plenoptic":
-            raise ValueError(
-                f"{mod} module should be plenoptic but got {obj.__module__}"
-            )
-        if inspect.ismodule(obj):
-            for mod2 in dir(obj):
-                obj2 = eval(f"plenoptic.{mod}.{mod2}")
-                if inspect.isclass(obj2) and obj2.__module__ != f"plenoptic.{mod}":
-                    raise ValueError(
-                        f"{mod2} module should be plenoptic.{mod} but got "
-                        f"{obj2.__module__}"
-                    )
-
-
 def test_api_nesting():
     # that our API only has a single level of nesting
     for mod in dir(plenoptic):

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -652,6 +652,39 @@ class TestEigendistortionSynthesis:
         with pytest.raises(ValueError, match=error_str):
             eig.load(gaussian_einstein_img_eig_saved, raise_on_checks=False)
 
+    @pytest.mark.parametrize(
+        "model",
+        ["frontend.OnOff.nograd", "naive.Gaussian.nograd"],
+        indirect=True,
+    )
+    @pytest.mark.parametrize("method", ["exact", "power", "randomized_svd"])
+    @pytest.mark.filterwarnings(
+        "ignore:Randomized SVD complete!:UserWarning",
+    )
+    def test_repr(self, einstein_img, model, method):
+        # don't need the regex match in this case, but keeping it here to be consistent
+        # with the other synthesis object test_repr and in case we need to extend it in
+        # the future.
+        eig = po.Eigendistortion(einstein_img[..., :SMALL_DIM, :SMALL_DIM], model)
+        if isinstance(model, po.models.OnOff):
+            model_str = (
+                r"OnOff\(\n    \(center_surround\): CenterSurround\(\)\n    "
+                r"\(luminance\): Gaussian\(\)\n    \(contrast\): Gaussian\(\)"
+                r"\n  \)"
+            )
+        elif isinstance(model, po.models.Gaussian):
+            model_str = r"Gaussian\(\)"
+        expected_str = (
+            rf"Eigendistortion\(\n  image = torch.Size\(\[1, 1, 20, 20\]\)"
+            rf" \(torch.float32\),\n  model = {model_str},\n\)"
+        )
+        assert repr(eig) == str(eig)
+        assert re.match(expected_str, repr(eig))
+        # synthesize doesn't change repr
+        eig.synthesize(method=method, max_iter=2)
+        assert repr(eig) == str(eig)
+        assert re.match(expected_str, repr(eig))
+
 
 class TestAutodiffFunctions:
     @pytest.fixture(scope="class")
@@ -756,36 +789,3 @@ class TestAutodiffFunctions:
         Jv = autodiff._jacobian_vector_product(y, x, V)
         Fv = autodiff._vector_jacobian_product(y, x, Jv)
         assert torch.diag(V.T @ Fv).sqrt().allclose(singular_value, rtol=1e-3)
-
-    @pytest.mark.parametrize(
-        "model",
-        ["frontend.OnOff.nograd", "naive.Gaussian.nograd"],
-        indirect=True,
-    )
-    @pytest.mark.parametrize("method", ["exact", "power", "randomized_svd"])
-    @pytest.mark.filterwarnings(
-        "ignore:Randomized SVD complete!:UserWarning",
-    )
-    def test_repr(self, einstein_img, model, method):
-        # don't need the regex match in this case, but keeping it here to be consistent
-        # with the other synthesis object test_repr and in case we need to extend it in
-        # the future.
-        eig = po.Eigendistortion(einstein_img[..., :SMALL_DIM, :SMALL_DIM], model)
-        if isinstance(model, po.models.OnOff):
-            model_str = (
-                r"OnOff\(\n    \(center_surround\): CenterSurround\(\)\n    "
-                r"\(luminance\): Gaussian\(\)\n    \(contrast\): Gaussian\(\)"
-                r"\n  \)"
-            )
-        elif isinstance(model, po.models.Gaussian):
-            model_str = r"Gaussian\(\)"
-        expected_str = (
-            rf"Eigendistortion\(\n  image = torch.Size\(\[1, 1, 20, 20\]\)"
-            rf" \(torch.float32\),\n  model = {model_str},\n\)"
-        )
-        assert repr(eig) == str(eig)
-        assert re.match(expected_str, repr(eig))
-        # synthesize doesn't change repr
-        eig.synthesize(method=method, max_iter=2)
-        assert repr(eig) == str(eig)
-        assert re.match(expected_str, repr(eig))

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -1,4 +1,5 @@
 import copy
+import re
 from contextlib import nullcontext as does_not_raise
 
 import pytest
@@ -755,3 +756,36 @@ class TestAutodiffFunctions:
         Jv = autodiff._jacobian_vector_product(y, x, V)
         Fv = autodiff._vector_jacobian_product(y, x, Jv)
         assert torch.diag(V.T @ Fv).sqrt().allclose(singular_value, rtol=1e-3)
+
+    @pytest.mark.parametrize(
+        "model",
+        ["frontend.OnOff.nograd", "naive.Gaussian.nograd"],
+        indirect=True,
+    )
+    @pytest.mark.parametrize("method", ["exact", "power", "randomized_svd"])
+    @pytest.mark.filterwarnings(
+        "ignore:Randomized SVD complete!:UserWarning",
+    )
+    def test_repr(self, einstein_img, model, method):
+        # don't need the regex match in this case, but keeping it here to be consistent
+        # with the other synthesis object test_repr and in case we need to extend it in
+        # the future.
+        eig = po.Eigendistortion(einstein_img[..., :SMALL_DIM, :SMALL_DIM], model)
+        if isinstance(model, po.models.OnOff):
+            model_str = (
+                r"OnOff\(\n    \(center_surround\): CenterSurround\(\)\n    "
+                r"\(luminance\): Gaussian\(\)\n    \(contrast\): Gaussian\(\)"
+                r"\n  \)"
+            )
+        elif isinstance(model, po.models.Gaussian):
+            model_str = r"Gaussian\(\)"
+        expected_str = (
+            rf"Eigendistortion\(\n  image = torch.Size\(\[1, 1, 20, 20\]\)"
+            rf" \(torch.float32\),\n  model = {model_str},\n\)"
+        )
+        assert repr(eig) == str(eig)
+        assert re.match(expected_str, repr(eig))
+        # synthesize doesn't change repr
+        eig.synthesize(method=method, max_iter=2)
+        assert repr(eig) == str(eig)
+        assert re.match(expected_str, repr(eig))

--- a/tests/test_mad.py
+++ b/tests/test_mad.py
@@ -1,5 +1,7 @@
+import functools
 import inspect
 import math
+import re
 from contextlib import nullcontext as does_not_raise
 
 import pytest
@@ -1382,3 +1384,62 @@ class TestMAD:
             mad.load(ssim_einstein_img_mad_saved)
         with pytest.raises(ValueError, match=error_str):
             mad.load(ssim_einstein_img_mad_saved, raise_on_checks=False)
+
+    @pytest.mark.parametrize(
+        "func_type", ["lambda", "partial", "local_def", "module", "nonmodule"]
+    )
+    @pytest.mark.parametrize("minmax", ["min", "max"])
+    @pytest.mark.parametrize("which_metric", ["optimized", "reference"])
+    @pytest.mark.filterwarnings("ignore:Image range falls outside:UserWarning")
+    def test_repr(self, einstein_img, func_type, minmax, which_metric):
+        kwargs = {
+            "optimized_metric": po.loss.l2_norm,
+            "reference_metric": po.loss.l2_norm,
+        }
+        default_metric_str = "l2_norm"
+        penalty_str = "penalize_range"
+        if func_type == "lambda":
+            kwargs[f"{which_metric}_metric"] = lambda *args: po.metric.nlpd(
+                *args, epsilon=1e-20
+            )
+            other_metric_str = "<lambda>"
+        elif func_type == "partial":
+            kwargs["penalty_function"] = functools.partial(
+                po.regularize.penalize_range, allowed_range=(0.5, 1)
+            )
+            penalty_str = (
+                r"functools.partial\(<function penalize_range at [0-9a-z]+?>"
+                r", allowed_range=\(0.5, 1\)\)"
+            )
+            other_metric_str = "l2_norm"
+        elif func_type == "local_def":
+            kwargs[f"{which_metric}_metric"] = dis_ssim
+            other_metric_str = "dis_ssim"
+        elif func_type == "module":
+            kwargs[f"{which_metric}_metric"] = ModuleMetric()
+            other_metric_str = r"ModuleMetric\(\n    \(mdl\): Gaussian\(\)\n  \)"
+        elif func_type == "nonmodule":
+            kwargs[f"{which_metric}_metric"] = NonModuleMetric()
+            other_metric_str = "<test_mad.NonModuleMetric object at [0-9a-z]+?>"
+        if which_metric == "optimized":
+            ref_str = default_metric_str
+            opt_str = other_metric_str
+        elif which_metric == "reference":
+            opt_str = default_metric_str
+            ref_str = other_metric_str
+        mad = po.MADCompetition(
+            einstein_img, metric_tradeoff_lambda=1, minmax=minmax, **kwargs
+        )
+        expected_str = (
+            r"MADCompetition\(\n  image = torch.Size\(\[1, 1, 256, 256\]\) "
+            rf"\(torch.float32\),\n  optimized_metric = {opt_str},\n  "
+            rf"reference_metric = {ref_str},\n  minmax = '{minmax}',\n  "
+            rf"metric_tradeoff_lambda = 1,\n  penalty_function = "
+            rf"{penalty_str},\n  penalty_lambda = 0.1,\n\)"
+        )
+        assert repr(mad) == str(mad)
+        assert re.match(expected_str, repr(mad))
+        # synthesize doesn't change repr
+        mad.synthesize(2)
+        assert repr(mad) == str(mad)
+        assert re.match(expected_str, repr(mad))

--- a/tests/test_mad.py
+++ b/tests/test_mad.py
@@ -1420,7 +1420,7 @@ class TestMAD:
             other_metric_str = r"ModuleMetric\(\n    \(mdl\): Gaussian\(\)\n  \)"
         elif func_type == "nonmodule":
             kwargs[f"{which_metric}_metric"] = NonModuleMetric()
-            other_metric_str = "<test_mad.NonModuleMetric object at [0-9a-z]+?>"
+            other_metric_str = r"<test_mad.NonModuleMetric object at [0-9a-z]+?>"
         if which_metric == "optimized":
             ref_str = default_metric_str
             opt_str = other_metric_str

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -1,5 +1,7 @@
 import copy
+import functools
 import math
+import re
 from contextlib import nullcontext as does_not_raise
 
 import pytest
@@ -1553,3 +1555,51 @@ class TestMetamers:
             saved_rep, met.target_representation
         )
         torch.testing.assert_close(met_loss.to(DEVICE), model_loss)
+
+    @pytest.mark.parametrize(
+        "model",
+        ["PortillaSimoncelli", "naive.Gaussian.nograd"],
+        indirect=True,
+    )
+    @pytest.mark.parametrize("func_type", [None, "lambda", "partial", "local_def"])
+    def test_repr(self, einstein_img, model, func_type):
+        kwargs = {}
+        loss_str = "mse"
+        penalty_str = "penalize_range"
+        if func_type == "lambda":
+            kwargs["loss_function"] = lambda *args: po.loss.mse(*args)
+            loss_str = "<lambda>"
+        elif func_type == "partial":
+            kwargs["penalty_function"] = functools.partial(
+                po.regularize.penalize_range, allowed_range=(0.5, 1)
+            )
+            penalty_str = (
+                r"functools.partial\(<function penalize_range at [0-9a-z]+?"
+                r">, allowed_range=\(0.5, 1\)\)"
+            )
+        elif func_type == "local_def":
+
+            def loss(*args):
+                return po.loss.mse(*args)
+
+            kwargs["loss_function"] = loss
+            loss_str = "loss"
+        met = po.Metamer(einstein_img, model, **kwargs)
+        if isinstance(model, po.models.PortillaSimoncelli):
+            model_str = (
+                r"PortillaSimoncelli\(\n    \(_pyr\): SteerablePyramidFreq\(\)\n  \)"
+            )
+        elif isinstance(model, po.models.Gaussian):
+            model_str = r"Gaussian\(\)"
+        expected_str = (
+            r"Metamer\(\n  image = torch.Size\(\[1, 1, 256, 256\]\) "
+            rf"\(torch.float32\),\n  model = {model_str},\n  "
+            rf"loss_function = {loss_str},\n  penalty_function = "
+            rf"{penalty_str},\n  penalty_lambda = 0.1,\n\)"
+        )
+        assert repr(met) == str(met)
+        assert re.match(expected_str, repr(met))
+        # synthesize doesn't change repr
+        met.synthesize(2)
+        assert repr(met) == str(met)
+        assert re.match(expected_str, repr(met))

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -1584,13 +1584,20 @@ class TestMetamers:
 
             kwargs["loss_function"] = loss
             loss_str = "loss"
-        met = po.Metamer(einstein_img, model, **kwargs)
         if isinstance(model, po.models.PortillaSimoncelli):
             model_str = (
                 r"PortillaSimoncelli\(\n    \(_pyr\): SteerablePyramidFreq\(\)\n  \)"
             )
+            if func_type is None:
+                # Note this behavior! the loss string is "loss" (the name of the
+                # function returned by portilla_simoncelli_loss_factory), not ps_loss
+                # (the name assigned here)
+                ps_loss = po.loss.portilla_simoncelli_loss_factory(model, einstein_img)
+                kwargs["loss_function"] = ps_loss
+                loss_str = "loss"
         elif isinstance(model, po.models.Gaussian):
             model_str = r"Gaussian\(\)"
+        met = po.Metamer(einstein_img, model, **kwargs)
         expected_str = (
             r"Metamer\(\n  image = torch.Size\(\[1, 1, 256, 256\]\) "
             rf"\(torch.float32\),\n  model = {model_str},\n  "

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -1603,3 +1603,31 @@ class TestMetamers:
         met.synthesize(2)
         assert repr(met) == str(met)
         assert re.match(expected_str, repr(met))
+
+    @pytest.mark.parametrize(
+        "model",
+        ["PortillaSimoncelli"],
+        indirect=True,
+    )
+    @pytest.mark.parametrize("ctf", ["together", "separate"])
+    @pytest.mark.filterwarnings(
+        "ignore:Validating whether model can work with coarse-to-fine:UserWarning",
+    )
+    def test_repr_metamerctf(self, einstein_img, model, ctf):
+        met = po.MetamerCTF(einstein_img, model, coarse_to_fine=ctf)
+        model_str = (
+            r"PortillaSimoncelli\(\n    \(_pyr\): SteerablePyramidFreq\(\)\n  \)"
+        )
+        expected_str = (
+            r"MetamerCTF\(\n  image = torch.Size\(\[1, 1, 256, 256\]\) "
+            rf"\(torch.float32\),\n  model = {model_str},\n  "
+            r"loss_function = mse,\n  penalty_function = "
+            r"penalize_range,\n  penalty_lambda = 0.1,\n  "
+            rf"coarse_to_fine = '{ctf}',\n\)"
+        )
+        assert repr(met) == str(met)
+        assert re.match(expected_str, repr(met))
+        # synthesize doesn't change repr
+        met.synthesize(2)
+        assert repr(met) == str(met)
+        assert re.match(expected_str, repr(met))


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

This fixes #439, where I noticed that not all the doctests where running. After investigating, the culprit turned out to be manually over-riding `__module__` in my objects in #418. The reason I had done that was to improve the string representation of the objects.

So here, I remove that manual over-riding, make a small change to the loading code to remain functional, and add a basic `__repr__` for each of the synthesis objects (the models, my only other objects, don't need one, since they inherit it from `torch.nn.Module`). This basic `__repr__` just summarizes how the object was initialized.

An extension of this could provide some information on synthesis status, but I think this is sufficient for now.

**Link any related issues, discussions, PRs**

Closes #439

**Describe changes**

- Remove `__module__` from all objects
- Updates loading code to map synthesis object names to `plenoptic.OBJ_NAME` for the purposes of checking object identity.
- Adds basic `__repr__` to synthesis objects, making use of helper method in `_Synthesis`
- Adds tests for `__repr__`

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
