### PR TITLE
Fix for class scoped fixtures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ docs = [
 ]
 
 test = [
-    "pytest>=5.1.2",
+    # 9.1.0 unsupported because of https://github.com/pytest-dev/pytest/issues/14591
+    "pytest>=5.1.2,!=9.1.0",
     'pytest-cov',
     'pytest-xdist',
     'pytest-order',

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -746,7 +746,8 @@ def template_test_synthesis_custom_fig(synthesis_object, func, fig_creation, tmp
 
 class TestMADDisplay:
     @pytest.fixture(scope="class", params=["rgb", "grayscale"])
-    def synthesized_mad(self, request):
+    @classmethod
+    def synthesized_mad(cls, request):
         # make the images really small so nothing takes as long
         if request.param == "rgb":
             img = po.load_images(IMG_DIR / "256" / "color_wheel.jpg", False).to(DEVICE)
@@ -774,7 +775,8 @@ class TestMADDisplay:
     @pytest.fixture(
         scope="class", params=["rgb-5", "rgb-4", "grayscale-5", "grayscale-4"]
     )
-    def synthesized_mad_store_progress(self, request):
+    @classmethod
+    def synthesized_mad_store_progress(cls, request):
         # make the images really small so nothing takes as long
         img, max_iter = request.param.split("-")
         if img == "rgb":
@@ -857,7 +859,8 @@ class TestMADDisplay:
         )
 
     @pytest.fixture(scope="class")
-    def all_mad(self):
+    @classmethod
+    def all_mad(cls):
         # run synthesis for all 4 MAD images.
         img = po.load_images(IMG_DIR / "256" / "nuts.pgm").to(DEVICE)
         img = img[..., :16, :16]
@@ -1084,7 +1087,8 @@ class TestMADDisplay:
 
 class TestMetamerDisplay:
     @pytest.fixture(scope="class", params=["rgb", "grayscale"])
-    def synthesized_met_nostore(self, request):
+    @classmethod
+    def synthesized_met_nostore(cls, request):
         img = request.param
         # make the images really small so nothing takes as long
         if img == "rgb":
@@ -1113,7 +1117,8 @@ class TestMetamerDisplay:
         return met
 
     @pytest.fixture(scope="class", params=["rgb", "grayscale"])
-    def synthesized_met(self, request):
+    @classmethod
+    def synthesized_met(cls, request):
         img = request.param
         # make the images really small so nothing takes as long
         if img == "rgb":
@@ -1142,7 +1147,8 @@ class TestMetamerDisplay:
         return met
 
     @pytest.fixture(scope="class", params=["rgb", "grayscale"])
-    def synthesized_met_3d(self, request):
+    @classmethod
+    def synthesized_met_3d(cls, request):
         img = request.param
         # make the images really small so nothing takes as long
         if img == "rgb":
@@ -1173,7 +1179,8 @@ class TestMetamerDisplay:
     @pytest.fixture(
         scope="class", params=["rgb-5", "rgb-4", "grayscale-5", "grayscale-4"]
     )
-    def synthesized_met_store_progress(self, request):
+    @classmethod
+    def synthesized_met_store_progress(cls, request):
         img, max_iter = request.param.split("-")
         # make the images really small so nothing takes as long
         if img == "rgb":
@@ -1539,7 +1546,8 @@ class TestEigendistortionDisplay:
             "Color-randomized_svd-3",
         ],
     )
-    def synthesized_eig(self, request, einstein_img, color_img):
+    @classmethod
+    def synthesized_eig(cls, request, einstein_img, color_img):
         model, method, k = request.param.split("-")
         if model == "OnOff":
             model = po.models.OnOff((31, 31), pretrained=True, cache_filt=True).to(

--- a/tests/test_eigendistortion.py
+++ b/tests/test_eigendistortion.py
@@ -17,7 +17,8 @@ LARGE_DIM = 100
 
 class TestEigendistortionSynthesis:
     @pytest.fixture(scope="class")
-    def gaussian_einstein_img_eig_saved(self, einstein_img, tmp_path_factory):
+    @classmethod
+    def gaussian_einstein_img_eig_saved(cls, einstein_img, tmp_path_factory):
         model = po.models.Gaussian((31, 31)).to(DEVICE)
         po.remove_grad(model)
         model.eval()
@@ -688,7 +689,8 @@ class TestEigendistortionSynthesis:
 
 class TestAutodiffFunctions:
     @pytest.fixture(scope="class")
-    def state(self, einstein_img_double):
+    @classmethod
+    def state(cls, einstein_img_double):
         """variables to be reused across tests in this class"""
 
         # num vectors with which to compute vjp, jvp, Fv

--- a/tests/test_mad.py
+++ b/tests/test_mad.py
@@ -57,7 +57,8 @@ class NonModuleMetric:
 
 class TestMAD:
     @pytest.fixture(scope="class")
-    def ssim_einstein_img_mad_saved(self, einstein_img, tmp_path_factory):
+    @classmethod
+    def ssim_einstein_img_mad_saved(cls, einstein_img, tmp_path_factory):
         mad = po.MADCompetition(einstein_img, test_metric.nlpd, po.metric.mse, "min", 1)
         mad.synthesize(2)
         save_path = tmp_path_factory.mktemp("data") / "ssim_einstein_img_mad_saved.pt"

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -27,7 +27,8 @@ def custom_penalty2(x1):
 
 class TestMetamers:
     @pytest.fixture(scope="class")
-    def gaussian_einstein_img_metamer_saved(self, einstein_img, tmp_path_factory):
+    @classmethod
+    def gaussian_einstein_img_metamer_saved(cls, einstein_img, tmp_path_factory):
         model = po.models.Gaussian((31, 31)).to(DEVICE)
         po.remove_grad(model)
         model.eval()

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -146,7 +146,8 @@ class TestSteerablePyramid:
             for shape in [None, 224, "128_1", "128_2"]
         ],
     )
-    def img(self, request):
+    @classmethod
+    def img(cls, request):
         im, shape = request.param.split("-")
         img = po.load_images(IMG_DIR / "256" / f"{im}.pgm").to(DEVICE)
         if shape == "224":
@@ -161,7 +162,8 @@ class TestSteerablePyramid:
         scope="class",
         params=[f"{shape}" for shape in [None, 224, "128_1", "128_2"]],
     )
-    def multichannel_img(self, request):
+    @classmethod
+    def multichannel_img(cls, request):
         shape = request.param
         # use fixture for img and use color_wheel instead.
         img = po.load_images(IMG_DIR / "mixed" / "flowers.jpg", as_gray=False).to(
@@ -181,7 +183,8 @@ class TestSteerablePyramid:
     # different sizes. Otherwise, this will generate a bunch of tests that use
     # the spyr with those strange shapes
     @pytest.fixture(scope="class")
-    def spyr(self, img, request):
+    @classmethod
+    def spyr(cls, img, request):
         height, order, is_complex, downsample, tightframe = request.param.split("-")
 
         with suppress(ValueError):
@@ -201,7 +204,8 @@ class TestSteerablePyramid:
         return pyr
 
     @pytest.fixture(scope="class")
-    def spyr_multi(self, multichannel_img, request):
+    @classmethod
+    def spyr_multi(cls, multichannel_img, request):
         height, order, is_complex, downsample, tightframe = request.param.split("-")
 
         with suppress(ValueError):

--- a/tests/test_uploaded_files.py
+++ b/tests/test_uploaded_files.py
@@ -536,7 +536,8 @@ class TestTutorialNotebooks:
     )
     class TestPortillaSimoncelli:
         @pytest.fixture(scope="class")
-        def ps_images(self):
+        @classmethod
+        def ps_images(cls):
             img_dir = po.data.fetch_data("portilla_simoncelli_images.tar.gz")
             images = po.load_images(img_dir).to(DEVICE).to(torch.float64)
             filenames = [p.stem for p in sorted(img_dir.iterdir())]
@@ -549,7 +550,8 @@ class TestTutorialNotebooks:
             return images[filenames.index(tgt_filename)].unsqueeze(0).clone()
 
         @pytest.fixture(scope="class")
-        def ps_regression(self):
+        @classmethod
+        def ps_regression(cls):
             return po.data.fetch_data("ps_regression.tar.gz")
 
         @pytest.mark.parametrize(


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

Pytest 9.1 deprecates [class-scoped fixtures as instance methods](https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method), which we were using in several of our tests. Therefore, that release caused many of our tests to start raising the deprecation warning and thus fail. Here, we update to the recommended way of using them: turning them into class methods. We don't actually *use* the behavior this enables, so it doesn't require any other changes.

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
