### PR TITLE
Remove filter warnings from top of notebooks

### DIFF
--- a/docs/user_guide/models_and_metrics/Perceptual_distance.md
+++ b/docs/user_guide/models_and_metrics/Perceptual_distance.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.19.1
+    jupytext_version: 1.17.3
 kernelspec:
   display_name: plenoptic
   language: python
@@ -14,19 +14,11 @@ kernelspec:
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-import warnings
-
 import pooch
 
 # don't have pooch output messages about downloading or untarring
 logger = pooch.get_logger()
 logger.setLevel("WARNING")
-
-warnings.filterwarnings(
-    "ignore",
-    message="The default behavior of tarfile extraction",
-    category=RuntimeWarning,
-)
 ```
 
 :::{admonition} Run this notebook yourself!

--- a/docs/user_guide/reproduce/Original_MAD.md
+++ b/docs/user_guide/reproduce/Original_MAD.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.18.1
+    jupytext_version: 1.17.3
 kernelspec:
   display_name: plenoptic
   language: python
@@ -14,13 +14,7 @@ kernelspec:
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-import warnings
 
-warnings.filterwarnings(
-    "ignore",
-    message="The default behavior of tarfile extraction",
-    category=RuntimeWarning,
-)
 ```
 
 :::{admonition} Under development


### PR DESCRIPTION
Several notebooks had blocks at the top filtering out the warning from pooch about tarball behavior. Given that we updated to pooch 1.9.0 in #441, these are no longer necessary.

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
