### PR TITLE
Fix flaky zenodo url checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
       with:
         file_types: .md,.py,.rst
         print_all: false
-        timeout: 15
+        timeout: 25
         retry_count: 5
         exclude_urls: https://github.com/github-username/plenoptic.git
   validate_switcher_json:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,8 +184,8 @@ jobs:
       with:
         file_types: .md,.py,.rst
         print_all: false
-        timeout: 25
-        retry_count: 5
+        timeout: 5
+        retry_count: 3
         exclude_urls: https://github.com/github-username/plenoptic.git
   validate_switcher_json:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,8 +184,8 @@ jobs:
       with:
         file_types: .md,.py,.rst
         print_all: false
-        timeout: 5
-        retry_count: 3
+        timeout: 15
+        retry_count: 5
         exclude_urls: https://github.com/github-username/plenoptic.git
   validate_switcher_json:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/plenoptic-org/plenoptic/blob/main/LICENSE)
 ![Python version](https://img.shields.io/badge/python-3.10|3.11|3.12|3.13|3.14-blue.svg)
 [![Build Status](https://github.com/plenoptic-org/plenoptic/workflows/build/badge.svg)](https://github.com/plenoptic-org/plenoptic/actions?query=workflow%3Abuild)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10151130.svg)](https://doi.org/10.5281/zenodo.10151130)
+[![DOI](https://img.shields.io/badge/DOI-10.5281/zenodo.10151130-blue)](https://doi.org/10.5281/zenodo.10151130)
 [![codecov](https://codecov.io/gh/plenoptic-org/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA)](https://codecov.io/gh/plenoptic-org/plenoptic)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/format.json)](https://github.com/astral-sh/ruff)
@@ -119,7 +119,7 @@ code, but just discussing the project, please cite the paper. You can click on
 `Cite this repository` on the right side of the GitHub page to get a copyable
 citation for the code, or use the following:
 
-- Code: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10151130.svg)](https://doi.org/10.5281/zenodo.10151130)
+- Code: [![DOI](https://img.shields.io/badge/DOI-10.5281/zenodo.10151130-blue)](https://doi.org/10.5281/zenodo.10151130)
 - Paper:
   ``` bibtex
   @article{duong2023plenoptic,

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/plenoptic-org/plenoptic/blob/main/LICENSE)
 ![Python version](https://img.shields.io/badge/python-3.10|3.11|3.12|3.13|3.14-blue.svg)
 [![Build Status](https://github.com/plenoptic-org/plenoptic/workflows/build/badge.svg)](https://github.com/plenoptic-org/plenoptic/actions?query=workflow%3Abuild)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10151130.svg)](https://doi.org/10.5281/zenodo.10151130)
+[![DOI](https://img.shields.io/badge/DOI-10.5281/zenodo.10151130-blue)](https://doi.org/10.5281/zenodo.10151130)
 [![codecov](https://codecov.io/gh/plenoptic-org/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA)](https://codecov.io/gh/plenoptic-org/plenoptic)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/format.json)](https://github.com/astral-sh/ruff)

--- a/docs/reference/citation.md
+++ b/docs/reference/citation.md
@@ -4,7 +4,7 @@
 
 If you use `plenoptic` in a published academic article or presentation, please cite both the code by the DOI (for the specific version you used) as well as the current publication, {cite:alp}`Duong2023-plenop`. You can use the following:
 
-- Most recent version of code: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10151130.svg)](https://doi.org/10.5281/zenodo.10151130)
+- Most recent version of code: [![DOI](https://img.shields.io/badge/DOI-10.5281/zenodo.10151130-blue)](https://doi.org/10.5281/zenodo.10151130)
 
   - See [zenodo](https://zenodo.org/search?q=parent.id%3A10151130&f=allversions%3Atrue&l=list&p=1&s=10&sort=version) for DOIs for older versions of the code.
 


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

Our url checker action regularly fails because of the zenodo badge svg, but every time I click on the link to manually check it, it's fine.

~Here, we try simply increasing the timeout and retries (as [suggested](https://github.com/urlstechie/urlchecker-action/issues/93)). If that doesn't work, I'll exclude it from the check (which isn't ideal, but I think if there's a problem with zenodo one of the other urls will also go down).~

That approach did not work. Instead, inspired by https://github.com/GenericMappingTools/pygmt/issues/4665, I swapped out the zenodo badges with a static one from https://shields.io with the same content.

**Link any related issues, discussions, PRs**

Closes #471

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
