### PR TITLE
Updates `__all__`, add `validate_penalty` to init

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,12 @@ repos:
       types_or: ["python"]
       files: ^src/
       entry: linting/check_return_literal.py
+    - id: check-api-docs
+      language: system
+      name: Ensure all public functions / classes are included in _api_change.py
+      entry: python linting/check_apidocs.py
+      always_run: true
+      pass_filenames: false
 
 - repo: https://github.com/codespell-project/codespell
   # Configuration for codespell is in pyproject.toml

--- a/linting/check_api_change.py
+++ b/linting/check_api_change.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# confirm that the _api_change.py file specifies all public functions
+
+import pathlib
+import re
+import sys
+
+# These are the files whose contents we don't want in the api docs. that's __init__.py
+# and those whose contents are meant for internal use
+EXCLUDE_MODULES = ["__init__.py", "conftest.py"]
+
+src_modules = pathlib.Path("src/plenoptic").glob("**/*.py")
+src_modules = [m for m in src_modules if m.name not in EXCLUDE_MODULES]
+# match public functions and classes that aren't nested (i.e., no tabs, don't start with
+# underscore)
+src_pattern = re.compile(r"^(?:def|class) ([A-Za-z].*)\(", flags=re.MULTILINE)
+
+sys.path.append("src/plenoptic/")
+import _api_change  # noqa: E402
+
+UPDATED_API = _api_change.API_CHANGE
+UPDATED_API.update(_api_change.SYNTH_PLOT_FUNCS)
+UPDATED_API.update(_api_change.PLOT_FUNCS)
+NEW_FUNCS = _api_change.NEW
+
+ALL_FUNCS = set(UPDATED_API.values()).union(NEW_FUNCS + _api_change.UNCHANGED)
+# making this behave similar to the dict in check_apidocs.py
+match_dict = {}
+for func in ALL_FUNCS:
+    func_split = func.split(".")
+    mod = ".".join(func_split[:-1])
+    if mod in match_dict:
+        match_dict[mod].append(func_split[-1])
+    else:
+        match_dict[mod] = [func_split[-1]]
+
+
+src_not_api_change = []
+for module in src_modules:
+    api_objs = []
+    # last two here will be . and ./src, which we can drop
+    possible_modules = [f.name for f in module.parents][:-2]
+    # reverse this so it goes from biggest (plenoptic) to smallest in scope
+    possible_modules = possible_modules[::-1]
+    # add the current module at the end
+    possible_modules.append(module.stem)
+    mod_name = ""
+    for p in possible_modules:
+        mod_name = ".".join([mod_name, p])
+        if mod_name[0] == ".":
+            mod_name = mod_name[1:]
+        api_objs.extend(match_dict.get(mod_name, []))
+    module_text = module.read_text()
+    src_objs = re.findall(src_pattern, module_text)
+    if missing_objs := set(src_objs) - set(api_objs):
+        src_not_api_change.append((module, missing_objs))
+
+
+if src_not_api_change:
+    print(
+        "The following public functions/classes are not found in the "
+        "_api_change.py file!"
+    )
+    for mod, objs in src_not_api_change:
+        print(f"{mod}:")
+        for ob in objs:
+            print(f"\t{ob}")
+    sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,8 @@ select = [
     # docstrings, note that DOC rules (pydoclint) are all in preview, so have to be explicitly added
     "D", "DOC201", "DOC202", "DOC402", "DOC403", "DOC501",
     "ANN",
+    # catch missing f-strings
+    "RUF027",
 ]
 ignore = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ select = [
     # docstrings, note that DOC rules (pydoclint) are all in preview, so have to be explicitly added
     "D", "DOC201", "DOC202", "DOC402", "DOC403", "DOC501",
     "ANN",
-    # catch missing f-strings
+    # catch missing f-strings (this is in preview and so has to be explicitly added)
     "RUF027",
 ]
 ignore = []

--- a/src/plenoptic/_api_change.py
+++ b/src/plenoptic/_api_change.py
@@ -188,6 +188,16 @@ DEPRECATED = [
 ]
 
 NEW = [
+    "plenoptic.validate.validate_penalty",
     "plenoptic.plot.histogram",
     "plenoptic.io.LoadWarning",
+]
+
+UNCHANGED = [
+    "plenoptic.__version__",
+    "plenoptic.data.curie",
+    "plenoptic.data.reptile_skin",
+    "plenoptic.data.color_wheel",
+    "plenoptic.data.einstein",
+    "plenoptic.data.parrot",
 ]

--- a/src/plenoptic/_synthesize/mad_competition.py
+++ b/src/plenoptic/_synthesize/mad_competition.py
@@ -22,7 +22,7 @@ from tqdm.auto import tqdm
 
 from .. import regularize
 from ..convergence import _loss_convergence
-from ..validate import validate_input, validate_metric
+from ..validate import validate_input, validate_metric, validate_penalty
 from .synthesis import _OptimizedSynthesis
 
 __all__ = [
@@ -112,6 +112,7 @@ class MADCompetition(_OptimizedSynthesis):
             image_dtype=image.dtype,
             device=image.device,
         )
+        validate_penalty(penalty_function, image.shape, image.dtype, image.device)
         self._optimized_metric = optimized_metric
         self._reference_metric = reference_metric
         self._image = image.detach()

--- a/src/plenoptic/_synthesize/metamer.py
+++ b/src/plenoptic/_synthesize/metamer.py
@@ -19,7 +19,12 @@ from tqdm.auto import tqdm
 from .. import loss, regularize
 from ..convergence import _coarse_to_fine_enough, _loss_convergence
 from ..process import signal
-from ..validate import validate_coarse_to_fine, validate_input, validate_model
+from ..validate import (
+    validate_coarse_to_fine,
+    validate_input,
+    validate_model,
+    validate_penalty,
+)
 from .synthesis import _OptimizedSynthesis
 
 __all__ = [
@@ -108,6 +113,7 @@ class Metamer(_OptimizedSynthesis):
             image_dtype=image.dtype,
             device=image.device,
         )
+        validate_penalty(penalty_function, image.shape, image.dtype, image.device)
         self._model = model
         self._image = image
         self._image_shape = image.shape

--- a/src/plenoptic/loss.py
+++ b/src/plenoptic/loss.py
@@ -20,6 +20,7 @@ __all__ = [
     "l2_norm",
     "relative_sse",
     "portilla_simoncelli_loss_factory",
+    "groupwise_relative_l2_norm_factory",
 ]
 
 

--- a/src/plenoptic/plot/synthesis.py
+++ b/src/plenoptic/plot/synthesis.py
@@ -455,7 +455,7 @@ def _get_synthesis_title(
             raise ValueError(
                 "When synthesis_object is an Eigendistortion, iteration must be None!"
             )
-        title_names = ["Eigendistortion[{batch_idx}]", "Reference"]
+        title_names = ["Eigendistortion[{batch_idx}]", "Reference"]  # noqa: RUF027
         if batch_idx is None:
             batch_idx = synthesis_object.eigenindex
     else:

--- a/src/plenoptic/validate.py
+++ b/src/plenoptic/validate.py
@@ -605,7 +605,7 @@ def validate_penalty(
     if output_dtype != allowed_dtypes:
         raise TypeError(
             "penalty_function should not change precision of the input, but got type"
-            ", {output_dtype} instead of {allowed_dtypes}"
+            f", {output_dtype} instead of {allowed_dtypes}"
         )
     if output.device != test_img.device:
         # pytorch device errors are RuntimeErrors

--- a/src/plenoptic/validate.py
+++ b/src/plenoptic/validate.py
@@ -540,9 +540,13 @@ def validate_penalty(
     """
     if image_shape is None:
         image_shape = (1, 1, 16, 16)
-    test_img = torch.rand(
+    # avoiding calling torch.rand, because that offsets the seed, breaking
+    # reproducibility
+    test_img = torch.ones(
         image_shape, dtype=image_dtype, requires_grad=False, device=device
     )
+    # give it some variation in values
+    test_img[..., ::2] = 0
     try:
         penalty = penalty_function(test_img)
     except TypeError:

--- a/src/plenoptic/validate.py
+++ b/src/plenoptic/validate.py
@@ -21,6 +21,7 @@ __all__ = [
     "validate_coarse_to_fine",
     "validate_metric",
     "validate_convert_tensor_dict",
+    "validate_penalty",
 ]
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ UPDATED_API.update(_api_change.SYNTH_PLOT_FUNCS)
 UPDATED_API.update(_api_change.PLOT_FUNCS)
 
 NEW_FUNCS = _api_change.NEW
+UNCHANGED = _api_change.UNCHANGED
 
 
 def test_api_nesting():
@@ -72,20 +73,34 @@ def test_new_api():
             if (
                 mod_name not in UPDATED_API.values()
                 and mod_name not in NEW_FUNCS
-                and mod_name not in OLD_API
+                and mod_name not in UNCHANGED
             ):
-                raise ValueError(f"{mod_name} not found in api change or old api!")
+                raise ValueError(f"{mod_name} not found in api change!")
         else:
             for mod2 in dir(obj):
                 mod2_name = f"plenoptic.{mod}.{mod2}"
                 if (
                     mod2_name not in UPDATED_API.values()
                     and mod2_name not in NEW_FUNCS
-                    and mod2_name not in OLD_API
+                    and mod2_name not in UNCHANGED
                 ):
-                    raise ValueError(f"{mod2_name} not found in api change or old api!")
+                    raise ValueError(f"{mod2_name} not found in api change!")
 
 
-# get old api and check:
-# - that everything in current API is either in old api or in _api_change
-# - that everything in new and not old is in _api_change
+def test_dunder_all():
+    # ensure that everything specified in _api_change is found in plenoptic's __all__ /
+    # __dir__. this is the inverse of the above, which checks that everything found in
+    # __dir__ is present in _api_change
+    all_funcs = set(UPDATED_API.values()).union(NEW_FUNCS + UNCHANGED)
+    current_public = []
+    for mod in dir(plenoptic):
+        mod_name = f"plenoptic.{mod}"
+        obj = eval(mod_name)
+        if not inspect.ismodule(obj):
+            current_public.append(mod_name)
+        else:
+            for mod2 in dir(obj):
+                current_public.append(f"plenoptic.{mod}.{mod2}")
+    extra_funcs = set(all_funcs) - set(current_public)
+    if extra_funcs:
+        raise ValueError(f"{extra_funcs} not found in any module's __dir__!")

--- a/tests/test_mad.py
+++ b/tests/test_mad.py
@@ -449,8 +449,7 @@ class TestMAD:
                 )
             mad.load(tmp_path / "test_mad_load_metric_change.pt")
 
-    @pytest.mark.parametrize("penalty_behav", ["dtype", "shape", "name"])
-    def test_load_penalty_change(self, einstein_img, penalty_behav, tmp_path):
+    def test_load_penalty_change(self, einstein_img, tmp_path):
         def base_penalty(x):
             return po.regularize.penalize_range(x)
 
@@ -467,20 +466,10 @@ class TestMAD:
         mad.save(tmp_path / "test_mad_load_penalty_change.pt")
 
         def new_penalty(x):
-            penalty = base_penalty(x)
-            if penalty_behav == "dtype":
-                return penalty.to(torch.float64)
-            if penalty_behav == "shape":
-                return torch.stack([penalty, penalty])
-            return penalty
+            return base_penalty(x)
 
-        if penalty_behav == "name":
-            expectation = "Saved and initialized penalty_function have different names"
-        else:
-            expectation = (
-                "Saved and initialized penalty_function output have different"
-                f" {penalty_behav}"
-            )
+        expectation = "Saved and initialized penalty_function have different names"
+
         mad = po.MADCompetition(
             einstein_img,
             po.metric.mse,


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

Realized that `validate_penalty` and `groupwise_relative_l2_norm_factory` weren't showing up when tab-completing, and turns out they weren't in `__all__`. This adds them, along with some checks to ensure this doesn't happen again.

Also adds `validate_penalty` to the initialization of Metamer and MADCompetition (@dherrera1911 had pointed out we forgot to put them there). I then changed the initialization of the test image to avoid using `torch.rand`, since that was essentially incrementing the random seed by an additional step, leading to breaking backwards compatibility.

(@dherrera1911 we had discussed using `torch.eye` but that wouldn't work if the user wanted to synthesize a tensor of shape `1,1,200`, for example. So instead I use `torch.ones` and then set some of the values to 0.)

**Describe changes**

- Adds `groupwise_relative_l2_norm_factory` and `validate_penalty` to their respective module's `__all__`
 - Adds `linting/check_api_change.py` to ensure that all public functions/classes are included in `_api_change.py` (follows same logic of earlier `linting/check_apidocs.py`)
 - Adds that to pre-commit
 - Adds test to `test_api.py` which checks that all functions/classes specified in `_api_change.py` are found in `__dir__` of a plenoptic module (the reverse was already tested)
 - Adds `validate_penalty` to `Metamer.__init__` and `MADCompetition.__init__`
     - removes conditions in `test_mad.test_load_penalty_change` which looked for loading behavior when shape or dtype were changed by penalty -- those are disallowed by `validate_penalty`
 - Adds RUF027 linting rule to check for unformatted f-strings
 - Adds `validate_penalty` to `_api_change.py`, along with the unchanged functions/attributes
 - Change `validate_penalty` to avoid using `torch.rand`
 - Fix f-string in `validate_penalty`

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
