### PR TITLE
updated setuptools_scm version_scheme with current name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ nb = [
 where = ["src"]
 
 [tool.setuptools_scm]
-version_scheme = 'python-simplified-semver'
+version_scheme = 'semver-pep440'
 local_scheme = 'no-local-version'
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

e.g.,
> This PR updates ``setuptools_scm`` to ``version_scheme = 'semver-pep440'`` due to deprecation of previous name

**Describe changes**

> - Changed ``version_scheme`` in ``pyproject.toml`` to be ``'semver-pep440'`` since the previous name is now [deprecated](https://setuptools-scm.readthedocs.io/en/latest/extending/#version-number-construction).

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
