### PR TITLE
When animating color videos/syntheses, only raise a single warning.

### DIFF
--- a/docs/user_guide/synthesis/Eigendistortions.md
+++ b/docs/user_guide/synthesis/Eigendistortions.md
@@ -27,11 +27,6 @@ warnings.filterwarnings(
     message="plenoptic's methods have mostly been tested on",
     category=UserWarning,
 )
-
-warnings.filterwarnings(
-    "ignore",
-    message="Clipping input data to the valid range",
-)
 ```
 
 :::{admonition} Run this notebook yourself!

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -509,7 +509,6 @@ def _clip_frames_warnings_msg(
     dims = " ".join(dims)
     n_frames_min = einops.reduce(video, f"{dims} -> t", "min") < 0
     n_frames_max = einops.reduce(video, f"{dims} -> t", "max") > 1
-    print(n_frames_min, n_frames_max)
     n_frames = einops.pack([n_frames_min, n_frames_max], "* t")[0].any(0).sum()
     if n_frames > 0:
         warning_msg = (

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -463,6 +463,64 @@ def imshow(
     )
 
 
+def _clip_frames_warnings_msg(
+    video: torch.Tensor,
+    time_dim: int = 2,
+    video_name: str = "video",
+    to_avoid_txt: str = "",
+) -> str:
+    """
+    Get warning message for clipped frames in RGB(A) videos.
+
+    Computes the number of frames with values outside [0, 1] and returns formatted
+    string describing how many clipped.
+
+    If no pixels would be clipped, empty string is returned.
+
+    Parameters
+    ----------
+    video
+        5d Tensor of shape to check. Note that this doesn't check ``video`` is RGB(A),
+        that must be done externally.
+    time_dim
+        Which dimension of ``video`` corresponds to the time dimension. E.g., if
+        ``time_idx==2``, then video is of shape (batch, channel, time, height, width).
+    video_name
+        For warning message, name of video.
+    to_avoid_txt
+        For warning message, extra info on how to avoid this clipping.
+
+    Returns
+    -------
+    warning_msg
+        The text to pass to ``warnings.warn``. If no frames would be clipped,
+        empty string is returned.
+    """
+    # with RGB float images, matplotlib will always clip them to lie between 0
+    # and 1 and raise a warning. because of how we animate, this warning gets
+    # raised on each frame. that's annoying, so let's do the clipping here,
+    # telling the user how much was lost.
+    mpl_warning_text = (
+        "Clipping input data to the valid range for imshow "
+        "with RGB data ([0..1] for floats)."
+    )
+    dims = ["b", "c", "h", "w"]
+    dims = dims[:time_dim] + ["t"] + dims[time_dim:]
+    dims = " ".join(dims)
+    n_frames_min = einops.reduce(video, f"{dims} -> t", "min") < 0
+    n_frames_max = einops.reduce(video, f"{dims} -> t", "max") > 1
+    print(n_frames_min, n_frames_max)
+    n_frames = einops.pack([n_frames_min, n_frames_max], "* t")[0].any(0).sum()
+    if n_frames > 0:
+        warning_msg = (
+            f"{n_frames.item()} frames of {video_name} clipped: "
+            f"{mpl_warning_text} {to_avoid_txt}"
+        )
+    else:
+        warning_msg = ""
+    return warning_msg
+
+
 def animshow(
     video: torch.Tensor | list[torch.Tensor],
     framerate: float = 2.0,
@@ -680,22 +738,9 @@ def animshow(
                 raise ValueError(
                     "If as_rgb is True, then channel must have 3 or 4 elements!"
                 )
-            # with RGB float images, matplotlib will always clip them to lie between 0
-            # and 1 and raise a warning. because of how we animate, this warning gets
-            # raised on each frame. that's annoying, so let's do the clipping here,
-            # telling the user how much was lost.
-            mpl_warning_text = (
-                "Clipping input data to the valid range for imshow "
-                "with RGB data ([0..1] for floats)."
-            )
-            n_frames_min = (einops.reduce(vid, "b c t h w -> t", "min") < 0).sum()
-            n_frames_max = (einops.reduce(vid, "b c t h w -> t", "max") > 1).sum()
-            if (n_frames := n_frames_min + n_frames_max) > 0:
-                warning_msg = (
-                    f"{n_frames.item()} frames of video {i} clipped: "
-                    f"{mpl_warning_text} To avoid clipping, modify video "
-                    "before calling animshow."
-                )
+            to_avoid = "To avoid clipping, modify video before calling animshow."
+            warning_msg = _clip_frames_warnings_msg(vid, 2, f"video {i}", to_avoid)
+            if warning_msg:
                 warnings.warn(warning_msg)
             vid = vid.transpose(0, 2, 3, 4, 1).clip(min=0, max=1)
             # want to insert a fake "channel" dimension here, so our putting it

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -578,7 +578,8 @@ def animshow(
         Whether to consider the channels as encoding RGB(A) values. If ``True``, we
         attempt to plot the image in color, so your tensor must have 3 (or 4 if
         you want the alpha channel) elements in the channel dimension. If ``False``,
-        we plot each channel as a separate grayscale image.
+        we plot each channel as a separate grayscale image. Note that if ``True``,
+        clipping may result, see Warns section below for details.
     **kwargs
         Passed to :func:`matplotlib.pyplot.imshow`.
 
@@ -601,6 +602,15 @@ def animshow(
         one batch and neither ``batch_idx`` nor ``channel_idx`` is set.
     Exception
         If ``plot_complex`` takes an illegal value.
+
+    Warns
+    -----
+    UserWarning
+        If ``as_rgb`` and ``video`` contains values outside of [0, 1], we will clip
+        ``video`` so all values lie within [0, 1]. (This is because of the requirements
+        of :func:`matplotlib.pyplot.imshow`.) The warning will say how many frames of
+        which video were clipped. To avoid clipping, you should remap ``video`` to
+        [0, 1] before calling this function.
 
     See Also
     --------
@@ -648,7 +658,7 @@ def animshow(
         raise ValueError("animshow only accepts videos as 5d tensors!")
     videos_to_show = []
     heights, widths = [], []
-    for vid in video:
+    for i, vid in enumerate(video):
         vid = to_numpy(vid)
         if vid.shape[0] > 1 and batch_idx is not None:
             # this preserves the number of dimensions
@@ -670,7 +680,24 @@ def animshow(
                 raise ValueError(
                     "If as_rgb is True, then channel must have 3 or 4 elements!"
                 )
-            vid = vid.transpose(0, 2, 3, 4, 1)
+            # with RGB float images, matplotlib will always clip them to lie between 0
+            # and 1 and raise a warning. because of how we animate, this warning gets
+            # raised on each frame. that's annoying, so let's do the clipping here,
+            # telling the user how much was lost.
+            mpl_warning_text = (
+                "Clipping input data to the valid range for imshow "
+                "with RGB data ([0..1] for floats)."
+            )
+            n_frames_min = (einops.reduce(vid, "b c t h w -> t", "min") < 0).sum()
+            n_frames_max = (einops.reduce(vid, "b c t h w -> t", "max") > 1).sum()
+            if (n_frames := n_frames_min + n_frames_max) > 0:
+                warning_msg = (
+                    f"{n_frames.item()} frames of video {i} clipped: "
+                    f"{mpl_warning_text} To avoid clipping, modify video "
+                    "before calling animshow."
+                )
+                warnings.warn(warning_msg)
+            vid = vid.transpose(0, 2, 3, 4, 1).clip(min=0, max=1)
             # want to insert a fake "channel" dimension here, so our putting it
             # into a list below works as expected
             vid = vid.reshape((vid.shape[0], 1, *vid.shape[1:]))

--- a/src/plenoptic/plot/synthesis.py
+++ b/src/plenoptic/plot/synthesis.py
@@ -1999,12 +1999,13 @@ def synthesis_animate(
       >>> # simple model which convoles identical Gaussians independently on each of the
       >>> # color channels.
       >>> class ColorGaussian(torch.nn.Module):
-      >>>     def __init__(self, *args, **kwargs):
-      >>>         super().__init__()
-      >>>         self.model = po.models.Gaussian(*args, **kwargs)
-      >>>         self._forward = torch.vmap(self.model.forward, 1)
-      >>>     def forward(self, x):
-      >>>         return self._forward(x)
+      ...     def __init__(self, *args, **kwargs):
+      ...         super().__init__()
+      ...         self.model = po.models.Gaussian(*args, **kwargs)
+      ...         self._forward = torch.vmap(self.model.forward, 1)
+      ...
+      ...     def forward(self, x):
+      ...         return self._forward(x)
       >>> model = ColorGaussian(30)
       >>> po.remove_grad(model)
       >>> met = po.Metamer(img, model)

--- a/src/plenoptic/plot/synthesis.py
+++ b/src/plenoptic/plot/synthesis.py
@@ -1,5 +1,6 @@
 """Plots for understanding synthesis objects."""  # numpydoc ignore=EX01
 
+import functools
 import re
 import warnings
 from collections.abc import Callable
@@ -677,6 +678,27 @@ def synthesis_histogram(
     )
 
 
+def _synth_as_rgb(image: torch.Tensor, channel_idx: int | None) -> bool:
+    """
+    Determine whether to try to plot image as RGB(A).
+
+    Checks whether channel_idx is ``None`` and image.shape[1] > 1.
+
+    Parameters
+    ----------
+    image
+        The tensor we'll be plotting, of shape (batch, channel, height, width).
+    channel_idx
+        If ``None``, we're plotting all channels. Else, the channel to plot.
+
+    Returns
+    -------
+    as_rgb
+        Whether to try to plot this as RGB(A).
+    """
+    return bool(channel_idx is None and image.shape[1] > 1)
+
+
 def synthesis_imshow(
     synthesis_object: Metamer | MADCompetition | Eigendistortion,
     batch_idx: int = 0,
@@ -915,7 +937,7 @@ def synthesis_imshow(
 
     # we're only plotting one image here, so if the user wants multiple
     # channels, they must be RGB
-    as_rgb = bool(channel_idx is None and image.shape[1] > 1)
+    as_rgb = _synth_as_rgb(image, channel_idx)
     if ax is None:
         ax = plt.gca()
     display.imshow(
@@ -1659,6 +1681,7 @@ def synthesis_animate(
     batch_idx: int = 0,
     channel_idx: int | None = None,
     included_plots: list[str] | None = None,
+    process_image: Callable[[torch.Tensor], torch.Tensor] | None = None,
     fig: mpl.figure.Figure | None = None,
     axes_idx: dict[str, int] = {},
     figsize: tuple[float, float] | None = None,
@@ -1701,6 +1724,11 @@ def synthesis_animate(
         Which plots to include. See above for behavior if ``None``, otherwise must be a
         list of strings whose values are names of plotting functions that can accept
         ``synthesis_object``, see above for list.
+    process_image
+        A function to process the stored image over time. E.g., rescaling so all values
+        lie between 0 and 1. If ``None``, no processing is performed for grayscale
+        images, and RGB(A) images will be clipped to lie within [0, 1]. See Warns
+        section for details.
     fig
         If ``None``, we create a new figure. Otherwise we assume this is
         a figure that has the appropriate size and number of subplots.
@@ -1766,6 +1794,15 @@ def synthesis_animate(
     TypeError
         If ``synthesis_object`` is not :class:`~plenoptic.MADCompetition` or
         :class:`~plenoptic.Metamer`
+
+    Warns
+    -----
+    UserWarning
+        If stored image contains values outside of [0, 1], has multiple channels, and
+        ``channel_idx=None``, we will clip each frame so all values lie within [0, 1].
+        (This is because of the requirements of :func:`matplotlib.pyplot.imshow`.) The
+        warning will say how many frames were clipped. To avoid clipping, use
+        ``process_image`` argument to remap values within [0, 1] in some other way.
 
     See Also
     --------
@@ -1951,6 +1988,51 @@ def synthesis_animate(
       >>> ani.save("animate-example-8.gif")
 
     .. image:: animate-example-8.gif
+
+    When working with RGB(A) images, clipping may occur. This is because matplotlib will
+    only display values in the range [0, 1] for RGB(A) images:
+
+    .. plot::
+      :context: close-figs
+
+      >>> img = po.process.center_crop(po.data.color_wheel(), 100)
+      >>> # simple model which convoles identical Gaussians independently on each of the
+      >>> # color channels.
+      >>> class ColorGaussian(torch.nn.Module):
+      >>>     def __init__(self, *args, **kwargs):
+      >>>         super().__init__()
+      >>>         self.model = po.models.Gaussian(*args, **kwargs)
+      >>>         self._forward = torch.vmap(self.model.forward, 1)
+      >>>     def forward(self, x):
+      >>>         return self._forward(x)
+      >>> model = ColorGaussian(30)
+      >>> po.remove_grad(model)
+      >>> met = po.Metamer(img, model)
+      >>> # here we start with an image whose pixel values
+      >>> met.setup(initial_image=torch.rand_like(img) - 0.5)
+      >>> met.synthesize(5, store_progress=True)
+      >>> ani = po.plot.synthesis_animate(met)
+      >>> # Save the video (here we're saving it as a .gif)
+      >>> ani.save("animate-example-9.gif")
+
+    .. image:: animate-example-9.gif
+
+    Many of the pixels in the above video are black because they fall below 0. A
+    warning message is displayed which says how many frames this happens on (this
+    message is not rendered in the online documentation).
+
+    If you wish to avoid this clipping, you can use the ``process_image`` argument to
+    map all pixels within [0, 1] in some other way, such as by linearly rescaling the
+    values with :func:`plenoptic.process.rescale`
+
+    .. plot::
+      :context: close-figs
+
+      >>> ani = po.plot.synthesis_animate(met, process_image=po.process.rescale)
+      >>> # Save the video (here we're saving it as a .gif)
+      >>> ani.save("animate-example-10.gif")
+
+    .. image:: animate-example-10.gif
     """
     if not isinstance(synthesis_object, (Metamer, MADCompetition)):
         raise TypeError(
@@ -1962,6 +2044,38 @@ def synthesis_animate(
     # rescale_ylim only relevant for metamer_representation_error plot
     if isinstance(synthesis_object, Metamer):
         rescale_ylim_interval = _get_rescale_ylim(synthesis_object, rescale_ylim)
+    if isinstance(synthesis_object, Metamer):
+        saved_synth = synthesis_object.saved_metamer
+        # this plot shows the metamer loss, which requires subtracting the penalty off
+        # of the objective function
+        met_loss = (
+            synthesis_object.losses
+            - synthesis_object.penalty_lambda * synthesis_object.penalties
+        )
+        losses = [met_loss]
+        video_name = "saved metamer"
+    elif isinstance(synthesis_object, MADCompetition):
+        saved_synth = synthesis_object.saved_mad_image
+        losses = [
+            synthesis_object.reference_metric_loss,
+            synthesis_object.optimized_metric_loss,
+        ]
+        video_name = "saved mad image"
+
+    as_rgb = _synth_as_rgb(saved_synth[0], channel_idx)
+    if process_image is None and as_rgb:
+        process_image = functools.partial(torch.clip, min=0, max=1)
+        print(saved_synth.shape)
+        to_avoid = "To avoid clipping, use process_image argument."
+        warning_msg = display._clip_frames_warnings_msg(
+            saved_synth, 0, video_name, to_avoid
+        )
+        if warning_msg:
+            warnings.warn(warning_msg)
+    if process_image is not None:
+        saved_synth = process_image(saved_synth)
+        kwargs["synthesis_imshow_kwargs"] = {"process_image": process_image}
+
     fig, axes_dict = _synthesis_status(
         synthesis_object,
         batch_idx,
@@ -1995,22 +2109,6 @@ def synthesis_animate(
         # this here because we need the figure to have been created
         for ax in axes_dict["metamer_representation_error"]:
             ax.set_title(re.sub(r"\n range: .* \n", "\n\n", ax.get_title()))
-
-    if isinstance(synthesis_object, Metamer):
-        saved_synth = synthesis_object.saved_metamer
-        # this plot shows the metamer loss, which requires subtracting the penalty off
-        # of the objective function
-        met_loss = (
-            synthesis_object.losses
-            - synthesis_object.penalty_lambda * synthesis_object.penalties
-        )
-        losses = [met_loss]
-    elif isinstance(synthesis_object, MADCompetition):
-        saved_synth = synthesis_object.saved_mad_image
-        losses = [
-            synthesis_object.reference_metric_loss,
-            synthesis_object.optimized_metric_loss,
-        ]
 
     def movie_plot(i: int) -> list[mpl.artist.Artist]:
         """

--- a/src/plenoptic/plot/synthesis.py
+++ b/src/plenoptic/plot/synthesis.py
@@ -2065,7 +2065,6 @@ def synthesis_animate(
     as_rgb = _synth_as_rgb(saved_synth[0], channel_idx)
     if process_image is None and as_rgb:
         process_image = functools.partial(torch.clip, min=0, max=1)
-        print(saved_synth.shape)
         to_avoid = "To avoid clipping, use process_image argument."
         warning_msg = display._clip_frames_warnings_msg(
             saved_synth, 0, video_name, to_avoid

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -598,6 +598,37 @@ class TestDisplay:
         with pytest.raises(ValueError, match="3 or 4 dimensional"):
             po.plot.update_plot(fig.axes[0], einstein_img.squeeze())
 
+    @pytest.mark.parametrize("pix_range", [(0, 1), (-0.5, 0.5), (-1, 0)])
+    @pytest.mark.parametrize("as_rgb", [True, False])
+    @pytest.mark.parametrize(
+        "video_n,video_i", [(1, [0]), (2, [0]), (2, [1]), (2, [0, 1])]
+    )
+    def test_animshow_rgb_clipping(self, pix_range, as_rgb, video_n, video_i):
+        # with RGB float images, matplotlib will always clip them to lie between 0
+        # and 1 and raise a warning. because of how we animate, this warning gets
+        # raised on each frame. that's annoying, so we do the clipping ourselves,
+        # telling the user how much was lost.
+        n_frames = 5
+        tmp = [torch.rand((1, 3, n_frames, 10, 10)) for _ in range(video_n)]
+        for i in video_i:
+            tmp[i] = po.process.rescale(tmp[i], *pix_range)
+        # no warning if all values lie between 0 and 1 or if we're animating it as
+        # grayscale
+        if pix_range == (0, 1) or not as_rgb:
+            po.plot.animshow(tmp, as_rgb=as_rgb)
+        else:
+            n_clip_min = (einops.reduce(tmp, "v b c t h w -> v t", "min") < 0).sum(1)
+            n_clip_max = (einops.reduce(tmp, "v b c t h w -> v t", "max") > 1).sum(1)
+            n_clip = torch.stack([n_clip_min, n_clip_max]).sum(0)
+            if pix_range == (0, 1):
+                assert all([n_clip[i] == n_frames for i in video_i])
+            warning_msg = [f"{n_clip[i]} frames of video {i}" for i in video_i]
+            with pytest.warns(UserWarning) as record:
+                po.plot.animshow(tmp, as_rgb=as_rgb)
+            assert len(record) == len(warning_msg)
+            for r, msg in zip(record, warning_msg):
+                assert str(r.message).startswith(msg)
+
     @pytest.mark.parametrize("zoom", [None, 0.5, 1, 3, 0, -1, 1.5, 1.1])
     @pytest.mark.parametrize("func", ["imshow", "animshow"])
     def test_zoom(self, zoom, func):

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -929,6 +929,9 @@ class TestMADDisplay:
         "ignore:SSIM was designed for grayscale images:UserWarning"
     )
     @pytest.mark.filterwarnings("ignore:Image range falls outside:UserWarning")
+    @pytest.mark.filterwarnings(
+        "ignore:. frames of saved mad image clipped:UserWarning"
+    )
     def test_custom_fig(self, synthesized_mad, func, fig_creation, tmp_path):
         # tests whether we can create our own figure and pass it to
         # MADCompetition's plotting and animating functions, specifying some or
@@ -980,6 +983,9 @@ class TestMADDisplay:
         "ignore:SSIM was designed for grayscale images:UserWarning"
     )
     @pytest.mark.filterwarnings("ignore:Image range falls outside:UserWarning")
+    @pytest.mark.filterwarnings(
+        "ignore:. frames of saved mad image clipped:UserWarning"
+    )
     def test_allowed_plots_exception(self, synthesized_mad, func, val, variable):
         if func == "plot":
             func = po.plot.synthesis_status
@@ -1151,6 +1157,9 @@ class TestMADDisplay:
     @pytest.mark.parametrize("variable", ["width_ratios", "axes_idx"])
     @pytest.mark.filterwarnings(
         "ignore:SSIM was designed for grayscale images:UserWarning"
+    )
+    @pytest.mark.filterwarnings(
+        "ignore:. frames of saved mad image clipped:UserWarning"
     )
     def test_plot_consistency(self, synthesized_mad, func, variable):
         if func == "plot":
@@ -1400,6 +1409,7 @@ class TestMetamerDisplay:
             "custom-preplot",
         ],
     )
+    @pytest.mark.filterwarnings("ignore:. frames of saved metamer clipped:UserWarning")
     def test_custom_fig(self, synthesized_met, func, fig_creation, tmp_path):
         # tests whether we can create our own figure and pass it to Metamer's
         # plotting and animating functions, specifying some or all of the
@@ -1465,6 +1475,7 @@ class TestMetamerDisplay:
     @pytest.mark.parametrize(
         "variable", ["included_plots", "width_ratios", "axes_idx", "kwargs"]
     )
+    @pytest.mark.filterwarnings("ignore:. frames of saved metamer clipped:UserWarning")
     def test_allowed_plots_exception(self, synthesized_met, func, val, variable):
         if func == "plot":
             func = po.plot.synthesis_status
@@ -1641,6 +1652,7 @@ class TestMetamerDisplay:
     @pytest.mark.parametrize(
         "rescale_ylim", [False, "rescale", "rescale10", (0, 1), "something_weird"]
     )
+    @pytest.mark.filterwarnings("ignore:. frames of saved metamer clipped:UserWarning")
     def test_rescale_ylim_4d(self, synthesized_met, rescale_ylim):
         # these are the allowed values: rescale (default) and False (what we do:
         # nothing)
@@ -1656,6 +1668,7 @@ class TestMetamerDisplay:
     @pytest.mark.parametrize(
         "rescale_ylim", [False, "rescale", "rescale1", (0, 1), "something_weird"]
     )
+    @pytest.mark.filterwarnings("ignore:. frames of saved metamer clipped:UserWarning")
     def test_rescale_ylim_3d(self, synthesized_met_3d, rescale_ylim):
         if rescale_ylim in [False, "rescale", "rescale1"]:
             expectation = does_not_raise()
@@ -1668,6 +1681,7 @@ class TestMetamerDisplay:
 
     @pytest.mark.parametrize("func", ["animate", "plot"])
     @pytest.mark.parametrize("variable", ["width_ratios", "axes_idx"])
+    @pytest.mark.filterwarnings("ignore:. frames of saved metamer clipped:UserWarning")
     def test_plot_consistency(self, synthesized_met, func, variable):
         if func == "plot":
             func = po.plot.synthesis_status

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,4 +1,6 @@
+import functools
 import inspect
+import logging
 from contextlib import nullcontext as does_not_raise
 
 import einops
@@ -24,6 +26,20 @@ mpl.use("agg")
 def close_figures_on_teardown():
     yield
     plt.close("all")
+
+
+# inspired by https://stackoverflow.com/a/59745629/4659293
+@pytest.fixture()
+def no_logs_warnings(caplog):
+    # want to raise an error if there's any logged warnings (or worse). this is intended
+    # to catch matplotlib warning about clipping RGB, which we handle ourselves
+    yield
+    warnings_and_more = [
+        record
+        for record in caplog.get_records("call")
+        if record.levelno >= logging.WARNING
+    ]
+    assert not warnings_and_more
 
 
 class TestDisplay:
@@ -598,29 +614,61 @@ class TestDisplay:
         with pytest.raises(ValueError, match="3 or 4 dimensional"):
             po.plot.update_plot(fig.axes[0], einstein_img.squeeze())
 
-    @pytest.mark.parametrize("pix_range", [(0, 1), (-0.5, 0.5), (-1, 0)])
+    @pytest.mark.parametrize(
+        "pix_range",
+        [
+            "fine",
+            "all-bad-min",
+            "all-bad-max",
+            "all-bad-both",
+            "mixed-min",
+            "mixed-max",
+            "mixed-both",
+        ],
+    )
     @pytest.mark.parametrize("as_rgb", [True, False])
     @pytest.mark.parametrize(
         "video_n,video_i", [(1, [0]), (2, [0]), (2, [1]), (2, [0, 1])]
     )
-    def test_animshow_rgb_clipping(self, pix_range, as_rgb, video_n, video_i):
+    def test_animshow_clipping(
+        self, pix_range, as_rgb, video_n, video_i, no_logs_warnings
+    ):
         # with RGB float images, matplotlib will always clip them to lie between 0
         # and 1 and raise a warning. because of how we animate, this warning gets
         # raised on each frame. that's annoying, so we do the clipping ourselves,
         # telling the user how much was lost.
         n_frames = 5
         tmp = [torch.rand((1, 3, n_frames, 10, 10)) for _ in range(video_n)]
-        for i in video_i:
-            tmp[i] = po.process.rescale(tmp[i], *pix_range)
+        if pix_range == "all-bad-min":
+            for i in video_i:
+                tmp[i] = po.process.rescale(tmp[i], -1, 0)
+        elif pix_range == "all-bad-max":
+            for i in video_i:
+                tmp[i] = po.process.rescale(tmp[i], 0, 2)
+        elif pix_range == "all-bad-both":
+            for i in video_i:
+                tmp[i] = po.process.rescale(tmp[i], -1, 2)
+        elif pix_range == "mixed-min":
+            for i in video_i:
+                t = tmp[i][:, :, ::2]
+                tmp[i][:, :, ::2] = po.process.rescale(t, -1, 0)
+        elif pix_range == "mixed-max":
+            for i in video_i:
+                t = tmp[i][:, :, ::2]
+                tmp[i][:, :, ::2] = po.process.rescale(t, 0, 2)
+        elif pix_range == "mixed-both":
+            for i in video_i:
+                t = tmp[i][:, :, ::2]
+                tmp[i][:, :, ::2] = po.process.rescale(t, -1, 2)
         # no warning if all values lie between 0 and 1 or if we're animating it as
         # grayscale
-        if pix_range == (0, 1) or not as_rgb:
+        if pix_range == "fine" or not as_rgb:
             po.plot.animshow(tmp, as_rgb=as_rgb)
         else:
-            n_clip_min = (einops.reduce(tmp, "v b c t h w -> v t", "min") < 0).sum(1)
-            n_clip_max = (einops.reduce(tmp, "v b c t h w -> v t", "max") > 1).sum(1)
-            n_clip = torch.stack([n_clip_min, n_clip_max]).sum(0)
-            if pix_range == (0, 1):
+            n_clip_min = einops.reduce(tmp, "v b c t h w -> v t", "min") < 0
+            n_clip_max = einops.reduce(tmp, "v b c t h w -> v t", "max") > 1
+            n_clip = torch.stack([n_clip_min, n_clip_max], axis=1).any(1).sum(-1)
+            if pix_range == "all-bad":
                 assert all([n_clip[i] == n_frames for i in video_i])
             warning_msg = [f"{n_clip[i]} frames of video {i}" for i in video_i]
             with pytest.warns(UserWarning) as record:
@@ -1115,6 +1163,75 @@ class TestMADDisplay:
         with pytest.raises(ValueError, match=f"{variable} contains keys"):
             func(synthesized_mad, included_plots=["synthesis_imshow"], **kwargs)
 
+    @pytest.mark.parametrize(
+        "pix_range",
+        [
+            "fine",
+            "all-bad-min",
+            "all-bad-max",
+            "all-bad-both",
+            "mixed-min",
+            "mixed-max",
+            "mixed-both",
+        ],
+    )
+    @pytest.mark.parametrize("process_image", [None, "rescale"])
+    @pytest.mark.filterwarnings("ignore:Image range falls outside:UserWarning")
+    @pytest.mark.filterwarnings(
+        "ignore:SSIM was designed for grayscale images:UserWarning"
+    )
+    def test_animate_clipping(
+        self, synthesized_mad_store_progress, pix_range, process_image, no_logs_warnings
+    ):
+        # with RGB float images, matplotlib will always clip them to lie between 0
+        # and 1 and raise a warning. because of how we animate, this warning gets
+        # raised on each frame. that's annoying, so we do the clipping ourselves,
+        # telling the user how much was lost.
+        # here, we manually overwrite saved_mad_image so we know what it looks like
+        saved_mad = synthesized_mad_store_progress.saved_mad_image
+        if process_image == "rescale":
+            # this is a way to avoid the warning: pass an argument that will do the
+            # proper remapping for you
+            process_image = functools.partial(po.process.rescale, a=0, b=1)
+        if pix_range == "fine":
+            saved_mad = po.process.rescale(saved_mad, 0, 1)
+        elif pix_range == "all-bad-min":
+            saved_mad = po.process.rescale(saved_mad, -1, 0)
+        elif pix_range == "all-bad-max":
+            saved_mad = po.process.rescale(saved_mad, 0, 2)
+        elif pix_range == "all-bad-both":
+            saved_mad = po.process.rescale(saved_mad, -1, 2)
+        elif pix_range == "mixed-min":
+            saved_mad[::2] = po.process.rescale(saved_mad[::2], -1, 0)
+            saved_mad[1::2] = po.process.rescale(saved_mad[1::2], 0, 1)
+        elif pix_range == "mixed-max":
+            saved_mad[::2] = po.process.rescale(saved_mad[::2], 0, 2)
+            saved_mad[1::2] = po.process.rescale(saved_mad[1::2], 0, 1)
+        elif pix_range == "mixed-both":
+            saved_mad[::2] = po.process.rescale(saved_mad[::2], -1, 2)
+            saved_mad[1::2] = po.process.rescale(saved_mad[1::2], 0, 1)
+        as_rgb = synthesized_mad_store_progress.image.shape[1] != 1
+        if not as_rgb or pix_range == "fine" or process_image:
+            expectation = does_not_raise()
+        else:
+            n_clip_min = einops.reduce(saved_mad, "t b c h w -> t", "min") < 0
+            n_clip_max = einops.reduce(saved_mad, "t b c h w -> t", "max") > 1
+            n_clip = torch.stack([n_clip_min, n_clip_max]).any(0).sum()
+            if pix_range == "all-bad":
+                assert all(
+                    [n_clip == len(synthesized_mad_store_progress.saved_mad_image)]
+                )
+            msg = f"{n_clip} frames of saved mad image"
+            expectation = pytest.warns(UserWarning, match=msg)
+        # last index here is the metamer attribute, which we need for computing the
+        # clipped frames above, but should leave out of the _saved_mad_image attribute
+        synthesized_mad_store_progress._saved_mad_image = saved_mad[:-1]
+        synthesized_mad_store_progress._mad_image = saved_mad[-1]
+        with expectation:
+            po.plot.synthesis_animate(
+                synthesized_mad_store_progress, process_image=process_image
+            )
+
 
 class TestMetamerDisplay:
     @pytest.fixture(scope="class", params=["rgb", "grayscale"])
@@ -1561,6 +1678,71 @@ class TestMetamerDisplay:
             kwargs[variable]["misc"] = 2
         with pytest.raises(ValueError, match=f"{variable} contains keys"):
             func(synthesized_met, included_plots=["synthesis_imshow"], **kwargs)
+
+    @pytest.mark.parametrize(
+        "pix_range",
+        [
+            "fine",
+            "all-bad-min",
+            "all-bad-max",
+            "all-bad-both",
+            "mixed-min",
+            "mixed-max",
+            "mixed-both",
+        ],
+    )
+    @pytest.mark.parametrize("process_image", [None, "rescale"])
+    def test_animate_clipping(
+        self, synthesized_met_store_progress, pix_range, process_image, no_logs_warnings
+    ):
+        # with RGB float images, matplotlib will always clip them to lie between 0
+        # and 1 and raise a warning. because of how we animate, this warning gets
+        # raised on each frame. that's annoying, so we do the clipping ourselves,
+        # telling the user how much was lost.
+        # here, we manually overwrite saved_metamer so we know what it looks like
+        saved_met = synthesized_met_store_progress.saved_metamer
+        if process_image == "rescale":
+            # this is a way to avoid the warning: pass an argument that will do the
+            # proper remapping for you
+            process_image = functools.partial(po.process.rescale, a=0, b=1)
+        if pix_range == "fine":
+            saved_met = po.process.rescale(saved_met, 0, 1)
+        elif pix_range == "all-bad-min":
+            saved_met = po.process.rescale(saved_met, -1, 0)
+        elif pix_range == "all-bad-max":
+            saved_met = po.process.rescale(saved_met, 0, 2)
+        elif pix_range == "all-bad-both":
+            saved_met = po.process.rescale(saved_met, -1, 2)
+        elif pix_range == "mixed-min":
+            saved_met[::2] = po.process.rescale(saved_met[::2], -1, 0)
+            saved_met[1::2] = po.process.rescale(saved_met[1::2], 0, 1)
+        elif pix_range == "mixed-max":
+            saved_met[::2] = po.process.rescale(saved_met[::2], 0, 2)
+            saved_met[1::2] = po.process.rescale(saved_met[1::2], 0, 1)
+        elif pix_range == "mixed-both":
+            saved_met[::2] = po.process.rescale(saved_met[::2], -1, 2)
+            saved_met[1::2] = po.process.rescale(saved_met[1::2], 0, 1)
+        as_rgb = synthesized_met_store_progress.image.shape[1] != 1
+        if not as_rgb or pix_range == "fine" or process_image:
+            expectation = does_not_raise()
+        else:
+            n_clip_min = einops.reduce(saved_met, "t b c h w -> t", "min") < 0
+            n_clip_max = einops.reduce(saved_met, "t b c h w -> t", "max") > 1
+            n_clip = torch.stack([n_clip_min, n_clip_max]).any(0).sum()
+            if pix_range == "all-bad":
+                assert all(
+                    [n_clip == len(synthesized_met_store_progress.saved_metamer)]
+                )
+            msg = f"{n_clip} frames of saved metamer"
+            expectation = pytest.warns(UserWarning, match=msg)
+        # last index here is the metamer attribute, which we need for computing the
+        # clipped frames above, but should leave out of the _saved_metamer attribute
+        synthesized_met_store_progress._saved_metamer = saved_met[:-1]
+        synthesized_met_store_progress._metamer = saved_met[-1]
+        with expectation:
+            po.plot.synthesis_animate(
+                synthesized_met_store_progress, process_image=process_image
+            )
 
 
 class TestEigendistortionDisplay:


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

In workshop materials for [CSHL](https://workshops.plenoptic.org/workshops/CSHL-vision-course-2026/branch/main/exercises/4_torchvision.html), noticed that the matplotlib RGB clipping warning gets printed on every frame where it comes up during animations (probably because of how we update the image). In the link above, this meant that when animating a deepnet metamer synthesis, we got that warning printed 100 times.

Turns out, this isn't warned using `warnings.warn` but `logging.warn`, which is used because (per [python docs](https://docs.python.org/3/howto/logging.html)):

> warnings.warn() in library code if the issue is avoidable and the client application should be modified to eliminate the warning
>
> A logger’s warning() method if there is nothing the client application can do about the situation, but the event should still be noted

Because of this, I can't catch the warning and do simple filtering using `warnings.filterwarnings`

Thus, instead we do the clipping ourselves in the animate functions, raising a single specific warning to say how many frames were clipped. This affects `animshow` and `synthesis_animate`, but in different ways.

Updated API pages for [synthesis_animate](https://docs.plenoptic.org/docs/pulls/462/api/generated/plenoptic.plot.synthesis_animate.html), [animshow](https://docs.plenoptic.org/docs/pulls/462/api/generated/plenoptic.plot.animshow.html)

**Describe changes**

- `animshow`: for each video, determine how many frames would be cliped and raise a separate warning for each (specifying video index and number of frames), then clip manually. no other functionality added, if users want to avoid clipping, they need to do so external to this function
- `synthesis_animate`:
    - warns similarly (though there's always only a single video). 
    - adds `process_image` argument, analogous to `synthesis_imshow`. set to none by default, in which case we clip color images (and don't do anything to grayscale). users can manually set this to avoid the clipping in other ways (e.g., with plenoptic's included linear-rescaling function)
- adds tests for that new functionality
- adds new examples to `synthesis_animate` docstring showing clipping and use of `process_image`
- adds simple helper function to determine whether a single image is RGB (for `synthesis_imshow` and `synthesis_animate`)
- adds helper function to determine how many frames would be clipped and format warning message.
- remove `warnings.filterwarnings` at top of Eigendistortion notebook, since it doesn't do anything.
- in `test_display.py`, figured out how to convert matplotlib's logged warnings into an error with the `no_logs_warnings` fixture. this is only applied to the tests where I'm interested in specifically looking into the clipping issue.

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
