### PR TITLE
Updates create_model call to match new syntax for `timm>=1.0.29`

### DIFF
--- a/docs/user_guide/models_and_metrics/deep_nets.md
+++ b/docs/user_guide/models_and_metrics/deep_nets.md
@@ -194,7 +194,7 @@ import plenoptic as po
 
 # since these two models are identical, they have the same layer names
 target_layer = "layer3"
-deepnet = timm.create_model("timm/resnet50.tv_in1k", pretrained=True)
+deepnet = timm.create_model("hf-hub:timm/resnet50.tv_in1k", pretrained=True)
 deepnet.eval()
 transform = create_transform(
     **resolve_data_config(deepnet.pretrained_cfg, model=deepnet)

--- a/src/plenoptic/conftest.py
+++ b/src/plenoptic/conftest.py
@@ -52,4 +52,4 @@ def download_timm():
 
     Similar potential problem to torchvision.
     """
-    timm.create_model("timm/resnet50.tv_in1k", pretrained=True)
+    timm.create_model("hf-hub:timm/resnet50.tv_in1k", pretrained=True)

--- a/src/plenoptic/models/feature_extractor.py
+++ b/src/plenoptic/models/feature_extractor.py
@@ -136,7 +136,9 @@ class DeepNetFeatures(torch.nn.Module):
     >>> import timm
     >>> from timm.data import resolve_data_config
     >>> from timm.data.transforms_factory import create_transform
-    >>> timm_model = timm.create_model("timm/resnet50.tv_in1k", pretrained=True).eval()
+    >>> timm_model = timm.create_model(
+    ...     "hf-hub:timm/resnet50.tv_in1k", pretrained=True
+    ... ).eval()
     >>> # Create Transform
     >>> timm_transform = create_transform(
     ...     **resolve_data_config(timm_model.pretrained_cfg, model=timm_model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def basic_stim():
 
 @pytest.fixture(scope="package")
 def timm_resnet50():
-    model = timm.create_model("timm/resnet50.tv_in1k", pretrained=True)
+    model = timm.create_model("hf-hub:timm/resnet50.tv_in1k", pretrained=True)
     return model
 
 


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

Starting with `timm==1.0.29`, `timm.create_model` raises an error for strings like `"timm/resnet50.tv_in1k"`: 

> Model name 'timm/resnet50.tv_in1k' has no source prefix but looks like a Hugging Face Hub repo id or a local path. Use 'hf-hub:timm/resnet50.tv_in1k' to load from the Hub or 'local-dir:timm/resnet50.tv_in1k' to load from a local folder.

This just adds `hf-hub` as a prefix to each of our invocations of `create_model` to avoid these warnings.

Required for timm>=1.0.29, also works with 1.0.28 (and hopefully older)

**Link any related issues, discussions, PRs**

Example [action failure](https://github.com/plenoptic-org/plenoptic/actions/runs/33289417483/job/99198297091). 

I can't find a mention of this in the release notes, and [the docs about `create_model`](https://huggingface.co/docs/timm/en/reference/models#timm.create_model.model_name) show passing it strings like `"resnet50.tv_in1k"`, so the problem appears to be the `timm/`, which could be a directory.

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a reproducible example was added: I have taken all required steps to ensure reproducibility, including setting the seed, using float64, calling `torch.use_deterministic_algorithms(True)`. See "Reproducibility and Compatibility" page in the docs for details.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
