### PR TITLE
Adds Color image `PortillaSimoncelli` model

### DIFF
--- a/docs/api/process.rst
+++ b/docs/api/process.rst
@@ -110,6 +110,19 @@ The following functions return a modified version of their input.
    ~center_crop
    ~modulate_phase
 
+.. rubric:: Color transformations
+   :heading-level: 3
+
+These functions transform the color space of RGB images.
+
+.. autosummary::
+   :signatures: none
+   :toctree: generated
+   :template: torch_module.rst.jinja
+
+   ~OPC
+   ~PCA
+
 .. rubric:: Image statistics
    :heading-level: 3
 

--- a/src/plenoptic/_api_change.py
+++ b/src/plenoptic/_api_change.py
@@ -193,6 +193,8 @@ NEW = [
     "plenoptic.io.LoadWarning",
     "plenoptic.data.macaque",
     "plenoptic.models.DeepNetFeatures",
+    "plenoptic.process.OPC",
+    "plenoptic.process.PCA",
 ]
 
 UNCHANGED = [

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -451,6 +451,11 @@ class PortillaSimoncelli(nn.Module):
             "residual_lowpass",
             dtype=object,
         )
+        color_shape_dict["cross_correlation_coarsest_scale_lowpass"] = np.full(
+            (N_RGB_CHANNELS * self.n_orientations, n_lowpass_signals),
+            self.n_scales - 1,
+            dtype=int,
+        )
         return color_shape_dict
 
     def _create_necessary_stats_dict(
@@ -617,6 +622,9 @@ class PortillaSimoncelli(nn.Module):
                     lowpass_mask[row, column] = True
                     seen_correlations.add(correlation)
         color_mask_dict["cross_correlation_lowpass"] = lowpass_mask
+        color_mask_dict["cross_correlation_coarsest_scale_lowpass"] = torch.ones(
+            n_signals, n_lowpass_signals, dtype=torch.bool
+        )
         return color_mask_dict
 
     @staticmethod
@@ -798,6 +806,11 @@ class PortillaSimoncelli(nn.Module):
             cross_corr_lowpass = self._compute_joint_cross_correlation(
                 [lowpass_signals], [lowpass_signals]
             ).squeeze(-1)
+            cross_corr_coarsest_scale_lowpass = (
+                self._compute_joint_cross_correlation(
+                    [real_pyr_coeffs[-1]], [lowpass_signals]
+                ).squeeze(-1)
+            )
         else:
             cross_ori_corr_mags = self._compute_cross_correlation(
                 mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var
@@ -862,6 +875,7 @@ class PortillaSimoncelli(nn.Module):
                 kurtosis_transformed,
                 cross_ori_corr_real,
                 cross_corr_lowpass,
+                cross_corr_coarsest_scale_lowpass,
             ]
         # And then pack them into a 3d tensor
         if self.color_statistics:

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -620,7 +620,8 @@ class PortillaSimoncelli(nn.Module):
             ):
                 # Compute relative shift, and disambiguate
                 relative_shift = (
-                  column_shift[0] - row_shift[0], column_shift[1] - row_shift[1]
+                    column_shift[0] - row_shift[0],
+                    column_shift[1] - row_shift[1],
                 )
                 if row_channel == column_channel:
                     opposite_shift = tuple(-offset for offset in relative_shift)
@@ -822,11 +823,9 @@ class PortillaSimoncelli(nn.Module):
             cross_corr_lowpass = self._compute_joint_cross_correlation(
                 [lowpass_signals], [lowpass_signals]
             ).squeeze(-1)
-            cross_corr_coarsest_scale_lowpass = (
-                self._compute_joint_cross_correlation(
-                    [real_pyr_coeffs[-1]], [lowpass_signals]
-                ).squeeze(-1)
-            )
+            cross_corr_coarsest_scale_lowpass = self._compute_joint_cross_correlation(
+                [real_pyr_coeffs[-1]], [lowpass_signals]
+            ).squeeze(-1)
         else:
             cross_ori_corr_mags = self._compute_cross_correlation(
                 mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -41,7 +41,7 @@ from ..tensors import to_numpy
 
 SCALES_TYPE = Literal["pixel_statistics"] | PYR_SCALES_TYPE
 N_RGB_CHANNELS = 3
-LOWPASS_SHIFTS = ((0, 0), (2, 0), (-2, 0), (0, 2), (0, -2))
+LOWPASS_SHIFTS = ((0, 0), (0, 2), (0, -2), (2, 0), (-2, 0))
 
 __all__ = [
     "PortillaSimoncelli",

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -410,6 +410,7 @@ class PortillaSimoncelli(nn.Module):
             if key in [
                 "cross_orientation_correlation_magnitude",
                 "cross_scale_correlation_magnitude",
+                "cross_scale_correlation_real",
             ]:
                 # Add the joint-channel statistics scales
                 color_shape_dict[key] = np.tile(
@@ -537,7 +538,10 @@ class PortillaSimoncelli(nn.Module):
                 )
                 mask[triu_inds[0], triu_inds[1]] = False
                 color_mask_dict[key] = mask
-            elif key == "cross_scale_correlation_magnitude":
+            elif key in [
+                "cross_scale_correlation_magnitude",
+                "cross_scale_correlation_real",
+            ]:
                 # Cross-scale correlations are not symmetric, so keep all entries.
                 color_mask_dict[key] = value.repeat(N_RGB_CHANNELS, N_RGB_CHANNELS, 1)
             else:
@@ -768,11 +772,24 @@ class PortillaSimoncelli(nn.Module):
                 )
             # Compute the cross-scale correlations between the real
             # coefficients and the real and imaginary coefficients at the next
-            # coarsest scale. this will be a tensor of shape (batch, channel,
-            # n_orientations, 2*n_orientations, n_scales-1)
-            cross_scale_corr_real = self._compute_cross_correlation(
-                real_pyr_coeffs[:-1], phase_doubled_sep
-            )
+            # coarsest scale.
+            if self.color_statistics:
+                # combine channel and ori so correlations are jointly across both.
+                joint_real_pyr_coeffs = [
+                    einops.rearrange(r, "b c o h w -> b 1 (c o) h w")
+                    for r in real_pyr_coeffs
+                ]
+                joint_phase_doubled_sep = [
+                    einops.rearrange(r, "b c o h w -> b 1 (c o) h w")
+                    for r in phase_doubled_sep
+                ]
+                cross_scale_corr_real = self._compute_cross_correlation(
+                    joint_real_pyr_coeffs[:-1], joint_phase_doubled_sep
+                ).squeeze(1)
+            else:
+                cross_scale_corr_real = self._compute_cross_correlation(
+                    real_pyr_coeffs[:-1], phase_doubled_sep
+                )
 
         # Compute the variance of the highpass residual
         var_highpass_residual = highpass.pow(2).mean(dim=(-2, -1))

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -204,8 +204,8 @@ class PortillaSimoncelli(nn.Module):
         if isinstance(transform, str):
             if transform != "opc":
                 raise ValueError(
-                  "The only recognized string transform is 'opc'."
-                  f" Received '{transform}' instead."
+                    "The only recognized string transform is 'opc'."
+                    f" Received '{transform}' instead."
                 )
             transform = OPC()
         self.transform = transform
@@ -392,9 +392,7 @@ class PortillaSimoncelli(nn.Module):
     def _create_color_scales_shape_dict(
         self, scales_shape_dict: OrderedDict
     ) -> OrderedDict:
-        """
-        Create dictionary defining scales and shape of each stat for the
-        joint color statistics.
+        """Create dictionary of scales and shape for stats for the joint color statistics.
 
         Parameters
         ----------
@@ -409,7 +407,13 @@ class PortillaSimoncelli(nn.Module):
         """
         color_shape_dict = OrderedDict()
         for key, value in scales_shape_dict.items():
-            color_shape_dict[key] = np.repeat(value[None], N_RGB_CHANNELS, axis=0)
+            if key == "cross_orientation_correlation_magnitude":
+                # Add the joint-channel statistics scales
+                color_shape_dict[key] = np.tile(
+                    value, (N_RGB_CHANNELS, N_RGB_CHANNELS, 1)
+                )
+            else:
+                color_shape_dict[key] = np.repeat(value[None], N_RGB_CHANNELS, axis=0)
             if key == "pixel_statistics":
                 # Add color pixel stats here due to dict ordering
                 color_shape_dict["color_covariance"] = np.full(
@@ -507,9 +511,7 @@ class PortillaSimoncelli(nn.Module):
     def _create_color_necessary_stats_dict(
         necessary_stats_dict: OrderedDict,
     ) -> OrderedDict:
-        """
-        Create mask specifying the necessary statistics for the joint
-        color statistics.
+        """Create the necessary-statistics mask for joint color statistics.
 
         Parameters
         ----------
@@ -524,9 +526,18 @@ class PortillaSimoncelli(nn.Module):
         """
         color_mask_dict = OrderedDict()
         for key, value in necessary_stats_dict.items():
-            color_mask_dict[key] = value.unsqueeze(0).repeat(
-                N_RGB_CHANNELS, *([1] * value.ndim)
-            )
+            if key == "cross_orientation_correlation_magnitude":
+                n_signals = N_RGB_CHANNELS * value.shape[0]
+                triu_inds = torch.triu_indices(n_signals, n_signals)
+                mask = torch.ones(
+                    n_signals, n_signals, value.shape[-1], dtype=torch.bool
+                )
+                mask[triu_inds[0], triu_inds[1]] = False
+                color_mask_dict[key] = mask
+            else:
+                color_mask_dict[key] = value.unsqueeze(0).repeat(
+                    N_RGB_CHANNELS, *([1] * value.ndim)
+                )
             if key == "pixel_statistics":
                 # Add color pixel stats here due to dict ordering
                 # The diagonal variances are already included in pixel_statistics,
@@ -704,11 +715,24 @@ class PortillaSimoncelli(nn.Module):
         )
 
         # Compute the cross-orientation correlations between the magnitude
-        # coefficients at each scale. this will be a tensor of shape (batch,
-        # channel, n_orientations, n_orientations, n_scales)
-        cross_ori_corr_mags = self._compute_cross_correlation(
-            mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var
-        )
+        # coefficients at each scale.
+        if self.color_statistics:
+            # combine channel and ori so correlations are jointly across both.
+            joint_mag_pyr_coeffs = [
+                einops.rearrange(m, "b c o h w -> b 1 (c o) h w")
+                for m in mag_pyr_coeffs
+            ]
+            joint_mags_var = einops.rearrange(mags_var, "b c o s -> b 1 (c o) s")
+            cross_ori_corr_mags = self._compute_cross_correlation(
+                joint_mag_pyr_coeffs,
+                joint_mag_pyr_coeffs,
+                joint_mags_var,
+                joint_mags_var,
+            ).squeeze(1)
+        else:
+            cross_ori_corr_mags = self._compute_cross_correlation(
+                mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var
+            )
 
         # If we have more than one scale, compute the cross-scale correlations
         if self.n_scales != 1:
@@ -1596,7 +1620,7 @@ class PortillaSimoncelli(nn.Module):
         """  # numpydoc ignore=EX01
         if self.color_statistics:
             raise NotImplementedError(
-              "Plotting is not implemented for `color_statistics=True`."
+                "Plotting is not implemented for `color_statistics=True`."
             )
         if set(rep.keys()) > set(self._necessary_stats_dict.keys()):
             raise ValueError("representation contains additional keys!")

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -406,40 +406,41 @@ class PortillaSimoncelli(nn.Module):
             Scale metadata dictionary for the joint color statistics.
         """
         color_shape_dict = OrderedDict()
+        joint_correlation_keys = [
+            "cross_orientation_correlation_magnitude",
+            "cross_scale_correlation_magnitude",
+            "cross_scale_correlation_real",
+        ]
         for key, value in scales_shape_dict.items():
-            if key in [
-                "cross_orientation_correlation_magnitude",
-                "cross_scale_correlation_magnitude",
-                "cross_scale_correlation_real",
-            ]:
+            if key in joint_correlation_keys:
                 # Add the joint-channel statistics scales
                 color_shape_dict[key] = np.tile(
                     value, (N_RGB_CHANNELS, N_RGB_CHANNELS, 1)
                 )
             else:
                 color_shape_dict[key] = np.repeat(value[None], N_RGB_CHANNELS, axis=0)
-            if key == "pixel_statistics":
-                # Add color pixel stats here due to dict ordering
-                color_shape_dict["color_covariance"] = np.full(
-                    (N_RGB_CHANNELS, N_RGB_CHANNELS),
-                    "pixel_statistics",
-                    dtype=object,
-                )
-                color_shape_dict["auto_correlation_transformed"] = np.full(
-                    (
-                        N_RGB_CHANNELS,
-                        self.spatial_corr_width,
-                        self.spatial_corr_width,
-                    ),
-                    "pixel_statistics",
-                    dtype=object,
-                )
-                color_shape_dict["skew_transformed"] = np.full(
-                    N_RGB_CHANNELS, "pixel_statistics", dtype=object
-                )
-                color_shape_dict["kurtosis_transformed"] = np.full(
-                    N_RGB_CHANNELS, "pixel_statistics", dtype=object
-                )
+
+        # Statistics that only exist for the color representation
+        color_shape_dict["color_covariance"] = np.full(
+            (N_RGB_CHANNELS, N_RGB_CHANNELS),
+            "pixel_statistics",
+            dtype=object,
+        )
+        color_shape_dict["auto_correlation_transformed"] = np.full(
+            (
+                N_RGB_CHANNELS,
+                self.spatial_corr_width,
+                self.spatial_corr_width,
+            ),
+            "pixel_statistics",
+            dtype=object,
+        )
+        color_shape_dict["skew_transformed"] = np.full(
+            N_RGB_CHANNELS, "pixel_statistics", dtype=object
+        )
+        color_shape_dict["kurtosis_transformed"] = np.full(
+            N_RGB_CHANNELS, "pixel_statistics", dtype=object
+        )
         return color_shape_dict
 
     def _create_necessary_stats_dict(
@@ -528,45 +529,52 @@ class PortillaSimoncelli(nn.Module):
         color_necessary_stats_dict
             Necessary statistics masks for the joint color statistics.
         """
-        color_mask_dict = OrderedDict()
-        for key, value in necessary_stats_dict.items():
-            if key == "cross_orientation_correlation_magnitude":
-                n_signals = N_RGB_CHANNELS * value.shape[0]
-                triu_inds = torch.triu_indices(n_signals, n_signals)
-                mask = torch.ones(
-                    n_signals, n_signals, value.shape[-1], dtype=torch.bool
-                )
-                mask[triu_inds[0], triu_inds[1]] = False
-                color_mask_dict[key] = mask
-            elif key in [
-                "cross_scale_correlation_magnitude",
-                "cross_scale_correlation_real",
-            ]:
-                # Cross-scale correlations are not symmetric, so keep all entries.
-                color_mask_dict[key] = value.repeat(N_RGB_CHANNELS, N_RGB_CHANNELS, 1)
-            else:
-                color_mask_dict[key] = value.unsqueeze(0).repeat(
-                    N_RGB_CHANNELS, *([1] * value.ndim)
-                )
-            if key == "pixel_statistics":
-                # Add color pixel stats here due to dict ordering
-                # The diagonal variances are already included in pixel_statistics,
-                # so they redundant.
-                color_mask_dict["color_covariance"] = torch.ones(
-                    N_RGB_CHANNELS, N_RGB_CHANNELS, dtype=torch.bool
-                ).tril(-1)
-                autocorr_mask = necessary_stats_dict["auto_correlation_reconstructed"][
-                    ..., 0
-                ]
-                color_mask_dict["auto_correlation_transformed"] = (
-                    autocorr_mask.unsqueeze(0).repeat(N_RGB_CHANNELS, 1, 1)
-                )
-                color_mask_dict["skew_transformed"] = torch.ones(
-                    N_RGB_CHANNELS, dtype=torch.bool
-                )
-                color_mask_dict["kurtosis_transformed"] = torch.ones(
-                    N_RGB_CHANNELS, dtype=torch.bool
-                )
+        # Apply generic treatment to all stats, some get overriden after
+        color_mask_dict = OrderedDict(
+            (
+                key,
+                value.unsqueeze(0).repeat(N_RGB_CHANNELS, *([1] * value.ndim)),
+            )
+            for key, value in necessary_stats_dict.items()
+        )
+
+        # Same-scale correlations are symmetric, keep only the strictly-lower triangle
+        same_scale_source = necessary_stats_dict[
+            "cross_orientation_correlation_magnitude"
+        ]
+        n_signals = N_RGB_CHANNELS * same_scale_source.shape[0]
+        triu_inds = torch.triu_indices(n_signals, n_signals)
+        same_scale_mask = torch.ones(
+            n_signals, n_signals, same_scale_source.shape[-1], dtype=torch.bool
+        )
+        same_scale_mask[triu_inds[0], triu_inds[1]] = False
+        color_mask_dict["cross_orientation_correlation_magnitude"] = same_scale_mask
+
+        # Cross-scale correlations are not symmetric, so keep all entries.
+        for key in [
+            "cross_scale_correlation_magnitude",
+            "cross_scale_correlation_real",
+        ]:
+            color_mask_dict[key] = necessary_stats_dict[key].repeat(
+                N_RGB_CHANNELS, N_RGB_CHANNELS, 1
+            )
+
+        # Statistics that only exist for the color representation
+        # The diagonal variances are already included in pixel_statistics,
+        # so they are redundant.
+        color_mask_dict["color_covariance"] = torch.ones(
+            N_RGB_CHANNELS, N_RGB_CHANNELS, dtype=torch.bool
+        ).tril(-1)
+        autocorr_mask = necessary_stats_dict["auto_correlation_reconstructed"][..., 0]
+        color_mask_dict["auto_correlation_transformed"] = autocorr_mask.unsqueeze(
+            0
+        ).repeat(N_RGB_CHANNELS, 1, 1)
+        color_mask_dict["skew_transformed"] = torch.ones(
+            N_RGB_CHANNELS, dtype=torch.bool
+        )
+        color_mask_dict["kurtosis_transformed"] = torch.ones(
+            N_RGB_CHANNELS, dtype=torch.bool
+        )
         return color_mask_dict
 
     @staticmethod
@@ -773,15 +781,8 @@ class PortillaSimoncelli(nn.Module):
 
         # Now, combine all these stats together, first into a list
         # Statistics families should be ordered as in self._necessary_stats_dict
-        all_stats = [pixel_stats]
-        if self.color_statistics:
-            all_stats += [
-                color_covariance,
-                autocorr_transformed,
-                skew_transformed,
-                kurtosis_transformed,
-            ]
-        all_stats += [
+        all_stats = [
+            pixel_stats,
             autocorr_mags,
             skew_recon,
             kurtosis_recon,
@@ -793,6 +794,13 @@ class PortillaSimoncelli(nn.Module):
         if self.n_scales != 1:
             all_stats += [cross_scale_corr_mags, cross_scale_corr_real]
         all_stats += [var_highpass_residual]
+        if self.color_statistics:
+            all_stats += [
+                color_covariance,
+                autocorr_transformed,
+                skew_transformed,
+                kurtosis_transformed,
+            ]
         # And then pack them into a 3d tensor
         if self.color_statistics:
             # When using joint color statistics we don't keep the separate

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -40,6 +40,7 @@ from ..process.steerable_pyramid_freq import (
 from ..tensors import to_numpy
 
 SCALES_TYPE = Literal["pixel_statistics"] | PYR_SCALES_TYPE
+N_RGB_CHANNELS = 3
 
 __all__ = [
     "PortillaSimoncelli",
@@ -388,9 +389,8 @@ class PortillaSimoncelli(nn.Module):
 
         return shape_dict
 
-    @staticmethod
     def _create_color_scales_shape_dict(
-        scales_shape_dict: OrderedDict,
+        self, scales_shape_dict: OrderedDict
     ) -> OrderedDict:
         """
         Create dictionary defining scales and shape of each stat for the
@@ -407,10 +407,32 @@ class PortillaSimoncelli(nn.Module):
         color_scales_shape_dict
             Scale metadata dictionary for the joint color statistics.
         """
-        return OrderedDict(
-            (key, np.repeat(value[None], 3, axis=0))
-            for key, value in scales_shape_dict.items()
-        )
+        color_shape_dict = OrderedDict()
+        for key, value in scales_shape_dict.items():
+            color_shape_dict[key] = np.repeat(value[None], N_RGB_CHANNELS, axis=0)
+            if key == "pixel_statistics":
+                # Add color pixel stats here due to dict ordering
+                color_shape_dict["color_covariance"] = np.full(
+                    (N_RGB_CHANNELS, N_RGB_CHANNELS),
+                    "pixel_statistics",
+                    dtype=object,
+                )
+                color_shape_dict["auto_correlation_transformed"] = np.full(
+                    (
+                        N_RGB_CHANNELS,
+                        self.spatial_corr_width,
+                        self.spatial_corr_width,
+                    ),
+                    "pixel_statistics",
+                    dtype=object,
+                )
+                color_shape_dict["skew_transformed"] = np.full(
+                    N_RGB_CHANNELS, "pixel_statistics", dtype=object
+                )
+                color_shape_dict["kurtosis_transformed"] = np.full(
+                    N_RGB_CHANNELS, "pixel_statistics", dtype=object
+                )
+        return color_shape_dict
 
     def _create_necessary_stats_dict(
         self, scales_shape_dict: OrderedDict
@@ -500,10 +522,49 @@ class PortillaSimoncelli(nn.Module):
         color_necessary_stats_dict
             Necessary statistics masks for the joint color statistics.
         """
-        return OrderedDict(
-            (key, value.unsqueeze(0).repeat(3, *([1] * value.ndim)))
-            for key, value in necessary_stats_dict.items()
-        )
+        color_mask_dict = OrderedDict()
+        for key, value in necessary_stats_dict.items():
+            color_mask_dict[key] = value.unsqueeze(0).repeat(
+                N_RGB_CHANNELS, *([1] * value.ndim)
+            )
+            if key == "pixel_statistics":
+                # Add color pixel stats here due to dict ordering
+                # The diagonal variances are already included in pixel_statistics,
+                # so they redundant.
+                color_mask_dict["color_covariance"] = torch.ones(
+                    N_RGB_CHANNELS, N_RGB_CHANNELS, dtype=torch.bool
+                ).tril(-1)
+                autocorr_mask = necessary_stats_dict["auto_correlation_reconstructed"][
+                    ..., 0
+                ]
+                color_mask_dict["auto_correlation_transformed"] = (
+                    autocorr_mask.unsqueeze(0).repeat(N_RGB_CHANNELS, 1, 1)
+                )
+                color_mask_dict["skew_transformed"] = torch.ones(
+                    N_RGB_CHANNELS, dtype=torch.bool
+                )
+                color_mask_dict["kurtosis_transformed"] = torch.ones(
+                    N_RGB_CHANNELS, dtype=torch.bool
+                )
+        return color_mask_dict
+
+    @staticmethod
+    def _compute_color_covariance(image: Tensor) -> Tensor:
+        """Compute the covariance between RGB channels.
+
+        Parameters
+        ----------
+        image
+            A 4d tensor with shape ``(batch, RGB, height, width)``.
+
+        Returns
+        -------
+        covariance
+            A tensor with shape ``(batch, RGB, RGB)``.
+        """
+        centered = image - image.mean(dim=(-2, -1), keepdim=True)
+        centered = centered.flatten(2)
+        return centered @ centered.mT / centered.shape[-1]
 
     def forward(self, image: Tensor, scales: list[SCALES_TYPE] | None = None) -> Tensor:
         r"""
@@ -556,9 +617,8 @@ class PortillaSimoncelli(nn.Module):
                 "PortillaSimoncelli expects a 4d image with shape "
                 "(batch, channel, height, width), but image has "
                 f"dimension {image.ndim} and shape {image.shape} instead."
-                
             )
-        if self.color_statistics and image.shape[1] != 3:
+        if self.color_statistics and image.shape[1] != N_RGB_CHANNELS:
             raise ValueError(
                 "PortillaSimoncelli with color_statistics=True expects an RGB image "
                 f"with three channels, but image has shape {image.shape} instead."
@@ -570,7 +630,17 @@ class PortillaSimoncelli(nn.Module):
             image_for_pyramid = (
                 image if self.transform is None else self.transform(image)
             )
-            image_var = torch.var(image_for_pyramid, dim=(-2, -1))
+            color_covariance = self._compute_color_covariance(image)
+            transformed_pixel_stats = self._compute_pixel_stats(image_for_pyramid)
+            image_var = transformed_pixel_stats[..., 1]
+            skew_transformed = transformed_pixel_stats[..., 2]
+            kurtosis_transformed = transformed_pixel_stats[..., 3]
+            centered_transformed = image_for_pyramid - image_for_pyramid.mean(
+                dim=(-2, -1), keepdim=True
+            )
+            autocorr_transformed = self._compute_autocorr([centered_transformed])[
+                0
+            ].squeeze(-1)
         else:
             image_for_pyramid = image
             image_var = pixel_stats[..., 1]
@@ -668,8 +738,16 @@ class PortillaSimoncelli(nn.Module):
         var_highpass_residual = highpass.pow(2).mean(dim=(-2, -1))
 
         # Now, combine all these stats together, first into a list
-        all_stats = [
-            pixel_stats,
+        # Statistics families should be ordered as in self._necessary_stats_dict
+        all_stats = [pixel_stats]
+        if self.color_statistics:
+            all_stats += [
+                color_covariance,
+                autocorr_transformed,
+                skew_transformed,
+                kurtosis_transformed,
+            ]
+        all_stats += [
             autocorr_mags,
             skew_recon,
             kurtosis_recon,
@@ -763,9 +841,10 @@ class PortillaSimoncelli(nn.Module):
         r"""
         Convert dictionary of statistics to a tensor.
 
-        The output has shape (batch, channel, n_statistics), flattening and
-        concatenating across all statistic classes. The dictionary representation
-        may be easier to make sense of.
+        The output has shape ``(batch, channel, n_statistics)`` when
+        ``color_statistics=False`` and ``(batch, 1, n_statistics)`` when
+        ``color_statistics=True``, flattening and concatenating across all statistic
+        classes. The dictionary representation may be easier to make sense of.
 
         Parameters
         ----------
@@ -798,7 +877,13 @@ class PortillaSimoncelli(nn.Module):
         >>> torch.equal(representation_tensor, representation_tensor_new)
         True
         """
-        rep = einops.pack(list(representation_dict.values()), "b c *")[0]
+        if self.color_statistics:
+            # Color statistics tensor does not preserve channel dimension
+            # because some statistics don't belong to a single channel
+            rep = einops.pack(list(representation_dict.values()), "b *")[0]
+            rep = rep.unsqueeze(1)
+        else:
+            rep = einops.pack(list(representation_dict.values()), "b c *")[0]
         # then get rid of all the nans / unnecessary stats
         return rep.index_select(-1, self._necessary_stats_mask)
 
@@ -811,6 +896,11 @@ class PortillaSimoncelli(nn.Module):
 
         This dictionary will contain NaNs in its values: these are placeholders
         for the redundant statistics.
+
+        When ``color_statistics=False``, dictionary values have a batch and a channel
+        dimension, over which statistics are computed independently. When
+        ``color_statistics=True``, the channel dimension is no longer meaningful for
+        some families of statistics that are computed jointly across channels.
 
         Parameters
         ----------
@@ -895,19 +985,28 @@ class PortillaSimoncelli(nn.Module):
             )
 
         rep = self._necessary_stats_dict.copy()
+        # Remove the color representation's singleton channel dimension, because the
+        # dictionary values shapes don't have this dimension
+        if self.color_statistics:
+            representation_values = representation_tensor[:, 0]
+        else:
+            representation_values = representation_tensor
         n_filled = 0
         for k, v in rep.items():
-            # each statistic is a tensor with batch and channel dimensions as
-            # found in representation_tensor and all the other dimensions
-            # determined by the values in necessary_stats_dict.
-            shape = (*representation_tensor.shape[:2], *v.shape)
+            if self.color_statistics:
+                shape = (representation_tensor.shape[0], *v.shape)
+            else:
+                # each statistic is a tensor with batch and channel dimensions as
+                # found in representation_tensor and all the other dimensions
+                # determined by the values in necessary_stats_dict.
+                shape = (*representation_tensor.shape[:2], *v.shape)
             new_v = torch.nan * torch.ones(
                 shape,
                 dtype=representation_tensor.dtype,
                 device=representation_tensor.device,
             )
             # v.sum() gives the number of necessary elements from this stat
-            this_stat_vec = representation_tensor[..., n_filled : n_filled + v.sum()]
+            this_stat_vec = representation_values[..., n_filled : n_filled + v.sum()]
             # use boolean indexing to put the values from new_stat_vec in the
             # appropriate place
             new_v[..., v] = this_stat_vec

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -17,6 +17,7 @@ References
 """  # numpydoc ignore=EX01
 
 from collections import OrderedDict
+from collections.abc import Callable
 from typing import Literal
 
 import einops
@@ -29,6 +30,7 @@ from torch import Tensor
 
 from ..plot.display import _clean_up_axes, _rescale_ylim, _update_stem, stem_plot
 from ..process import signal, stats
+from ..process.color import OPC
 from ..process.steerable_pyramid_freq import (
     SCALES_TYPE as PYR_SCALES_TYPE,
 )
@@ -67,6 +69,12 @@ class PortillaSimoncelli(nn.Module):
     variance, skew, and kurtosis) of the image and down-sampled versions of that image.
     See the paper and notebook for more description.
 
+    By default, channels are analyzed independently with the original set of
+    Portilla Simoncelli statistics. Setting ``color_statistics=True``
+    enables an extended set of joint color statistics for RGB images that produces
+    better color metamers, as originally implemented in
+    https://www.cns.nyu.edu/~lcv/texture/, and as described by Vacher & Briand [4]_.
+
     .. versionchanged:: 2.0.0
        Default ``spatial_corr_width`` value changed from 9 to 7, in order to match
        the value used to generate the figures in the Portilla and Simoncelli, 2000
@@ -82,6 +90,14 @@ class PortillaSimoncelli(nn.Module):
         The number of orientations used to measure the statistics.
     spatial_corr_width
         The width of the spatial cross- and auto-correlation statistics.
+    color_statistics
+        Whether to compute the joint color representation. If ``False``, all channels
+        are analyzed independently and ``transform`` is ignored.
+    transform
+        Callable color transform applied before computing pyramid statistics when
+        ``color_statistics=True``. The default, ``"opc"``, creates a fresh
+        :class:`~plenoptic.process.OPC` transform. If ``None``, no transform is
+        applied.
 
     Attributes
     ----------
@@ -106,6 +122,9 @@ class PortillaSimoncelli(nn.Module):
     .. [3] E P Simoncelli and W T Freeman, "The Steerable Pyramid: A Flexible
        Architecture for Multi-Scale Derivative Computation," Second Int'l Conf
        on Image Processing, Washington, DC, Oct 1995.
+    .. [4] Vacher, J., & Briand, T. (2021). "The Portilla-Simoncelli texture
+       model: towards understanding the early visual cortex". Image Processing
+       On Line, 11, 170-211.
 
     Examples
     --------
@@ -171,10 +190,24 @@ class PortillaSimoncelli(nn.Module):
         n_scales: int = 4,
         n_orientations: int = 4,
         spatial_corr_width: int = 7,
+        color_statistics: bool = False,
+        transform: nn.Module
+        | Callable[[Tensor], Tensor]
+        | Literal["opc"]
+        | None = "opc",
     ):
         super().__init__()
 
         self.image_shape = image_shape
+        self.color_statistics = color_statistics
+        if isinstance(transform, str):
+            if transform != "opc":
+                raise ValueError(
+                  "The only recognized string transform is 'opc'."
+                  f" Received '{transform}' instead."
+                )
+            transform = OPC()
+        self.transform = transform
         if any([(image_shape[-1] / 2**i) % 2 for i in range(n_scales)]) or any(
             [(image_shape[-2] / 2**i) % 2 for i in range(n_scales)]
         ):
@@ -206,9 +239,13 @@ class PortillaSimoncelli(nn.Module):
 
         # Dictionary defining necessary statistics, that is, those that are not
         # redundant
-        self._necessary_stats_dict = self._create_necessary_stats_dict(
-            scales_shape_dict
-        )
+        necessary_stats_dict = self._create_necessary_stats_dict(scales_shape_dict)
+        if self.color_statistics:
+            scales_shape_dict = self._create_color_scales_shape_dict(scales_shape_dict)
+            necessary_stats_dict = self._create_color_necessary_stats_dict(
+                necessary_stats_dict
+            )
+        self._necessary_stats_dict = necessary_stats_dict
         # turn this into tensor we can use in forward pass. first into a
         # boolean mask...
         _necessary_stats_mask = einops.pack(
@@ -351,6 +388,30 @@ class PortillaSimoncelli(nn.Module):
 
         return shape_dict
 
+    @staticmethod
+    def _create_color_scales_shape_dict(
+        scales_shape_dict: OrderedDict,
+    ) -> OrderedDict:
+        """
+        Create dictionary defining scales and shape of each stat for the
+        joint color statistics.
+
+        Parameters
+        ----------
+        scales_shape_dict
+            Scale metadata dictionary for the grayscale statistics.
+            Generated via `_create_scales_shape_dict()`.
+
+        Returns
+        -------
+        color_scales_shape_dict
+            Scale metadata dictionary for the joint color statistics.
+        """
+        return OrderedDict(
+            (key, np.repeat(value[None], 3, axis=0))
+            for key, value in scales_shape_dict.items()
+        )
+
     def _create_necessary_stats_dict(
         self, scales_shape_dict: OrderedDict
     ) -> OrderedDict:
@@ -420,11 +481,37 @@ class PortillaSimoncelli(nn.Module):
             mask_dict[k] = mask
         return mask_dict
 
+    @staticmethod
+    def _create_color_necessary_stats_dict(
+        necessary_stats_dict: OrderedDict,
+    ) -> OrderedDict:
+        """
+        Create mask specifying the necessary statistics for the joint
+        color statistics.
+
+        Parameters
+        ----------
+        necessary_stats_dict
+            Necessary statistics masks for the channel-independent representation.
+            Generated via `_create_necessary_stats_dict()`.
+
+        Returns
+        -------
+        color_necessary_stats_dict
+            Necessary statistics masks for the joint color statistics.
+        """
+        return OrderedDict(
+            (key, value.unsqueeze(0).repeat(3, *([1] * value.ndim)))
+            for key, value in necessary_stats_dict.items()
+        )
+
     def forward(self, image: Tensor, scales: list[SCALES_TYPE] | None = None) -> Tensor:
         r"""
         Generate Texture Statistics representation of an image.
 
-        Note that separate batches and channels are analyzed in parallel.
+        By default, separate batches and channels are analyzed in parallel. If
+        ``color_statistics=True``, the input must have three channels and is analyzed
+        as one joint color image.
 
         For any representation that contains info across scales, the scales always run
         from fine to coarse, representing all orientations at a given scale before
@@ -444,13 +531,16 @@ class PortillaSimoncelli(nn.Module):
         Returns
         -------
         representation_tensor
-            3d tensor of shape (batch, channel, stats) containing the measured
-            texture statistics.
+            3d tensor containing the measured texture statistics. Its shape is
+            ``(batch, channel, stats)`` when ``color_statistics=False`` and
+            ``(batch, 1, stats)`` when ``color_statistics=True``.
 
         Raises
         ------
         ValueError
             If ``image`` is not 4d or has a dtype other than float or complex.
+        ValueError
+            If ``color_statistics=True`` but ``image`` does not have three channels.
 
         Examples
         --------
@@ -461,6 +551,30 @@ class PortillaSimoncelli(nn.Module):
         >>> representation_tensor.shape
         torch.Size([1, 1, 710])
         """
+        if image.ndim != 4:
+            raise ValueError(
+                "PortillaSimoncelli expects a 4d image with shape "
+                "(batch, channel, height, width), but image has "
+                f"dimension {image.ndim} and shape {image.shape} instead."
+                
+            )
+        if self.color_statistics and image.shape[1] != 3:
+            raise ValueError(
+                "PortillaSimoncelli with color_statistics=True expects an RGB image "
+                f"with three channels, but image has shape {image.shape} instead."
+            )
+
+        # Pixel statistics are always computed in the original image space.
+        pixel_stats = self._compute_pixel_stats(image)
+        if self.color_statistics:
+            image_for_pyramid = (
+                image if self.transform is None else self.transform(image)
+            )
+            image_var = torch.var(image_for_pyramid, dim=(-2, -1))
+        else:
+            image_for_pyramid = image
+            image_var = pixel_stats[..., 1]
+
         # pyr_dict is the dictionary of complex-valued tensors returned by the
         # steerable pyramid. pyr_coeffs is a list (length n_scales) of 5d
         # tensors, each of shape (batch, channel, scales, n_orientations,
@@ -469,7 +583,7 @@ class PortillaSimoncelli(nn.Module):
         # width). Note that the residual lowpass in pyr_dict has been demeaned.
         # We keep both the dict and list of pyramid coefficients because we
         # need the dictionary for reconstructing the image done later on.
-        pyr_dict, pyr_coeffs, highpass, _ = self._compute_pyr_coeffs(image)
+        pyr_dict, pyr_coeffs, highpass, _ = self._compute_pyr_coeffs(image_for_pyramid)
 
         # Now, we create several intermediate representations that we'll use to
         # compute the texture statistics later.
@@ -494,10 +608,6 @@ class PortillaSimoncelli(nn.Module):
 
         # Now, start calculating the PS texture stats.
 
-        # Calculate pixel statistics (mean, variance, skew, kurtosis, min,
-        # max).
-        pixel_stats = self._compute_pixel_stats(image)
-
         # Compute the central autocorrelation of the coefficient magnitudes. This is a
         # tensor of shape: (batch, channel, spatial_corr_width, spatial_corr_width,
         # n_orientations, n_scales). var_mags is a tensor of shape (batch, channel,
@@ -520,7 +630,7 @@ class PortillaSimoncelli(nn.Module):
         # n_scales+1)
         std_recon = var_recon.sqrt()
         skew_recon, kurtosis_recon = self._compute_skew_kurtosis_recon(
-            reconstructed_images, var_recon, pixel_stats[..., 1]
+            reconstructed_images, var_recon, image_var
         )
 
         # Compute the cross-orientation correlations between the magnitude
@@ -572,7 +682,13 @@ class PortillaSimoncelli(nn.Module):
             all_stats += [cross_scale_corr_mags, cross_scale_corr_real]
         all_stats += [var_highpass_residual]
         # And then pack them into a 3d tensor
-        representation_tensor, pack_info = einops.pack(all_stats, "b c *")
+        if self.color_statistics:
+            # When using joint color statistics we don't keep the separate
+            # channels, since some statistics don't correspond to a single channel
+            representation_tensor, pack_info = einops.pack(all_stats, "b *")
+            representation_tensor = representation_tensor.unsqueeze(1)
+        else:
+            representation_tensor, pack_info = einops.pack(all_stats, "b c *")
 
         # the only time when this is None is during testing, when we make sure
         # that our assumptions are all valid.
@@ -1376,7 +1492,13 @@ class PortillaSimoncelli(nn.Module):
             If ``rep`` contains additional keys.
         KeyError
             If ``rep`` is missing any keys.
+        NotImplementedError
+            If ``color_statistics=True``.
         """  # numpydoc ignore=EX01
+        if self.color_statistics:
+            raise NotImplementedError(
+              "Plotting is not implemented for `color_statistics=True`."
+            )
         if set(rep.keys()) > set(self._necessary_stats_dict.keys()):
             raise ValueError("representation contains additional keys!")
         elif set(rep.keys()) < set(self._necessary_stats_dict.keys()):

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -392,7 +392,7 @@ class PortillaSimoncelli(nn.Module):
     def _create_color_scales_shape_dict(
         self, scales_shape_dict: OrderedDict
     ) -> OrderedDict:
-        """Create dictionary of scales and shape for stats for the joint color statistics.
+        """Create dictionary of scales and shape for joint color statistics.
 
         Parameters
         ----------
@@ -407,7 +407,10 @@ class PortillaSimoncelli(nn.Module):
         """
         color_shape_dict = OrderedDict()
         for key, value in scales_shape_dict.items():
-            if key == "cross_orientation_correlation_magnitude":
+            if key in [
+                "cross_orientation_correlation_magnitude",
+                "cross_scale_correlation_magnitude",
+            ]:
                 # Add the joint-channel statistics scales
                 color_shape_dict[key] = np.tile(
                     value, (N_RGB_CHANNELS, N_RGB_CHANNELS, 1)
@@ -534,6 +537,9 @@ class PortillaSimoncelli(nn.Module):
                 )
                 mask[triu_inds[0], triu_inds[1]] = False
                 color_mask_dict[key] = mask
+            elif key == "cross_scale_correlation_magnitude":
+                # Cross-scale correlations are not symmetric, so keep all entries.
+                color_mask_dict[key] = value.repeat(N_RGB_CHANNELS, N_RGB_CHANNELS, 1)
             else:
                 color_mask_dict[key] = value.unsqueeze(0).repeat(
                     N_RGB_CHANNELS, *([1] * value.ndim)
@@ -744,12 +750,22 @@ class PortillaSimoncelli(nn.Module):
             ) = self._double_phase_pyr_coeffs(pyr_coeffs)
             # Compute the cross-scale correlations between the magnitude
             # coefficients. For each coefficient, we're correlating it with the
-            # coefficients at the next-coarsest scale. this will be a tensor of
-            # shape (batch, channel, n_orientations, n_orientations,
-            # n_scales-1)
-            cross_scale_corr_mags = self._compute_cross_correlation(
-                mag_pyr_coeffs[:-1], phase_doubled_mags, mags_var[..., :-1]
-            )
+            # coefficients at the next-coarsest scale.
+            if self.color_statistics:
+                # combine channel and ori so correlations are jointly across both.
+                joint_phase_doubled_mags = [
+                    einops.rearrange(m, "b c o h w -> b 1 (c o) h w")
+                    for m in phase_doubled_mags
+                ]
+                cross_scale_corr_mags = self._compute_cross_correlation(
+                    joint_mag_pyr_coeffs[:-1],
+                    joint_phase_doubled_mags,
+                    joint_mags_var[..., :-1],
+                ).squeeze(1)
+            else:
+                cross_scale_corr_mags = self._compute_cross_correlation(
+                    mag_pyr_coeffs[:-1], phase_doubled_mags, mags_var[..., :-1]
+                )
             # Compute the cross-scale correlations between the real
             # coefficients and the real and imaginary coefficients at the next
             # coarsest scale. this will be a tensor of shape (batch, channel,

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -727,18 +727,9 @@ class PortillaSimoncelli(nn.Module):
         # Compute the cross-orientation correlations between the magnitude
         # coefficients at each scale.
         if self.color_statistics:
-            # combine channel and ori so correlations are jointly across both.
-            joint_mag_pyr_coeffs = [
-                einops.rearrange(m, "b c o h w -> b 1 (c o) h w")
-                for m in mag_pyr_coeffs
-            ]
-            joint_mags_var = einops.rearrange(mags_var, "b c o s -> b 1 (c o) s")
-            cross_ori_corr_mags = self._compute_cross_correlation(
-                joint_mag_pyr_coeffs,
-                joint_mag_pyr_coeffs,
-                joint_mags_var,
-                joint_mags_var,
-            ).squeeze(1)
+            cross_ori_corr_mags = self._compute_joint_cross_correlation(
+                mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var
+            )
         else:
             cross_ori_corr_mags = self._compute_cross_correlation(
                 mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var
@@ -756,16 +747,11 @@ class PortillaSimoncelli(nn.Module):
             # coefficients. For each coefficient, we're correlating it with the
             # coefficients at the next-coarsest scale.
             if self.color_statistics:
-                # combine channel and ori so correlations are jointly across both.
-                joint_phase_doubled_mags = [
-                    einops.rearrange(m, "b c o h w -> b 1 (c o) h w")
-                    for m in phase_doubled_mags
-                ]
-                cross_scale_corr_mags = self._compute_cross_correlation(
-                    joint_mag_pyr_coeffs[:-1],
-                    joint_phase_doubled_mags,
-                    joint_mags_var[..., :-1],
-                ).squeeze(1)
+                cross_scale_corr_mags = self._compute_joint_cross_correlation(
+                    mag_pyr_coeffs[:-1],
+                    phase_doubled_mags,
+                    mags_var[..., :-1],
+                )
             else:
                 cross_scale_corr_mags = self._compute_cross_correlation(
                     mag_pyr_coeffs[:-1], phase_doubled_mags, mags_var[..., :-1]
@@ -774,18 +760,9 @@ class PortillaSimoncelli(nn.Module):
             # coefficients and the real and imaginary coefficients at the next
             # coarsest scale.
             if self.color_statistics:
-                # combine channel and ori so correlations are jointly across both.
-                joint_real_pyr_coeffs = [
-                    einops.rearrange(r, "b c o h w -> b 1 (c o) h w")
-                    for r in real_pyr_coeffs
-                ]
-                joint_phase_doubled_sep = [
-                    einops.rearrange(r, "b c o h w -> b 1 (c o) h w")
-                    for r in phase_doubled_sep
-                ]
-                cross_scale_corr_real = self._compute_cross_correlation(
-                    joint_real_pyr_coeffs[:-1], joint_phase_doubled_sep
-                ).squeeze(1)
+                cross_scale_corr_real = self._compute_joint_cross_correlation(
+                    real_pyr_coeffs[:-1], phase_doubled_sep
+                )
             else:
                 cross_scale_corr_real = self._compute_cross_correlation(
                     real_pyr_coeffs[:-1], phase_doubled_sep
@@ -1405,6 +1382,39 @@ class PortillaSimoncelli(nn.Module):
             # into the cross-correlation
             covars.append(covar / var_outer_prod.sqrt())
         return torch.stack(covars, -1)
+
+    def _compute_joint_cross_correlation(
+        self,
+        coeffs_tensor: list[Tensor],
+        coeffs_tensor_other: list[Tensor],
+        coeffs_var: None | Tensor = None,
+        coeffs_other_var: None | Tensor = None,
+    ) -> Tensor:
+        """Compute cross-correlations jointly across channel and orientation.
+
+        Returns
+        -------
+        joint_cross_correlations
+            Cross-correlations with channel and orientation combined into each
+            signal dimension.
+        """
+        # Combine channel and orientation into one dimension to compute correlations
+        coeffs_tensor = [
+            einops.rearrange(c, "b c o h w -> b 1 (c o) h w") for c in coeffs_tensor
+        ]
+        coeffs_tensor_other = [
+            einops.rearrange(c, "b c o h w -> b 1 (c o) h w")
+            for c in coeffs_tensor_other
+        ]
+        if coeffs_var is not None:
+            coeffs_var = einops.rearrange(coeffs_var, "b c o s -> b 1 (c o) s")
+        if coeffs_other_var is not None:
+            coeffs_other_var = einops.rearrange(
+                coeffs_other_var, "b c o s -> b 1 (c o) s"
+            )
+        return self._compute_cross_correlation(
+            coeffs_tensor, coeffs_tensor_other, coeffs_var, coeffs_other_var
+        ).squeeze(1)
 
     @staticmethod
     def _double_phase_pyr_coeffs(

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -407,6 +407,8 @@ class PortillaSimoncelli(nn.Module):
             Scale metadata dictionary for the joint color statistics.
         """
         color_shape_dict = OrderedDict()
+        # Vacher 2021 Appendix B.2 specifies that grayscale statistics (iv)-(vi)
+        # are computed jointly across the transformed color bands.
         joint_correlation_keys = [
             "cross_orientation_correlation_magnitude",
             "cross_scale_correlation_magnitude",
@@ -415,18 +417,22 @@ class PortillaSimoncelli(nn.Module):
         for key, value in scales_shape_dict.items():
             if key in joint_correlation_keys:
                 # Add the joint-channel statistics scales
+                # Specified in Appendix B.2, second bullet point.
                 color_shape_dict[key] = np.tile(
                     value, (N_RGB_CHANNELS, N_RGB_CHANNELS, 1)
                 )
             else:
                 color_shape_dict[key] = np.repeat(value[None], N_RGB_CHANNELS, axis=0)
 
-        # Add statistics that only exist for the color representation
+        # Additional color statistics from Vacher & Briand (2021), Appendix B.2.
+        # Comments below number the new statistics as they appear in the Appendix B.2.
+        # (vii) Color covariance matrix.
         color_shape_dict["color_covariance"] = np.full(
             (N_RGB_CHANNELS, N_RGB_CHANNELS),
             "pixel_statistics",
             dtype=object,
         )
+        # (viii) Autocorrelations of each transformed band.
         color_shape_dict["auto_correlation_transformed"] = np.full(
             (
                 N_RGB_CHANNELS,
@@ -436,21 +442,25 @@ class PortillaSimoncelli(nn.Module):
             "pixel_statistics",
             dtype=object,
         )
+        # (ix) Skewness and kurtosis of each transformed band.
         color_shape_dict["skew_transformed"] = np.full(
             N_RGB_CHANNELS, "pixel_statistics", dtype=object
         )
         color_shape_dict["kurtosis_transformed"] = np.full(
             N_RGB_CHANNELS, "pixel_statistics", dtype=object
         )
+        # (x) Same-scale correlations of real oriented coefficients.
         color_shape_dict["cross_orientation_correlation_real"] = color_shape_dict[
             "cross_orientation_correlation_magnitude"
         ].copy()
         n_lowpass_signals = len(LOWPASS_SHIFTS) * N_RGB_CHANNELS
+        # (xi) Correlations among shifted lowpass signals.
         color_shape_dict["cross_correlation_lowpass"] = np.full(
             (n_lowpass_signals, n_lowpass_signals),
             "residual_lowpass",
             dtype=object,
         )
+        # (xii) Correlations between the coarsest real coefficients and lowpass.
         color_shape_dict["cross_correlation_coarsest_scale_lowpass"] = np.full(
             (N_RGB_CHANNELS * self.n_orientations, n_lowpass_signals),
             self.n_scales - 1,
@@ -709,11 +719,14 @@ class PortillaSimoncelli(nn.Module):
             image_for_pyramid = (
                 image if self.transform is None else self.transform(image)
             )
+            # Vacher 2021 Appendix B.2, statistic (vii).
             color_covariance = self._compute_color_covariance(image)
             transformed_pixel_stats = self._compute_pixel_stats(image_for_pyramid)
             image_var = transformed_pixel_stats[..., 1]
+            # Vacher 2021 Appendix B.2, statistic (ix).
             skew_transformed = transformed_pixel_stats[..., 2]
             kurtosis_transformed = transformed_pixel_stats[..., 3]
+            # Vacher 2021 Appendix B.2, statistic (viii).
             centered_transformed = image_for_pyramid - image_for_pyramid.mean(
                 dim=(-2, -1), keepdim=True
             )
@@ -787,12 +800,15 @@ class PortillaSimoncelli(nn.Module):
         # Compute the cross-orientation correlations between the magnitude
         # coefficients at each scale.
         if self.color_statistics:
+            # Vacher 2021 Appendix B.2, second bullet point
             cross_ori_corr_mags = self._compute_joint_cross_correlation(
                 mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var
             )
+            # Vacher 2021 Appendix B.2, statistic (x).
             cross_ori_corr_real = self._compute_joint_cross_correlation(
                 real_pyr_coeffs, real_pyr_coeffs
             )
+            # Vacher 2021 Appendix B.2, statistics (xi) and (xii).
             # Upsample the lowpass in Fourier space and add its four periodic
             # two-pixel shifts.
             expanded_lowpass = signal.expand(lowpass, 2)
@@ -828,6 +844,7 @@ class PortillaSimoncelli(nn.Module):
             # coefficients. For each coefficient, we're correlating it with the
             # coefficients at the next-coarsest scale.
             if self.color_statistics:
+                # Vacher 2021 Appendix B.2, second bullet point
                 cross_scale_corr_mags = self._compute_joint_cross_correlation(
                     mag_pyr_coeffs[:-1],
                     phase_doubled_mags,
@@ -841,6 +858,7 @@ class PortillaSimoncelli(nn.Module):
             # coefficients and the real and imaginary coefficients at the next
             # coarsest scale.
             if self.color_statistics:
+                # Vacher Appendix B.2, statistic (vi), second bullet point
                 cross_scale_corr_real = self._compute_joint_cross_correlation(
                     real_pyr_coeffs[:-1], phase_doubled_sep
                 )

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -41,6 +41,7 @@ from ..tensors import to_numpy
 
 SCALES_TYPE = Literal["pixel_statistics"] | PYR_SCALES_TYPE
 N_RGB_CHANNELS = 3
+LOWPASS_SHIFTS = ((0, 0), (2, 0), (-2, 0), (0, 2), (0, -2))
 
 __all__ = [
     "PortillaSimoncelli",
@@ -444,6 +445,12 @@ class PortillaSimoncelli(nn.Module):
         color_shape_dict["cross_orientation_correlation_real"] = color_shape_dict[
             "cross_orientation_correlation_magnitude"
         ].copy()
+        n_lowpass_signals = len(LOWPASS_SHIFTS) * N_RGB_CHANNELS
+        color_shape_dict["cross_correlation_lowpass"] = np.full(
+            (n_lowpass_signals, n_lowpass_signals),
+            "residual_lowpass",
+            dtype=object,
+        )
         return color_shape_dict
 
     def _create_necessary_stats_dict(
@@ -579,6 +586,37 @@ class PortillaSimoncelli(nn.Module):
             N_RGB_CHANNELS, dtype=torch.bool
         )
         color_mask_dict["cross_orientation_correlation_real"] = same_scale_mask.clone()
+
+        # These correlations depend only on the channel pair and the relative
+        # shift. E.g. (-2, 0) and (0, 0) have same correlation as (0, 0), (2, 0)
+        lowpass_signal_labels = [
+            (channel, shift)
+            for channel in range(N_RGB_CHANNELS)
+            for shift in LOWPASS_SHIFTS
+        ]
+        n_lowpass_signals = len(lowpass_signal_labels)
+        lowpass_mask = torch.zeros(
+            n_lowpass_signals, n_lowpass_signals, dtype=torch.bool
+        )
+        seen_correlations = set()
+        for row, (row_channel, row_shift) in enumerate(lowpass_signal_labels):
+            for column, (column_channel, column_shift) in enumerate(
+                lowpass_signal_labels[:row]
+            ):
+                # Compute relative shift, and disambiguate
+                relative_shift = (
+                  column_shift[0] - row_shift[0], column_shift[1] - row_shift[1]
+                )
+                if row_channel == column_channel:
+                    opposite_shift = tuple(-offset for offset in relative_shift)
+                    relative_shift = min(relative_shift, opposite_shift)
+                # Check if redundant entry was already seen. If not, set to true and
+                # add to seen entries
+                correlation = (row_channel, column_channel, relative_shift)
+                if correlation not in seen_correlations:
+                    lowpass_mask[row, column] = True
+                    seen_correlations.add(correlation)
+        color_mask_dict["cross_correlation_lowpass"] = lowpass_mask
         return color_mask_dict
 
     @staticmethod
@@ -686,7 +724,9 @@ class PortillaSimoncelli(nn.Module):
         # width). Note that the residual lowpass in pyr_dict has been demeaned.
         # We keep both the dict and list of pyramid coefficients because we
         # need the dictionary for reconstructing the image done later on.
-        pyr_dict, pyr_coeffs, highpass, _ = self._compute_pyr_coeffs(image_for_pyramid)
+        pyr_dict, pyr_coeffs, highpass, lowpass = self._compute_pyr_coeffs(
+            image_for_pyramid
+        )
 
         # Now, we create several intermediate representations that we'll use to
         # compute the texture statistics later.
@@ -745,6 +785,19 @@ class PortillaSimoncelli(nn.Module):
             cross_ori_corr_real = self._compute_joint_cross_correlation(
                 real_pyr_coeffs, real_pyr_coeffs
             )
+            # Upsample the lowpass in Fourier space and add its four periodic
+            # two-pixel shifts.
+            expanded_lowpass = signal.expand(lowpass, 2)
+            lowpass_signals = torch.stack(
+                [
+                    torch.roll(expanded_lowpass, shift, (-2, -1))
+                    for shift in LOWPASS_SHIFTS
+                ],
+                dim=2,
+            )
+            cross_corr_lowpass = self._compute_joint_cross_correlation(
+                [lowpass_signals], [lowpass_signals]
+            ).squeeze(-1)
         else:
             cross_ori_corr_mags = self._compute_cross_correlation(
                 mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var
@@ -808,6 +861,7 @@ class PortillaSimoncelli(nn.Module):
                 skew_transformed,
                 kurtosis_transformed,
                 cross_ori_corr_real,
+                cross_corr_lowpass,
             ]
         # And then pack them into a 3d tensor
         if self.color_statistics:

--- a/src/plenoptic/models/portilla_simoncelli.py
+++ b/src/plenoptic/models/portilla_simoncelli.py
@@ -420,7 +420,7 @@ class PortillaSimoncelli(nn.Module):
             else:
                 color_shape_dict[key] = np.repeat(value[None], N_RGB_CHANNELS, axis=0)
 
-        # Statistics that only exist for the color representation
+        # Add statistics that only exist for the color representation
         color_shape_dict["color_covariance"] = np.full(
             (N_RGB_CHANNELS, N_RGB_CHANNELS),
             "pixel_statistics",
@@ -441,6 +441,9 @@ class PortillaSimoncelli(nn.Module):
         color_shape_dict["kurtosis_transformed"] = np.full(
             N_RGB_CHANNELS, "pixel_statistics", dtype=object
         )
+        color_shape_dict["cross_orientation_correlation_real"] = color_shape_dict[
+            "cross_orientation_correlation_magnitude"
+        ].copy()
         return color_shape_dict
 
     def _create_necessary_stats_dict(
@@ -559,7 +562,7 @@ class PortillaSimoncelli(nn.Module):
                 N_RGB_CHANNELS, N_RGB_CHANNELS, 1
             )
 
-        # Statistics that only exist for the color representation
+        # Add statistics that only exist for the color representation
         # The diagonal variances are already included in pixel_statistics,
         # so they are redundant.
         color_mask_dict["color_covariance"] = torch.ones(
@@ -575,6 +578,7 @@ class PortillaSimoncelli(nn.Module):
         color_mask_dict["kurtosis_transformed"] = torch.ones(
             N_RGB_CHANNELS, dtype=torch.bool
         )
+        color_mask_dict["cross_orientation_correlation_real"] = same_scale_mask.clone()
         return color_mask_dict
 
     @staticmethod
@@ -738,6 +742,9 @@ class PortillaSimoncelli(nn.Module):
             cross_ori_corr_mags = self._compute_joint_cross_correlation(
                 mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var
             )
+            cross_ori_corr_real = self._compute_joint_cross_correlation(
+                real_pyr_coeffs, real_pyr_coeffs
+            )
         else:
             cross_ori_corr_mags = self._compute_cross_correlation(
                 mag_pyr_coeffs, mag_pyr_coeffs, mags_var, mags_var
@@ -800,6 +807,7 @@ class PortillaSimoncelli(nn.Module):
                 autocorr_transformed,
                 skew_transformed,
                 kurtosis_transformed,
+                cross_ori_corr_real,
             ]
         # And then pack them into a 3d tensor
         if self.color_statistics:

--- a/src/plenoptic/process/__init__.pyi
+++ b/src/plenoptic/process/__init__.pyi
@@ -27,8 +27,11 @@ __all__ = [
     "kurtosis",
     "normalized_laplacian_pyramid",
     "ssim_map",
+    "OPC",
+    "PCA",
 ]
 
+from .color import OPC, PCA
 from .convolutions import (
     blur_downsample,
     correlate_downsample,

--- a/src/plenoptic/process/color.py
+++ b/src/plenoptic/process/color.py
@@ -1,0 +1,110 @@
+"""Color-space transformations."""
+
+import torch
+from torch import Tensor
+
+__all__ = [
+    "OPC",
+    "PCA",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def _validate_color_image(image: Tensor) -> None:
+    if image.ndim not in (3, 4):
+        raise ValueError(
+          "Expected a 3d or 4d color image tensor."
+          f" Got {image.ndim}d tensor with shape {tuple(image.shape)}."
+        )
+    if image.shape[-3] != 3:
+        raise ValueError(
+          "Expected an image with three color channels."
+          f" Got {image.shape[-3]} channels."
+        )
+
+
+class OPC(torch.nn.Module):
+    """Transform an RGB image to opponent-cone (OPC) space.
+
+    This first maps RGB values to approximate LMS cone responses, then maps
+    those responses to achromatic, red-green, and blue-yellow channels. The
+    matrices are from the PooledStatisticsMetamers implementation [1]_.
+
+    References
+    ----------
+    .. [1] https://github.com/ProgramofComputerGraphics/PooledStatisticsMetamers/
+       blob/main/poolstatmetamer/color_utils.py
+    """
+
+    def __init__(self):
+        super().__init__()
+        rgb_to_lms = torch.tensor(
+            [
+                [0.3811, 0.5783, 0.0402],
+                [0.1967, 0.7244, 0.0782],
+                [0.0241, 0.1288, 0.8444],
+            ]
+        )
+        lms_to_opponent = torch.tensor(
+            [
+                [0.5, 0.5, 0.0],
+                [-4.0, 4.0, 0.0],
+                [0.5, 0.5, -1.0],
+            ]
+        )
+        self.register_buffer("matrix", lms_to_opponent @ rgb_to_lms)
+
+    def forward(self, image: Tensor) -> Tensor:
+        """Transform ``image`` from RGB to opponent-cone space.
+
+        Returns
+        -------
+        transformed_image
+            The opponent-cone image, with the same shape as ``image``.
+        """
+        _validate_color_image(image)
+        return torch.einsum("ij,...jhw->...ihw", self.matrix, image)
+
+
+class PCA(torch.nn.Module):
+    """Center and whiten color channels with respect to a target image PCA.
+
+    Parameters
+    ----------
+    image
+        A 3d tensor with shape ``(channel, height, width)`` or a 4d tensor with
+        shape ``(1, channel, height, width)``. The fitted transform is fixed
+        after initialization and can be applied to later image batches.
+    """
+
+    def __init__(self, image: Tensor):
+        super().__init__()
+        _validate_color_image(image)
+        if image.ndim == 4:
+            if image.shape[0] != 1:
+                raise ValueError("PCA must be fit to a single image.")
+            image = image.squeeze(0)
+
+        mean = image.mean(dim=(-2, -1), keepdim=True)
+        centered = (image - mean).flatten(1)
+        covariance = centered @ centered.mT / centered.shape[-1]
+        eigenvalues, eigenvectors = torch.linalg.eigh(covariance)
+        eigenvalues = eigenvalues.clamp_min(torch.finfo(eigenvalues.dtype).eps)
+        transform = torch.einsum("i,ji->ij", eigenvalues.rsqrt(), eigenvectors)
+        self.register_buffer("mean", mean.detach())
+        self.register_buffer("matrix", transform.detach())
+
+    def forward(self, image: Tensor) -> Tensor:
+        """Center and whiten ``image`` using the fitted PCA transform.
+
+        Returns
+        -------
+        transformed_image
+            The PCA-whitened image, with the same shape as ``image``.
+        """
+        _validate_color_image(image)
+        centered = image - self.mean
+        return torch.einsum("ij,...jhw->...ihw", self.matrix, centered)

--- a/src/plenoptic/process/color.py
+++ b/src/plenoptic/process/color.py
@@ -16,13 +16,13 @@ def __dir__() -> list[str]:
 def _validate_color_image(image: Tensor) -> None:
     if image.ndim not in (3, 4):
         raise ValueError(
-          "Expected a 3d or 4d color image tensor."
-          f" Got {image.ndim}d tensor with shape {tuple(image.shape)}."
+            "Expected a 3d or 4d color image tensor."
+            f" Got {image.ndim}d tensor with shape {tuple(image.shape)}."
         )
     if image.shape[-3] != 3:
         raise ValueError(
-          "Expected an image with three color channels."
-          f" Got {image.shape[-3]} channels."
+            "Expected an image with three color channels."
+            f" Got {image.shape[-3]} channels."
         )
 
 
@@ -78,11 +78,17 @@ class PCA(torch.nn.Module):
         A 3d tensor with shape ``(channel, height, width)`` or a 4d tensor with
         shape ``(1, channel, height, width)``. The fitted transform is fixed
         after initialization and can be applied to later image batches.
+    max_relative_scaling
+        Maximum ratio between the largest and smallest scaling applied along
+        the principal components by the whitening transform. Must be at least 1.
+        By default, no relative scaling limit is applied.
     """
 
-    def __init__(self, image: Tensor):
+    def __init__(self, image: Tensor, max_relative_scaling: float = float("inf")):
         super().__init__()
         _validate_color_image(image)
+        if not max_relative_scaling >= 1:
+            raise ValueError("max_relative_scaling must be greater than or equal to 1.")
         if image.ndim == 4:
             if image.shape[0] != 1:
                 raise ValueError("PCA must be fit to a single image.")
@@ -92,6 +98,8 @@ class PCA(torch.nn.Module):
         centered = (image - mean).flatten(1)
         covariance = centered @ centered.mT / centered.shape[-1]
         eigenvalues, eigenvectors = torch.linalg.eigh(covariance)
+        eigenvalue_floor = eigenvalues.max() / max_relative_scaling**2
+        eigenvalues = eigenvalues.clamp_min(eigenvalue_floor)
         eigenvalues = eigenvalues.clamp_min(torch.finfo(eigenvalues.dtype).eps)
         transform = torch.einsum("i,ji->ij", eigenvalues.rsqrt(), eigenvectors)
         self.register_buffer("mean", mean.detach())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,11 @@ def color_img():
 
 
 @pytest.fixture(scope="package")
+def color_img_small(color_img):
+    return po.process.shrink(color_img, 4)
+
+
+@pytest.fixture(scope="package")
 def parrot_square():
     img = po.load_images(IMG_DIR / "mixed" / "Parrot.png").to(DEVICE)
     return po.process.center_crop(img, 254)

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,0 +1,95 @@
+import pytest
+import torch
+
+import plenoptic as po
+from conftest import DEVICE
+
+
+@pytest.mark.parametrize("batched", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_opc(batched, dtype):
+    image = torch.rand(1, 3, 8, 8, device=DEVICE, dtype=dtype)
+    if not batched:
+        image = image.squeeze(0)
+    transform = po.process.OPC().to(device=DEVICE, dtype=dtype)
+    rgb_to_lms = torch.tensor(
+        [
+            [0.3811, 0.5783, 0.0402],
+            [0.1967, 0.7244, 0.0782],
+            [0.0241, 0.1288, 0.8444],
+        ]
+    ).to(device=DEVICE, dtype=dtype)
+    lms_to_opponent = torch.tensor(
+        [
+          [0.5, 0.5, 0.0],
+          [-4.0, 4.0, 0.0],
+          [0.5, 0.5, -1.0],
+        ]
+    ).to(device=DEVICE, dtype=dtype)
+    expected = torch.einsum("ij,...jhw->...ihw", lms_to_opponent @ rgb_to_lms, image)
+    torch.testing.assert_close(transform(image), expected)
+    assert transform(image).shape == image.shape
+
+
+@pytest.mark.parametrize("batched", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_pca(batched, dtype):
+    target = torch.rand(1, 3, 16, 16, device=DEVICE, dtype=dtype)
+    if not batched:
+        target = target.squeeze(0)
+    transform = po.process.PCA(target)
+    transformed = transform(target)
+    assert transformed.shape == target.shape
+
+    # Transformed data should have zero mean and identity covariance
+    transformed = transformed.reshape(3, -1)
+    torch.testing.assert_close(
+        transformed.mean(-1),
+        torch.zeros(3, device=DEVICE, dtype=dtype),
+        atol=1e-6,
+        rtol=0,
+    )
+    covariance = transformed @ transformed.mT / transformed.shape[-1]
+    torch.testing.assert_close(
+        covariance,
+        torch.eye(3, device=DEVICE, dtype=dtype),
+        atol=1e-5,
+        rtol=1e-5,
+    )
+
+
+def test_pca_batch_application_and_gradients():
+    target = torch.rand(1, 3, 8, 8, device=DEVICE)
+    image = torch.rand(2, 3, 8, 8, device=DEVICE, requires_grad=True)
+    transform = po.process.PCA(target)
+    transformed = transform(image)
+    assert transformed.shape == image.shape
+    transformed.square().mean().backward()
+    assert image.grad is not None
+    assert torch.isfinite(image.grad).all()
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+      torch.rand(2, 3, 8, 8), # Invalid: batch size > 1
+      torch.rand(1, 2, 8, 8), # Invalid: channel size != 3
+      torch.rand(3, 8), # Invalid: not 3D or 4D
+    ],
+)
+def test_color_invalid_fit_image(image):
+    # Test PCA initialization with invalid images
+    with pytest.raises(ValueError):
+        po.process.PCA(image)
+
+    # Multi-batch images are not allowed for PCA initialization,
+    # but are allowed for OPC and PCA application
+    is_multibatch = (image.ndim == 4) & (image.shape[0] > 1)
+    if not is_multibatch:
+        # Test PCA application with invalid images
+        transform = po.process.PCA(torch.rand(1, 3, 8, 8))
+        with pytest.raises(ValueError):
+            transform(image)
+        # Test OPC application with invalid images
+        with pytest.raises(ValueError):
+            po.process.OPC()(image)

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -72,7 +72,9 @@ def test_pca_batch_application_and_gradients():
 @pytest.mark.parametrize("max_relative_scaling", [1, 2, 10])
 def test_pca_max_relative_scaling(max_relative_scaling):
     channel = torch.rand(1, 1, 8, 8, device=DEVICE, dtype=torch.float64)
-    target = channel.repeat(1, 3, 1, 1) # Perfect color correlation, inf relative scaling
+    target = channel.repeat(
+        1, 3, 1, 1
+    )  # Perfect color correlation, inf relative scaling
     transform = po.process.PCA(target, max_relative_scaling=max_relative_scaling)
     scaling = torch.linalg.svdvals(transform.matrix)
     torch.testing.assert_close(

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -21,9 +21,9 @@ def test_opc(batched, dtype):
     ).to(device=DEVICE, dtype=dtype)
     lms_to_opponent = torch.tensor(
         [
-          [0.5, 0.5, 0.0],
-          [-4.0, 4.0, 0.0],
-          [0.5, 0.5, -1.0],
+            [0.5, 0.5, 0.0],
+            [-4.0, 4.0, 0.0],
+            [0.5, 0.5, -1.0],
         ]
     ).to(device=DEVICE, dtype=dtype)
     expected = torch.einsum("ij,...jhw->...ihw", lms_to_opponent @ rgb_to_lms, image)
@@ -69,12 +69,39 @@ def test_pca_batch_application_and_gradients():
     assert torch.isfinite(image.grad).all()
 
 
+@pytest.mark.parametrize("max_relative_scaling", [1, 2, 10])
+def test_pca_max_relative_scaling(max_relative_scaling):
+    channel = torch.rand(1, 1, 8, 8, device=DEVICE, dtype=torch.float64)
+    target = channel.repeat(1, 3, 1, 1) # Perfect color correlation, inf relative scaling
+    transform = po.process.PCA(target, max_relative_scaling=max_relative_scaling)
+    scaling = torch.linalg.svdvals(transform.matrix)
+    torch.testing.assert_close(
+        scaling.max() / scaling.min(),
+        torch.as_tensor(max_relative_scaling, device=DEVICE, dtype=torch.float64),
+    )
+
+
+def test_pca_infinite_max_relative_scaling_is_default():
+    target = torch.rand(1, 3, 8, 8, device=DEVICE)
+    default = po.process.PCA(target)
+    infinite = po.process.PCA(target, max_relative_scaling=float("inf"))
+    torch.testing.assert_close(default.mean, infinite.mean)
+    torch.testing.assert_close(default.matrix, infinite.matrix)
+
+
+@pytest.mark.parametrize("max_relative_scaling", [-1, 0, 0.5, float("nan")])
+def test_pca_invalid_max_relative_scaling(max_relative_scaling):
+    target = torch.rand(1, 3, 8, 8, device=DEVICE)
+    with pytest.raises(ValueError, match="max_relative_scaling"):
+        po.process.PCA(target, max_relative_scaling=max_relative_scaling)
+
+
 @pytest.mark.parametrize(
     "image",
     [
-      torch.rand(2, 3, 8, 8), # Invalid: batch size > 1
-      torch.rand(1, 2, 8, 8), # Invalid: channel size != 3
-      torch.rand(3, 8), # Invalid: not 3D or 4D
+        torch.rand(2, 3, 8, 8),  # Invalid: batch size > 1
+        torch.rand(1, 2, 8, 8),  # Invalid: channel size != 3
+        torch.rand(3, 8),  # Invalid: not 3D or 4D
     ],
 )
 def test_color_invalid_fit_image(image):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1076,6 +1076,18 @@ class TestPortillaSimoncelli:
             model.n_scales - 1,
         )
 
+    def test_color_cross_scale_correlation_real_shape(self, color_img_small):
+        model = self._small_ps(color_img_small, color_statistics=True)
+        representation = model.convert_to_dict(model(color_img_small))
+        n_signals = color_img_small.shape[1] * model.n_orientations
+
+        assert representation["cross_scale_correlation_real"].shape == (
+            color_img_small.shape[0],
+            n_signals,
+            2 * n_signals,
+            model.n_scales - 1,
+        )
+
     def test_default_color_transform(self):
         # The color PS model should run out of the box with the OPC transform
         image = torch.rand(1, 3, 32, 32, device=DEVICE)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1064,6 +1064,18 @@ class TestPortillaSimoncelli:
             model.n_scales,
         )
 
+    def test_color_cross_orientation_correlation_real_shape(self, color_img_small):
+        model = self._small_ps(color_img_small, color_statistics=True)
+        representation = model.convert_to_dict(model(color_img_small))
+        n_signals = color_img_small.shape[1] * model.n_orientations
+
+        assert representation["cross_orientation_correlation_real"].shape == (
+            color_img_small.shape[0],
+            n_signals,
+            n_signals,
+            model.n_scales,
+        )
+
     def test_color_cross_scale_correlation_magnitude_shape(self, color_img_small):
         model = self._small_ps(color_img_small, color_statistics=True)
         representation = model.convert_to_dict(model(color_img_small))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1076,6 +1076,20 @@ class TestPortillaSimoncelli:
             model.n_scales,
         )
 
+    def test_color_cross_correlation_lowpass_shape(self, color_img_small):
+        model = self._small_ps(color_img_small, color_statistics=True)
+        representation = model.convert_to_dict(model(color_img_small))
+        lowpass_correlations = representation["cross_correlation_lowpass"]
+        necessary_mask = model._necessary_stats_dict["cross_correlation_lowpass"]
+
+        assert lowpass_correlations.shape == (
+            color_img_small.shape[0],
+            15,
+            15,
+        )
+        assert necessary_mask.sum() == 57
+        assert lowpass_correlations[..., necessary_mask].unique().numel() == 57
+
     def test_color_cross_scale_correlation_magnitude_shape(self, color_img_small):
         model = self._small_ps(color_img_small, color_statistics=True)
         representation = model.convert_to_dict(model(color_img_small))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -699,20 +699,27 @@ class TestPortillaSimoncelli:
     @pytest.mark.parametrize("n_scales", [1, 2, 3, 4])
     @pytest.mark.parametrize("n_orientations", [2, 3, 4])
     @pytest.mark.parametrize("spatial_corr_width", range(3, 10))
+    @pytest.mark.parametrize("color_statistics", [False, True])
     def test_portilla_simoncelli(
         self,
         n_scales,
         n_orientations,
         spatial_corr_width,
+        color_statistics,
         einstein_img,
+        color_img,
     ):
+        image = color_img if color_statistics else einstein_img
+        transform = po.process.OPC()
         ps = po.models.PortillaSimoncelli(
-            einstein_img.shape[-2:],
+            image.shape[-2:],
             n_scales=n_scales,
             n_orientations=n_orientations,
             spatial_corr_width=spatial_corr_width,
+            color_statistics=color_statistics,
+            transform=transform,
         ).to(DEVICE)
-        ps(einstein_img)
+        ps(image)
 
     # tests for whether output matches the original matlab output.  This implicitly
     # tests that Portilla_simoncelli.forward() returns an object of the correct size.
@@ -1028,6 +1035,23 @@ class TestPortillaSimoncelli:
             f"Color representation is missing grayscale statistics: {missing_keys}"
         )
 
+    def test_color_statistics_dict_mask(self, color_img_small):
+        model = self._small_ps(color_img_small, color_statistics=True)
+        representation = model.convert_to_dict(model(color_img_small))
+
+        color_statistics = {
+            "color_covariance",
+            "auto_correlation_transformed",
+            "skew_transformed",
+            "kurtosis_transformed",
+        }
+        assert color_statistics <= representation.keys()
+
+        for key, value in representation.items():
+            mask = model._necessary_stats_dict[key].to(value.device)
+            assert torch.isfinite(value[..., mask]).all()
+            assert torch.isnan(value[..., ~mask]).all()
+
     def test_default_color_transform(self):
         # The color PS model should run out of the box with the OPC transform
         image = torch.rand(1, 3, 32, 32, device=DEVICE)
@@ -1202,41 +1226,74 @@ class TestPortillaSimoncelli:
 
     # fft doesn't support float16, so we can't support it
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-    def test_dtypes(self, dtype, einstein_img):
-        model = po.models.PortillaSimoncelli(einstein_img.shape[-2:]).to(DEVICE)
-        model(einstein_img.to(dtype))
+    @pytest.mark.parametrize("color_statistics", [False, True])
+    def test_dtypes(self, dtype, color_statistics, einstein_img, color_img):
+        image = color_img if color_statistics else einstein_img
+        image = image.to(dtype)
+        transform = po.process.OPC()
+        model = po.models.PortillaSimoncelli(
+            image.shape[-2:], color_statistics=color_statistics, transform=transform,
+        ).to(device=DEVICE, dtype=dtype)
+        representation = model(image)
+        assert representation.dtype == dtype
+
+    def test_validate_color_model(self):
+        image_shape = (1, 3, 32, 32)
+        transform = po.process.OPC()
+        model = po.models.PortillaSimoncelli(
+            image_shape[-2:],
+            n_scales=2,
+            spatial_corr_width=3,
+            color_statistics=True,
+            transform=transform,
+        ).to(DEVICE)
+        po.validate.validate_model(model, image_shape=image_shape, device=DEVICE)
 
     @pytest.mark.parametrize("n_scales", [1, 2, 3, 4])
     @pytest.mark.parametrize("n_orientations", [2, 3, 4])
     @pytest.mark.parametrize("spatial_corr_width", range(3, 10))
+    @pytest.mark.parametrize("color_statistics", [False, True])
     def test_scales_shapes(
-        self, n_scales, n_orientations, spatial_corr_width, einstein_img
+        self,
+        n_scales,
+        n_orientations,
+        spatial_corr_width,
+        color_statistics,
+        einstein_img,
+        color_img,
     ):
         # test that the shapes we use to assign scale labels to each statistic
         # and determine redundant stats are accurate
+        image = color_img if color_statistics else einstein_img
+        transform = po.process.OPC()
         model = po.models.PortillaSimoncelli(
-            einstein_img.shape[-2:],
+            image.shape[-2:],
             n_scales=n_scales,
             n_orientations=n_orientations,
             spatial_corr_width=spatial_corr_width,
+            color_statistics=color_statistics,
+            transform=transform,
         ).to(DEVICE)
         # this hack is to prevent model from removing redundant stats
         model._necessary_stats_mask = None
-        rep = model(einstein_img)
+        rep = model(image)
         # and then we get them back into their original shapes
         unpacked_rep = einops.unpack(rep, model._pack_info, "b c *")
+        # Discard empty statistics families (cros-corrs when scales=1)
+        # Matches keys of unpacked_rep and necessary_stats in zip below
+        necessary_stats = [
+            (key, value)
+            for key, value in model._necessary_stats_dict.items()
+            if value.nelement() > 0
+        ]
+        assert len(unpacked_rep) == len(necessary_stats)
         # because _necessary_stats_dict is an ordered dictionary, its elements
         # will be in the same order as in unpackaged_rep
-        for unp_v, dict_v in zip(unpacked_rep, model._necessary_stats_dict.values()):
-            # when we have a single scale, _necessary_stats_dict will contain
-            # keys for the cross_scale correlations, but there are no
-            # corresponding values. Thus, skip.
-            if dict_v.nelement() == 0:
-                continue
+        for unp_v, (key, dict_v) in zip(unpacked_rep, necessary_stats):
             # ignore batch and channel
             unp_v = unp_v[0, 0]
-            if not unp_v.shape:
-                # then this is var_residual_highpass, which has a single element
+            if key == "var_highpass_residual":
+                # this statistic has no explicit singleton statistic dimension
                 np.testing.assert_equal(unp_v.nelement(), dict_v.nelement())
             else:
                 np.testing.assert_equal(unp_v.shape, dict_v.shape)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -685,6 +685,17 @@ def remove_redundant_and_normalize(
 
 
 class TestPortillaSimoncelli:
+    @staticmethod
+    def _small_ps(image, **kwargs):
+        """Helper to easily generate lightweight PS model"""
+        return po.models.PortillaSimoncelli(
+            image.shape[-2:],
+            n_scales=2,
+            n_orientations=4,
+            spatial_corr_width=3,
+            **kwargs,
+        ).to(DEVICE)
+
     @pytest.mark.parametrize("n_scales", [1, 2, 3, 4])
     @pytest.mark.parametrize("n_orientations", [2, 3, 4])
     @pytest.mark.parametrize("spatial_corr_width", range(3, 10))
@@ -986,6 +997,88 @@ class TestPortillaSimoncelli:
             raise ValueError(
                 "Output doesn't have same number of batch/channel dims as input!"
             )
+
+    def test_explicit_color_statistics(self):
+        image = torch.rand(2, 3, 32, 32, device=DEVICE)
+        # PCA is fitted to a single target image
+        transform = po.process.PCA(image[0]).to(DEVICE)
+        model = self._small_ps(image, color_statistics=True, transform=transform)
+        representation_tensor = model(image)
+
+        # Batch dimension preserved, channels reduced to 1
+        assert representation_tensor.shape[:2] == (2, 1)
+
+        # Convert to dict and back to tensor, should match the original tensor
+        representation_dict = model.convert_to_dict(representation_tensor)
+        representation_tensor_new = model.convert_to_tensor(representation_dict)
+        torch.testing.assert_close(representation_tensor, representation_tensor_new)
+
+        # Test that removing a scale works and maintains batch and channel dims
+        assert model.remove_scales(representation_tensor, [0]).shape[:2] == (2, 1)
+
+        # Test that all grayscale statistics families are in the color statistics model
+        grayscale_image = image[:, :1]
+        grayscale_model = self._small_ps(grayscale_image)
+        grayscale_representation_dict = grayscale_model.convert_to_dict(
+            grayscale_model(grayscale_image)
+        )
+
+        missing_keys = set(grayscale_representation_dict) - set(representation_dict)
+        assert not missing_keys, (
+            f"Color representation is missing grayscale statistics: {missing_keys}"
+        )
+
+    def test_default_color_transform(self):
+        # The color PS model should run out of the box with the OPC transform
+        image = torch.rand(1, 3, 32, 32, device=DEVICE)
+        default_model = self._small_ps(image, color_statistics=True)
+        explicit_model = self._small_ps(
+            image, color_statistics=True, transform=po.process.OPC()
+        )
+        torch.testing.assert_close(default_model(image), explicit_model(image))
+
+    def test_none_color_transform(self):
+        # The transform=None parameter is the identity color transform
+        # Test that the object initializes, it can compute statistics,
+        # and they are different from default OPC color
+        image = torch.rand(1, 3, 32, 32, device=DEVICE)
+        color_model_id = self._small_ps(image, color_statistics=True, transform=None)
+        color_model_opc = self._small_ps(image, color_statistics=True)
+
+        representation_id = color_model_id(image)
+        representation_opc = color_model_opc(image)
+        assert not torch.allclose(representation_id, representation_opc)
+
+    def test_transform_ignored_without_color_statistics(self):
+        def transform(image):
+            raise RuntimeError("Non-color model shouldn't call this transform")
+
+        image = torch.rand(1, 3, 32, 32, device=DEVICE)
+        model = self._small_ps(image, transform=transform)
+        assert model(image).shape[:2] == image.shape[:2]
+
+    @pytest.mark.parametrize("n_channels", [1, 2])
+    def test_color_statistics_requires_rgb(self, n_channels):
+        image = torch.rand(1, n_channels, 32, 32, device=DEVICE)
+        model = self._small_ps(image, color_statistics=True)
+        with pytest.raises(ValueError, match="three channels"):
+            model(image)
+
+    def test_portilla_simoncelli_requires_4d(self):
+        image = torch.rand(1, 32, 32, device=DEVICE)
+        model = self._small_ps(image)
+        with pytest.raises(ValueError, match="expects a 4d image"):
+            model(image)
+
+    def test_color_statistics_plot_not_implemented(self):
+        image = torch.rand(1, 3, 32, 32, device=DEVICE)
+        model = self._small_ps(image, color_statistics=True)
+        representation = model(image)
+
+        with pytest.raises(NotImplementedError, match="Plotting is not implem"):
+            model.plot_representation(representation)
+        with pytest.raises(NotImplementedError, match="Plotting is not implem"):
+            model.update_plot([], representation)
 
     @pytest.mark.parametrize("input_type", ["tensor", "dict"])
     @pytest.mark.parametrize("batch_channel", [(1, 1), (1, 3), (2, 1), (2, 3)])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1055,24 +1055,26 @@ class TestPortillaSimoncelli:
     def test_color_cross_orientation_correlation_magnitude_shape(self, color_img_small):
         model = self._small_ps(color_img_small, color_statistics=True)
         representation = model.convert_to_dict(model(color_img_small))
-        n_signals = color_img_small.shape[1] * model.n_orientations
+        n_channels = color_img_small.shape[1]
+        n_oriented_signals = n_channels * model.n_orientations
 
         assert representation["cross_orientation_correlation_magnitude"].shape == (
             color_img_small.shape[0],
-            n_signals,
-            n_signals,
+            n_oriented_signals,
+            n_oriented_signals,
             model.n_scales,
         )
 
     def test_color_cross_orientation_correlation_real_shape(self, color_img_small):
         model = self._small_ps(color_img_small, color_statistics=True)
         representation = model.convert_to_dict(model(color_img_small))
-        n_signals = color_img_small.shape[1] * model.n_orientations
+        n_channels = color_img_small.shape[1]
+        n_oriented_signals = n_channels * model.n_orientations
 
         assert representation["cross_orientation_correlation_real"].shape == (
             color_img_small.shape[0],
-            n_signals,
-            n_signals,
+            n_oriented_signals,
+            n_oriented_signals,
             model.n_scales,
         )
 
@@ -1090,27 +1092,43 @@ class TestPortillaSimoncelli:
         assert necessary_mask.sum() == 57
         assert lowpass_correlations[..., necessary_mask].unique().numel() == 57
 
+    def test_color_cross_correlation_coarsest_scale_lowpass_shape(
+        self, color_img_small
+    ):
+        model = self._small_ps(color_img_small, color_statistics=True)
+        representation = model.convert_to_dict(model(color_img_small))
+        n_channels = color_img_small.shape[1]
+        n_oriented_signals = n_channels * model.n_orientations
+
+        assert representation["cross_correlation_coarsest_scale_lowpass"].shape == (
+            color_img_small.shape[0],
+            n_oriented_signals,
+            15,
+        )
+
     def test_color_cross_scale_correlation_magnitude_shape(self, color_img_small):
         model = self._small_ps(color_img_small, color_statistics=True)
         representation = model.convert_to_dict(model(color_img_small))
-        n_signals = color_img_small.shape[1] * model.n_orientations
+        n_channels = color_img_small.shape[1]
+        n_oriented_signals = n_channels * model.n_orientations
 
         assert representation["cross_scale_correlation_magnitude"].shape == (
             color_img_small.shape[0],
-            n_signals,
-            n_signals,
+            n_oriented_signals,
+            n_oriented_signals,
             model.n_scales - 1,
         )
 
     def test_color_cross_scale_correlation_real_shape(self, color_img_small):
         model = self._small_ps(color_img_small, color_statistics=True)
         representation = model.convert_to_dict(model(color_img_small))
-        n_signals = color_img_small.shape[1] * model.n_orientations
+        n_channels = color_img_small.shape[1]
+        n_oriented_signals = n_channels * model.n_orientations
 
         assert representation["cross_scale_correlation_real"].shape == (
             color_img_small.shape[0],
-            n_signals,
-            2 * n_signals,
+            n_oriented_signals,
+            2 * n_oriented_signals,
             model.n_scales - 1,
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1052,6 +1052,18 @@ class TestPortillaSimoncelli:
             assert torch.isfinite(value[..., mask]).all()
             assert torch.isnan(value[..., ~mask]).all()
 
+    def test_color_cross_orientation_correlation_magnitude_shape(self, color_img_small):
+        model = self._small_ps(color_img_small, color_statistics=True)
+        representation = model.convert_to_dict(model(color_img_small))
+        n_signals = color_img_small.shape[1] * model.n_orientations
+
+        assert representation["cross_orientation_correlation_magnitude"].shape == (
+            color_img_small.shape[0],
+            n_signals,
+            n_signals,
+            model.n_scales,
+        )
+
     def test_default_color_transform(self):
         # The color PS model should run out of the box with the OPC transform
         image = torch.rand(1, 3, 32, 32, device=DEVICE)
@@ -1232,7 +1244,9 @@ class TestPortillaSimoncelli:
         image = image.to(dtype)
         transform = po.process.OPC()
         model = po.models.PortillaSimoncelli(
-            image.shape[-2:], color_statistics=color_statistics, transform=transform,
+            image.shape[-2:],
+            color_statistics=color_statistics,
+            transform=transform,
         ).to(device=DEVICE, dtype=dtype)
         representation = model(image)
         assert representation.dtype == dtype

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1064,6 +1064,18 @@ class TestPortillaSimoncelli:
             model.n_scales,
         )
 
+    def test_color_cross_scale_correlation_magnitude_shape(self, color_img_small):
+        model = self._small_ps(color_img_small, color_statistics=True)
+        representation = model.convert_to_dict(model(color_img_small))
+        n_signals = color_img_small.shape[1] * model.n_orientations
+
+        assert representation["cross_scale_correlation_magnitude"].shape == (
+            color_img_small.shape[0],
+            n_signals,
+            n_signals,
+            model.n_scales - 1,
+        )
+
     def test_default_color_transform(self):
         # The color PS model should run out of the box with the OPC transform
         image = torch.rand(1, 3, 32, 32, device=DEVICE)


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

This PR adds the color Portilla-Simoncelli model into the existing `PortillaSimoncelli()` class. It follows [Vacher & Briand, Image Processing On Line (2021)](https://www.ipol.im/pub/art/2021/324/) appendix B2, which offers a description of the original color Portilla-Simoncelli model.

The color model has three main components compared to the standard model:
1. A color-space transform that maps RGB images to a different color space
2. Extension of existing statistics families to include cross-channel correlations
3. New statistics families not present in the original Portilla-Simoncelli model

The `PortillaSimoncelli()` class now takes two new parameters, `color_statistics: bool` to indicate whether to use the extended set of color statistics, and `transform: Callable` containing the color-space transform.

A minimal example of the new API:
```python
import torch
import plenoptic as po
import matplotlib.pyplot as plt

img_color = po.process.center_crop(po.data.color_wheel(as_gray=False)[:,:,:512,:512], 128)

pca = po.process.PCA(img_color) # Generate color-space PCA transform
model_color = po.models.PortillaSimoncelli(
  img_color.shape[-2:],
  color_statistics=True,  # Flag to use color model
  transform=pca,          # Color space transform
)
met_color = po.Metamer(img_color, model_color)
met_color.synthesize(max_iter=50)

po.plot.imshow(
  [img_color, met_color.metamer], title=["Target", "PCA color metamer"], as_rgb=True
)
plt.show()
```
I'll add more specific examples in the comments below.

**Link any related issues, discussions, PRs**

Towards #46.

**Outstanding questions / particular feedback**

- [We were wondering](https://github.com/plenoptic-org/plenoptic/issues/46#issuecomment-5217918925) whether to have a separate class for the color Portilla-Simoncelli. I think that I managed to fit it into the existing class tidily, so I favor the single class as implemented here.
- I set the OPC color transform discussed in #46 as the default value of `transform`. When `color_statistics = False` the transform is ignored, maintaining default behavior. I anticipate @billbrod might not like this default, and prefer having no transform as default. My argument for it is that there is value in providing reasonable defaults for the user, even if they could set them themselves.
- I haven't checked yet whether `portilla_simoncelli_loss_factory` works with the color model, it might need tweaking.
- Plotting the color model representation is not implemented. I would rather leave for future PR.
- The new model is not yet added to the docs. I propose that: 1) We review the implementation, 2) We delineate what the new docs about color Portilla-Simoncelli would include, 3) I implement the new docs/tutorial. This might also require adding a color texture image to `plenoptic`.
- Similarly, I need to add docstring examples.
- Do we want to change the name of `po.process.PCA` to `po.process.ColorPCA` or such?
- Do we need more checks for the color transform inside `PortillaSimoncelli()`?
- Initialization with an image that has similar RGB pixel statistics to the original is important. Should we add helpers for this?
- We currently require that the inputs to color `PortillaSimoncelli()` have 3 color channels. We could accept arbitrary channels, but maybe I would leave that for a future PR.
- Should we not ignore `transform` when `color_statistics=False`? This would only make sense if we change the default to the identity transform. It would enable using the independent-channel model with a color transform. But not sure this is important, the user can transform the image outside `PortillaSimoncelli()` if they wanted to do this.

**Describe changes**

- Added the module `process.color` with the color-space transforms `OPC()` and `PCA()` that can be passed to `PortillaSimoncelli()`
- Added explicit color model path to `PortillaSimoncelli()` via flag `color_statistics`
- Added `transform` argument to `PortillaSimoncelli()`, that transforms the input image color space (ignored when `color_statistics=False`)
- The same attributes `self._necessary_stats_dict` and `self._representation_scales` are used by the independent-channel and the color model. The color model extends them as needed.
- The representation tensor for the independent-channel model has shape `(batch, n_channels, n_stats)`, but the color model has `(batch, 1, n_stats)`, because it no longer makes sense to separate stats by channel.
- As described in Vacher 2021 appendix B2 bullet point 2, cross correlations families `"cross_orientation_correlation_magnitude", `"cross_scale_correlation_magnitude"`, `"cross_scale_correlation_real"` are extended to include correlations across (transformed) channels.
- As described in Vacher 2021 extra statistics are added to the model: (vii) color covariance in input color space, (viii) auto-correlation of transformed image channels,  (ix) skewness and kurtosis of each transformed channel, (x) cross-correlation of real coeffs across channel-orientation for each scale, (xi) cross-correlation of low pass residual, across image shifts and channels, (xii) cross-correlation of real coeffs and low pass residuals across different shifts and channels.
- Extended several existing tests to include the color model
- Added tests checking that some of the new statistics have the expected shapes.
- The `test_scales_shapes()` was improperly handling the case with `n_scales=1`, where some statistics are empty. Can't remember the details 100%, but I think it was zipping dicts of different length, and it passed out of luck. This PR also fixes that. 


**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [ ] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
**Daniel:** I added docstrings (see if some need improvement), but not documentation yet, as described above.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.

**AI disclaimer**

I used coding agents for this contribution. The major design decisions (API and internals) are almost entirely my own. I either wrote docstrings myself or edited almost all AI-generated docstrings, and the ones I didn't modify I read and didn't find anything requiring editing. I reviewed all AI generated code, and often edited for better design, readability or correctness.

