### PR TITLE
Fix bug in steerable pyramid multichannel lowpass reconstruction

### DIFF
--- a/src/plenoptic/process/steerable_pyramid_freq.py
+++ b/src/plenoptic/process/steerable_pyramid_freq.py
@@ -1019,7 +1019,7 @@ class SteerablePyramidFreq(nn.Module):
                     dim=(-2, -1),
                     norm=self.fft_norm,
                 )
-                lodft = fft.fftshift(lodft)
+                lodft = fft.fftshift(lodft, dim=(-2, -1))
             else:
                 lodft = fft.fft2(
                     torch.zeros_like(pyr_coeffs["residual_lowpass"]),

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -163,19 +163,15 @@ class TestSteerablePyramid:
         params=[f"{shape}" for shape in [None, 224, "128_1", "128_2"]],
     )
     @classmethod
-    def multichannel_img(cls, request):
+    def multichannel_img(cls, color_img, request):
         shape = request.param
-        # use fixture for img and use color_wheel instead.
-        img = po.load_images(IMG_DIR / "256" / "color_wheel.jpg", as_gray=False).to(
-            DEVICE
-        )
         if shape == "224":
-            img = img[..., :224, :224]
+            color_img = color_img[..., :224, :224]
         elif shape == "128_1":
-            img = img[..., :128, :]
+            color_img = color_img[..., :128, :]
         elif shape == "128_2":
-            img = img[..., :128]
-        return img
+            color_img = color_img[..., :128]
+        return color_img
 
     # WARNING: because this fixture requires the img fixture above, it should
     # only be used in tests that also use the img fixture. That is, tests where

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -166,7 +166,7 @@ class TestSteerablePyramid:
     def multichannel_img(cls, request):
         shape = request.param
         # use fixture for img and use color_wheel instead.
-        img = po.load_images(IMG_DIR / "mixed" / "flowers.jpg", as_gray=False).to(
+        img = po.load_images(IMG_DIR / "256" / "color_wheel.jpg", as_gray=False).to(
             DEVICE
         )
         if shape == "224":


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

Image reconstruction from Steerable Pyramid coefficients had a bug for multichannel images with lowpass band. When `"residual_lowpass"` is in the reconstruction band, `fft.fftshift()` is called without specifying `dim=(-2,-1)`, producing a shift of the batch and channel dimensions too.

A test already existed that should have caught this, but it was faulty. This PR also fixes the test.

**Link any related issues, discussions, PRs**

I wonder if this bug affected attempts at synthesizing color PortillaSimoncelli textures from #46. 

**Outstanding questions / particular feedback**

In testing we use `po.load_images(IMG_DIR ...` instead of `po.data.image_name()` on purpose, right? Something related to making tests robust to potential problems in `po.data`?

**Describe changes**

The change in `SteerablePyramidFreq()` just involved adding `dim=(-2, -1)` to a line in `_recon_levels()`, to not shift batch and channel dimensions.

On my way to add a regression test for this, I noticed that `test_steerable_pyr.py::test_complete_recon_multi` should have caught this problem. Then looking closer, I realized that `multichannel_img()` defined there used the `flowers.jpg`, which is apparently a grayscale image. Although it was imported with `as_gray=False`, the three color channels were identical, and the color channel shift in reconstruction was not captured.

I changed the loaded image to `color_wheel.jpg` (matching a stale comment in the test), and now `test_complete_recon_multi()` did fail for the current `main` branch, showcasing the bug. The test passes with the fix of this PR, so this fix constitutes a regression test.

Note, I didn't run all of Steerable Pyramid testing suite with the actual color image, so we'll learn if any other failures appear when CI/CD is run.


**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.


**AI usage disclaimer:**

This bug was caught by a coding agent as I worked on the color version of PortillaSimoncelli. I made sure to understand the problem, and I identified and fixed the faulty test myself.