### PR TITLE
Contributing guide cloning instructions

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -93,7 +93,7 @@ $ git remote add upstream git@github.com:plenoptic-org/plenoptic.git
 :::{tab-item} HTTPS
 :sync: windows
 
-```{code-block} pwsh-session
+```{code-block} console
 $ # replace with your personal GitHub username
 $ git clone https://github.com/github-username/plenoptic.git
 $ cd plenoptic

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -79,7 +79,6 @@ You'll need a local copy of `plenoptic` which keeps up-to-date with any changes 
 
 ::::{tab-set}
 :::{tab-item} SSH
-:sync: posix
 
 ```{code-block} console
 $ # replace github-username with your personal username
@@ -91,7 +90,6 @@ $ git remote add upstream git@github.com:plenoptic-org/plenoptic.git
 ```
 :::
 :::{tab-item} HTTPS
-:sync: windows
 
 ```{code-block} console
 $ # replace with your personal GitHub username

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -82,11 +82,11 @@ You'll need a local copy of `plenoptic` which keeps up-to-date with any changes 
 :sync: posix
 
 ```{code-block} console
-# replace github-username with your personal username
+$ # replace github-username with your personal username
 $ git clone git@github.com:github-username/plenoptic.git
 $ cd plenoptic
-# add the upstream branch. you will now have two remotes:
-# your fork (origin) and the canonical version (upstream)
+$ # add the upstream branch. you will now have two remotes:
+$ # your fork (origin) and the canonical version (upstream)
 $ git remote add upstream git@github.com:plenoptic-org/plenoptic.git
 ```
 :::
@@ -94,12 +94,12 @@ $ git remote add upstream git@github.com:plenoptic-org/plenoptic.git
 :sync: windows
 
 ```{code-block} pwsh-session
-PS> # replace with your personal GitHub username
-PS> git clone https://github.com/github-username/plenoptic.git
-PS> cd plenoptic
-PS> # add the upstream branch. you will now have two remotes:
-PS> # your fork (origin) and the canonical version (upstream)
-PS> remote add upstream https://github.com/plenoptic-org/plenoptic.git
+$ # replace with your personal GitHub username
+$ git clone https://github.com/github-username/plenoptic.git
+$ cd plenoptic
+$ # add the upstream branch. you will now have two remotes:
+$ # your fork (origin) and the canonical version (upstream)
+$ remote add upstream https://github.com/plenoptic-org/plenoptic.git
 ```
 :::
 ::::

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -75,7 +75,7 @@ Before we begin: everyone finds `git` confusing the first few (dozen) times they
 You'll need a local copy of `plenoptic` which keeps up-to-date with any changes you make. To do so, you will need to fork and clone `plenoptic`.
 
 1. Go to the [plenoptic repo](https://github.com/plenoptic-org/plenoptic/) and click on the `Fork` button at the top right of the page. This creates a copy of plenoptic in your Github account.
-2. You should then clone *your fork* to your local machine and create an editable installation. You will also add the upstream version, which makes it easy to keep your `plenoptic` up to date with the canonical version. To do so, run the lines of code below, also outlined in our [docs](source). It is recommended to set up an [ssh key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) through GitHub and clone with ssh rather than HTTPS, but both options are listed below:
+2. You should then clone *your fork* to your local machine and create an editable installation. You will also add the upstream version, which makes it easy to keep your `plenoptic` up to date with the canonical version. To do so, run the lines of code below, also outlined in our [docs](source). It is recommended to set up an [SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) through GitHub and clone with SSH rather than HTTPS, but both options are listed below:
 
 ::::{tab-set}
 :::{tab-item} SSH

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -75,16 +75,34 @@ Before we begin: everyone finds `git` confusing the first few (dozen) times they
 You'll need a local copy of `plenoptic` which keeps up-to-date with any changes you make. To do so, you will need to fork and clone `plenoptic`.
 
 1. Go to the [plenoptic repo](https://github.com/plenoptic-org/plenoptic/) and click on the `Fork` button at the top right of the page. This creates a copy of plenoptic in your Github account.
-2. You should then clone *your fork* to your local machine and create an editable installation. You will also add the upstream version, which makes it easy to keep your `plenoptic` up to date with the canonical version. To do so, run the lines of code below, also outlined in our [docs](source):
+2. You should then clone *your fork* to your local machine and create an editable installation. You will also add the upstream version, which makes it easy to keep your `plenoptic` up to date with the canonical version. To do so, run the lines of code below, also outlined in our [docs](source). It is recommended to set up an [ssh key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) through GitHub and clone with ssh rather than HTTPS, but both options are listed below:
 
-```bash
-# replace with your personal GitHub username
-git clone https://github.com/github-username/plenoptic.git
-cd plenoptic
+::::{tab-set}
+:::{tab-item} SSH
+:sync: posix
+
+```{code-block} console
+# replace github-username with your personal username
+$ git clone git@github.com:github-username/plenoptic.git
+$ cd plenoptic
 # add the upstream branch. you will now have two remotes:
 # your fork (origin) and the canonical version (upstream)
-git remote add upstream https://github.com/plenoptic-org/plenoptic.git
+$ git remote add upstream git@github.com:plenoptic-org/plenoptic.git
 ```
+:::
+:::{tab-item} HTTPS
+:sync: windows
+
+```{code-block} pwsh-session
+PS> # replace with your personal GitHub username
+PS> git clone https://github.com/github-username/plenoptic.git
+PS> cd plenoptic
+PS> # add the upstream branch. you will now have two remotes:
+PS> # your fork (origin) and the canonical version (upstream)
+PS> remote add upstream https://github.com/plenoptic-org/plenoptic.git
+```
+:::
+::::
 
 3. You will then want to install all the `docs` and `devs` optional dependencies, so that you can run tests and build the documentation. To do so, make a virtual environment and run the installation from within the copy of `plenoptic` on your machine.
 

--- a/src/plenoptic/data/_fetch.py
+++ b/src/plenoptic/data/_fetch.py
@@ -86,7 +86,7 @@ REGISTRY_URLS = {
     "example_eigendistortion.pt": OSF_TEMPLATE.format("gwhz2"),
     "load_image_test.tar.gz": OSF_TEMPLATE.format("avpzq"),
     "berardino_onoff.pt": OSF_TEMPLATE.format("uqfa8"),
-    "berardino_vgg16.pt": OSF_TEMPLATE.format("6r87b"),
+    "berardino_vgg16.pt": OSF_TEMPLATE.format("6r87b/?revision=4"),
     "ps_regression.tar.gz": OSF_TEMPLATE.format("7t4fj/?revision=15"),
     "example_metamer_gaussian-old.pt": OSF_TEMPLATE.format("7e48u/?revision=5"),
     "example_metamer_gaussian.pt": OSF_TEMPLATE.format("7e48u/?revision=6"),


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

> This PR updated the instructions in the plenoptic contributing guide to include both SSH and HTTPS options for cloning the repository.

**Outstanding questions / particular feedback**

N/A

**Describe changes**

> - edited text in Creating a development environment regarding recommendation to use SSH key
> - added text blocks with switching tabs showing code for using both SSH and HTTPS cloning options

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
