### PR TITLE
Bugfix: adds support, testing for plotting/updating 2d representations in `DeepNetFeatures`

### DIFF
--- a/src/plenoptic/models/feature_extractor.py
+++ b/src/plenoptic/models/feature_extractor.py
@@ -456,6 +456,11 @@ class DeepNetFeatures(torch.nn.Module):
             A list of the artists used to update the information on the
             plots.
 
+        Raises
+        ------
+        ValueError
+            If the data to use is not 2, 3, or 4 dimensional.
+
         See Also
         --------
         plot_representation
@@ -499,23 +504,50 @@ class DeepNetFeatures(torch.nn.Module):
             data = self.convert_to_dict(data)
 
         artists = []
-        per_channel_reps = []
-        for i, (k, v) in enumerate(data.items()):
-            # Average representation across channels
-            avg_channel_rep = v.mean(dim=1, keepdim=True)
-            # Average representation across additional dimensions (probably space)
-            per_channel_rep = v.mean(dim=tuple(np.arange(2, v.ndim)))
-            while per_channel_rep.ndim < 3:
-                per_channel_rep = per_channel_rep.unsqueeze(0)
-            per_channel_reps.append(per_channel_rep)
-            art = display.update_plot(
-                axes[2 * i : 2 * (i + 1)],
-                {"00": avg_channel_rep, "01": per_channel_rep},
-                batch_idx=batch_idx,
-            )
+        axis_i = 0
+        # keep track of the axes which contain plots to rescale and the data plotted on
+        # them
+        rescalable_axes = []
+        rescalable_reps = []
+        for k, v in data.items():
+            if v.ndim in [3, 4]:
+                # Average representation across channels
+                avg_channel_rep = v.mean(dim=1, keepdim=True)
+                # Average representation across additional dimensions (probably space)
+                per_channel_rep = v.mean(dim=tuple(np.arange(2, v.ndim)))
+                while per_channel_rep.ndim < 3:
+                    per_channel_rep = per_channel_rep.unsqueeze(0)
+                rescalable_reps.append(per_channel_rep)
+                art = display.update_plot(
+                    axes[axis_i : axis_i + 2],
+                    {"00": avg_channel_rep, "01": per_channel_rep},
+                    batch_idx=batch_idx,
+                )
+                # the second axis, showing per-channel rep, is a stem plot and so we
+                # want to rescale it
+                rescalable_axes.append(axis_i + 1)
+                axis_i += 2
+            elif v.ndim == 2:
+                # then there's only a single axis
+                art = display.update_plot(
+                    axes[axis_i],
+                    {"_container0": v.unsqueeze(1)},
+                    batch_idx=batch_idx,
+                )
+                # this axis is a stem plot, and so we want to rescale it
+                rescalable_axes.append(axis_i)
+                rescalable_reps.append(v.unsqueeze(1))
+                axis_i += 1
+            else:
+                raise ValueError(
+                    "Only 2, 3, or 4d data is supported; don't know"
+                    f" how to handle data with ndim={v.ndim}"
+                )
             artists.extend(art)
         if rescale_ylim:
-            display._rescale_ylim(axes[1::2], torch.cat(per_channel_reps, -1))
+            display._rescale_ylim(
+                np.asarray(axes)[rescalable_axes], torch.cat(rescalable_reps, -1)
+            )
         return artists
 
     def plot_representation(
@@ -569,6 +601,8 @@ class DeepNetFeatures(torch.nn.Module):
         ------
         ValueError
             If both ``figsize`` and ``ax`` are not ``None``.
+        ValueError
+            If the data to plot is not 2, 3, or 4 dimensional.
 
         Examples
         --------
@@ -666,17 +700,33 @@ class DeepNetFeatures(torch.nn.Module):
         for i, (k, v) in enumerate(data.items()):
             ax = fig.add_subplot(gs[i])
 
-            # Average representation across channels
-            avg_channel_rep = v.mean(dim=1, keepdim=True)
-            # Average representation across additional dimensions (probably space)
-            per_channel_rep = v.mean(dim=tuple(np.arange(2, v.ndim)))
-            while per_channel_rep.ndim < 3:
-                per_channel_rep = per_channel_rep.unsqueeze(0)
+            if v.ndim in [3, 4]:
+                # Average representation across channels
+                avg_channel_rep = v.mean(dim=1, keepdim=True)
+                # Average representation across additional dimensions (probably space)
+                per_channel_rep = v.mean(dim=tuple(np.arange(2, v.ndim)))
+                while per_channel_rep.ndim < 3:
+                    per_channel_rep = per_channel_rep.unsqueeze(0)
 
-            if avg_channel_rep.ndim == 3:
-                height_ratios = [1, 1]
-            elif avg_channel_rep.ndim == 4:
-                height_ratios = [2, 1]
+                if avg_channel_rep.ndim == 3:
+                    height_ratios = [1, 1]
+                elif avg_channel_rep.ndim == 4:
+                    height_ratios = [2, 1]
+                plot_data = {
+                    f"{k} avg across channels": avg_channel_rep,
+                    f"{k} per channel (n={v.shape[1]})": per_channel_rep,
+                }
+
+            elif v.ndim == 2:
+                # then we can just plot all channels, single plot. need to make the data
+                # 3d for generic plot_representation to work
+                plot_data = {k: v.unsqueeze(1)}
+                height_ratios = [1]
+            else:
+                raise ValueError(
+                    "Only 2, 3, or 4d data is supported; don't know"
+                    f" how to handle data with ndim={v.ndim}"
+                )
 
             # this warning is not relevant here
             with warnings.catch_warnings():
@@ -684,10 +734,7 @@ class DeepNetFeatures(torch.nn.Module):
                     "ignore", message="data has keys, so we're ignoring title"
                 )
                 ax = display.plot_representation(
-                    data={
-                        f"{k} avg across channels": avg_channel_rep,
-                        f"{k} per channel (n={v.shape[1]})": per_channel_rep,
-                    },
+                    data=plot_data,
                     ax=ax,
                     batch_idx=batch_idx,
                     axes_direction="vertical",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1480,8 +1480,11 @@ class TestDeepNetFeatures:
         "model",
         [
             "torchvision_resnet50-layer2",
+            # fc layer has a different dimensionality than the convolutional layers
+            "torchvision_resnet50-fc",
             "timm_resnet50-layer2",
             "torchvision_resnet50-layer2,layer4",
+            "torchvision_resnet50-layer2,fc",
             "timm_resnet50-layer2,layer4",
         ],
         indirect=True,
@@ -1659,6 +1662,122 @@ class TestDeepNetFeatures:
     @pytest.mark.parametrize(
         "model",
         [
+            # fc layer has a different dimensionality than the convolutional layers
+            "torchvision_resnet50-fc",
+        ],
+        indirect=True,
+    )
+    @pytest.mark.parametrize("input_type", ["tensor", "dict"])
+    @pytest.mark.parametrize("axis", ["existing", None])
+    @pytest.mark.parametrize("ylim", [False, None, (0, 1)])
+    @pytest.mark.parametrize("plot_func", ["model", "display"])
+    def test_plot_representation_2d_only(
+        self,
+        model,
+        input_type,
+        axis,
+        ylim,
+        plot_func,
+        torchvision_img,
+        close_figures_on_teardown,
+    ):
+        rep = model(torchvision_img)
+        if input_type == "dict":
+            rep = model.convert_to_dict(rep)
+        if axis == "existing":
+            _, axis = plt.subplots(1, 1)
+        if plot_func == "model":
+            _, axes = model.plot_representation(
+                rep, ax=axis, title="Representation", ylim=ylim
+            )
+        elif plot_func == "display":
+            axes = po.plot.plot_representation(
+                model, rep, ax=axis, title="Representation", ylim=ylim
+            )
+        if not isinstance(rep, dict):
+            rep = model.convert_to_dict(rep)
+        assert len(axes) == 1
+        ax_ylim = axes[0].get_ylim()
+        # then this is the stem plot
+        if ylim is False:
+            # in this case ymin is just below 0, ymax is something positive
+            assert ax_ylim[0] < 0
+            assert abs(ax_ylim[0]) < ax_ylim[1]
+            assert ax_ylim[1] > 0
+        elif ylim is None:
+            # in this case ymin and ymax are symmetric about 0
+            assert ax_ylim[0] < 0
+            assert abs(ax_ylim[0]) == ax_ylim[1]
+            assert ax_ylim[1] > 0
+        else:
+            # in this case ymin and ymax are set explicitly
+            assert ax_ylim[0] == ylim[0]
+            assert ax_ylim[1] == ylim[1]
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "torchvision_resnet50-layer2,fc",
+        ],
+        indirect=True,
+    )
+    @pytest.mark.parametrize("input_type", ["tensor", "dict"])
+    @pytest.mark.parametrize("axis", ["existing", None])
+    @pytest.mark.parametrize("ylim", [False, None, (0, 1)])
+    @pytest.mark.parametrize("plot_func", ["model", "display"])
+    def test_plot_representation_2d_mixed(
+        self,
+        model,
+        input_type,
+        axis,
+        ylim,
+        plot_func,
+        torchvision_img,
+        close_figures_on_teardown,
+    ):
+        rep = model(torchvision_img)
+        if input_type == "dict":
+            rep = model.convert_to_dict(rep)
+        if axis == "existing":
+            _, axis = plt.subplots(1, 1)
+        if plot_func == "model":
+            _, axes = model.plot_representation(
+                rep, ax=axis, title="Representation", ylim=ylim
+            )
+        elif plot_func == "display":
+            axes = po.plot.plot_representation(
+                model, rep, ax=axis, title="Representation", ylim=ylim
+            )
+        if not isinstance(rep, dict):
+            rep = model.convert_to_dict(rep)
+        layers = ["layer2", "layer2", "fc"]
+        for i, (ax, layer) in enumerate(zip(axes, layers)):
+            ax_ylim = ax.get_ylim()
+            if i == 0:
+                # then this is an image axis, so ylim should correspond to the size of
+                # the image
+                assert ax_ylim[0] == rep[layer].shape[-1] - 0.5
+                assert ax_ylim[1] == -0.5
+            else:
+                # then this is the stem plot
+                if ylim is False:
+                    # in this case ymin is just below 0, ymax is something positive
+                    assert ax_ylim[0] < 0
+                    assert abs(ax_ylim[0]) < ax_ylim[1]
+                    assert ax_ylim[1] > 0
+                elif ylim is None:
+                    # in this case ymin and ymax are symmetric about 0
+                    assert ax_ylim[0] < 0
+                    assert abs(ax_ylim[0]) == ax_ylim[1]
+                    assert ax_ylim[1] > 0
+                else:
+                    # in this case ymin and ymax are set explicitly
+                    assert ax_ylim[0] == ylim[0]
+                    assert ax_ylim[1] == ylim[1]
+
+    @pytest.mark.parametrize(
+        "model",
+        [
             "torchvision_resnet50-layer2",
             "timm_resnet50-layer2",
             "torchvision_resnet50-layer2,layer4",
@@ -1678,8 +1797,25 @@ class TestDeepNetFeatures:
         "model",
         [
             "torchvision_resnet50-layer2",
+        ],
+        indirect=True,
+    )
+    def test_plot_representation_invalid(
+        self, model, torchvision_img, close_figures_on_teardown
+    ):
+        rep = model.convert_to_dict(model(torchvision_img))
+        # change this from 4d to 5d, so we can test the failure.
+        rep["layer2"] = rep["layer2"].unsqueeze(1)
+        with pytest.raises(ValueError, match="Only 2, 3, or 4d data"):
+            model.plot_representation(rep)
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "torchvision_resnet50-layer2",
             "timm_resnet50-layer2",
             "torchvision_resnet50-layer2,layer4",
+            "torchvision_resnet50-layer2,fc",
             "timm_resnet50-layer2,layer4",
         ],
         indirect=True,
@@ -1718,3 +1854,39 @@ class TestDeepNetFeatures:
             raise ValueError("Update plot didn't rescale_ylim successfully!")
         if not np.equal(orig_img_ylim, updated_img_ylim).all():
             raise ValueError("Image ylim should never change!")
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # fc layer has a different dimensionality than the convolutional layers
+            "torchvision_resnet50-fc",
+        ],
+        indirect=True,
+    )
+    @pytest.mark.parametrize("input_type", ["tensor", "dict"])
+    @pytest.mark.parametrize("rescale_ylim", [True, False])
+    def test_update_plot_2d_only(
+        self,
+        model,
+        input_type,
+        rescale_ylim,
+        torchvision_img,
+        close_figures_on_teardown,
+    ):
+        # with 2d rep only, no image created, so slightly different test
+        rep = model(torchvision_img)
+        fig, axes = model.plot_representation(rep, title="Representation")
+        orig_y = axes[0].containers[0].markerline.get_ydata()
+        orig_ylim = axes[0].get_ylim()
+        rep = model(torch.rand_like(torchvision_img))
+        if input_type == "dict":
+            rep = model.convert_to_dict(rep)
+        artists = model.update_plot(axes, rep, rescale_ylim=rescale_ylim)
+        updated_y = artists[0].get_ydata()
+        updated_ylim = axes[0].get_ylim()
+        if np.equal(orig_y, updated_y).all():
+            raise ValueError("Update plot didn't run successfully!")
+        if rescale_ylim and np.equal(orig_ylim, updated_ylim).all():
+            raise ValueError("Update plot didn't rescale_ylim successfully!")
+        if not rescale_ylim and not np.equal(orig_ylim, updated_ylim).all():
+            raise ValueError("Update plot didn't rescale_ylim successfully!")


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

In #476, @raffles-xingqi-zhu pointed out that he got an error in `po.plot.synthesis_status` when the model he was using was matching target layer `"fc"`. Looking into this, it turned out to be an error with `DeepNetFeatures.plot_representation` for 2d data -- it had only been tested with convolutional layers (which all have 4d data) or data that had been manually averaged to become 3d. As convnet fully-connected layers such as ResNet50 `"fc"` have 2d representations, we should ensure we support them.

(This didn't come up in #467 because for MADCompetition, `po.plot.synthesis_status` doesn't call a model's `plot_representation`; that happens for Metamer because of `po.plot.metamer_representation_error`.)

**Link any related issues, discussions, PRs**

See #476

**Describe changes**

- `DeepNetFeatures.plot_representation` and `update_plot` now support 2, 3, or 4d representations and raise specific ValueError for all other dimensionalities.
- These changes should allow mixed layers as well, e.g., making plots for models that match ResNet50 `layer2` and `fc`.
- Adds tests for the above.

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
