### PR TITLE
Hotfix: correct loss animation

### DIFF
--- a/src/plenoptic/plot/synthesis.py
+++ b/src/plenoptic/plot/synthesis.py
@@ -1998,7 +1998,13 @@ def synthesis_animate(
 
     if isinstance(synthesis_object, Metamer):
         saved_synth = synthesis_object.saved_metamer
-        losses = [synthesis_object.losses]
+        # this plot shows the metamer loss, which requires subtracting the penalty off
+        # of the objective function
+        met_loss = (
+            synthesis_object.losses
+            - synthesis_object.penalty_lambda * synthesis_object.penalties
+        )
+        losses = [met_loss]
     elif isinstance(synthesis_object, MADCompetition):
         saved_synth = synthesis_object.saved_mad_image
         losses = [


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

In #438, I changed the curve plotted by `synthesis_loss` for the metamer object to be the "metamer loss", rather than the output of the objective function. This means its `losses - penalty_lambda * penalties`, but the update in `synthesis_animate` (for the red dot on the loss plot) is just using the `losses` attribute.

You can see the result in the [quickstart](https://docs.plenoptic.org/docs/tags/2.0.0/getting_started/quickstart.html) notebook, where the red dot is slightly above the loss curve (for syntheses of a reasonable length, this effect will be subtle, but it's pretty obvious if you run it for 10 iterations).

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
