### PR TITLE
Fix issue where MADCompetition attributes were not tab-completing in ipython/jupyter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,12 @@ repos:
       files: ^docs/
       entry: linting/fix_tutorial_semicolons.py
       additional_dependencies: ["jupytext"]
+    - id: return-literal-annotation
+      language: python
+      name: Ensure we have no Literal return annotations
+      types_or: ["python"]
+      files: ^src/
+      entry: linting/check_return_literal.py
 
 - repo: https://github.com/codespell-project/codespell
   # Configuration for codespell is in pyproject.toml

--- a/linting/check_return_literal.py
+++ b/linting/check_return_literal.py
@@ -1,0 +1,52 @@
+"""
+Raise error if we ever have a literal return annotation.
+
+Realized that if a function has a Literal return annotation, e.g.,:
+
+def func() -> Literal["x"]:
+   return "x"
+
+then ipython's autocomplete doesn't work; if a single method in a class has this, then
+all the autocompletes fail. found this issue about it
+(https://github.com/ipython/ipython/issues/14412), which discovered it's a jedi issue
+(https://github.com/davidhalter/jedi/issues/1990) which they haven't fixed for over two
+years.
+
+to avoid this, just ensure that we don't have any of them (replace with the generic
+version instead).
+
+This checks in the simplest possible way: looking for the string "-> Literal".
+
+I also found out that returning a tuple with Literal in it, e.g.,:
+
+def func() -> tuple[Literal["x"], int]:
+    return "x", 1
+
+does not have this problem.
+"""
+
+import pathlib
+import sys
+
+paths = []
+for p in sys.argv[1:]:
+    p = pathlib.Path(p)
+    if p.is_dir():
+        p = list(p.glob("**/*.py"))
+    elif p.suffix == ".py":
+        p = [p]
+    else:
+        p = []
+    paths.extend(p)
+
+error_files = []
+for p in paths:
+    txt = p.read_text()
+    if "-> Literal" in txt:
+        error_files.append(p)
+
+if error_files:
+    print("return Literal annotation found in following files:")
+    for f in error_files:
+        print(f"\t{f}")
+    sys.exit(1)

--- a/linting/check_return_literal.py
+++ b/linting/check_return_literal.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Raise error if we ever have a literal return annotation.
 

--- a/src/plenoptic/_synthesize/mad_competition.py
+++ b/src/plenoptic/_synthesize/mad_competition.py
@@ -955,7 +955,7 @@ class MADCompetition(_OptimizedSynthesis):
         return self._metric_tradeoff_lambda
 
     @property
-    def minmax(self) -> Literal["min", "max"]:
+    def minmax(self) -> str:
         """Whether we are minimizing or maximizing :attr:`optimized_metric`."""
         # numpydoc ignore=RT01,ES01
         return self._minmax


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

I recently noticed that tab completion was not working for `po.MADCompetition` (either the class or instances) in ipython or jupyter. Turns out, it's an issue with [jedi](https://github.com/davidhalter/jedi/issues/1990), which underlies that tab completion. They should fix it, but until they do, the solution on our end is to make sure we have no `Literal` return annotations. This does that and then adds a new check to pre-commit to ensure we don't add any more of them.

From the user end, they could also run `%config IPCompleter.use_jedi = False` in ipython/jupyter, which fixes it. (found in https://github.com/ipython/ipython/issues/14412)

**Describe changes**

- Change return annotation of `MADCompetition.minmax` to `str` from `Literal['min','max']`.
- add new check script, `linting/check_return_literal.py`, which checks whether the substring `-> Literal` is present in `.py`.
- adds that script to pre-commit, only running on python files within `src/`

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
