### PR TITLE
Use deterministic algorithms for deep nets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,4 +37,5 @@ Affirm that you have done the following:
 - [ ] I have described the changes in this PR, following the template above.
 - [ ] I have added any necessary tests.
 - [ ] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
+- [ ] If a reproducible example was added: I have taken all required steps to ensure reproducibility, including setting the seed, using float64, calling `torch.use_deterministic_algorithms(True)`. See "Reproducibility and Compatibility" page in the docs for details.
 - [ ] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.

--- a/docs/user_guide/models_and_metrics/deep_nets.md
+++ b/docs/user_guide/models_and_metrics/deep_nets.md
@@ -65,7 +65,8 @@ plt.rcParams["animation.ffmpeg_args"] = ["-threads", "1"]
 po.set_seed(1)
 # To guarantee reproducibility for this example on the GPU, we must tell torch to use
 # deterministic algorithms -- the default behavior for convolution is non-deterministic.
-# See "Reproducibility and Compatibility" in the docs for more details.
+# Note this will make things slower! See "Reproducibility and Compatibility" in the docs
+# for more details.
 torch.use_deterministic_algorithms(True)
 ```
 

--- a/docs/user_guide/models_and_metrics/deep_nets.md
+++ b/docs/user_guide/models_and_metrics/deep_nets.md
@@ -63,6 +63,10 @@ plt.rcParams["animation.ffmpeg_args"] = ["-threads", "1"]
 
 # set seed for reproducibility
 po.set_seed(1)
+# To guarantee reproducibility for this example on the GPU, we must tell torch to use
+# deterministic algorithms -- the default behavior for convolution is non-deterministic.
+# See "Reproducibility and Compatibility" in the docs for more details.
+torch.use_deterministic_algorithms(True)
 ```
 
 ## Prepare model and image for synthesis

--- a/docs/user_guide/reproduce/synthesizing_adversarial_examples/adversarial_examples_mad.md
+++ b/docs/user_guide/reproduce/synthesizing_adversarial_examples/adversarial_examples_mad.md
@@ -60,7 +60,8 @@ plt.rcParams["figure.dpi"] = 72
 po.set_seed(4)
 # To guarantee reproducibility for this example on the GPU, we must tell torch to use
 # deterministic algorithms -- the default behavior for convolution is non-deterministic.
-# See "Reproducibility and Compatibility" in the docs for more details.
+# Note this will make things slower! See "Reproducibility and Compatibility" in the docs
+# for more details.
 torch.use_deterministic_algorithms(True)
 ```
 

--- a/docs/user_guide/reproduce/synthesizing_adversarial_examples/adversarial_examples_mad.md
+++ b/docs/user_guide/reproduce/synthesizing_adversarial_examples/adversarial_examples_mad.md
@@ -58,6 +58,10 @@ plt.rcParams["figure.dpi"] = 72
 
 # set seed for reproducibility
 po.set_seed(4)
+# To guarantee reproducibility for this example on the GPU, we must tell torch to use
+# deterministic algorithms -- the default behavior for convolution is non-deterministic.
+# See "Reproducibility and Compatibility" in the docs for more details.
+torch.use_deterministic_algorithms(True)
 ```
 
 ## Prepare model and image for synthesis

--- a/docs/user_guide/reproduce/synthesizing_adversarial_examples/adversarial_examples_metamer.md
+++ b/docs/user_guide/reproduce/synthesizing_adversarial_examples/adversarial_examples_metamer.md
@@ -58,9 +58,10 @@ plt.rcParams["figure.dpi"] = 72
 
 # set seed for reproducibility
 po.set_seed(4)
-# To guarantee reproducibility on the GPU, we must tell torch to use deterministic
-# algorithms -- the default behavior for convolution is non-deterministic. See
-# "Reproducibility and Compatibility" in the docs for more details.
+# To guarantee reproducibility for this example on the GPU, we must tell torch to use
+# deterministic algorithms -- the default behavior for convolution is non-deterministic.
+# Note this will make things slower! See "Reproducibility and Compatibility" in the docs
+# for more details.
 torch.use_deterministic_algorithms(True)
 ```
 

--- a/docs/user_guide/reproduce/synthesizing_adversarial_examples/adversarial_examples_metamer.md
+++ b/docs/user_guide/reproduce/synthesizing_adversarial_examples/adversarial_examples_metamer.md
@@ -58,6 +58,10 @@ plt.rcParams["figure.dpi"] = 72
 
 # set seed for reproducibility
 po.set_seed(4)
+# To guarantee reproducibility on the GPU, we must tell torch to use deterministic
+# algorithms -- the default behavior for convolution is non-deterministic. See
+# "Reproducibility and Compatibility" in the docs for more details.
+torch.use_deterministic_algorithms(True)
 ```
 
 ## Prepare model and images for synthesis


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

In #476 , realized that the category for the MAD Adversarial Example had changed from "cheeseburger" to "malinois". After poking around a bit, realized this was because I need to call [torch.use_deterministic_algorithms(True)](https://docs.pytorch.org/docs/2.12/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms) because, among other things, convolutions are non-deterministic on GPUs by default. This adds that line to three docs pages: the two adversarial examples ones and the "How to use Deep Nets" one (it is unnecessary for reproducing Feather et al., 2023, since that notebook just loads in cached results, and the test producing those results already has this option).

**Link any related issues, discussions, PRs**

Originally encountered this problem in #460, should've realized this was an issue earlier. Thus, I've now updated the PR template to include a question about this.

**Describe changes**

- Adds `torch.use_deterministic_algorithms(True)` with comment to top of relevant notebooks, right after setting seed.
- Updates PR template to include a question about reproducibility practices

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
