### PR TITLE
Updates imshow/animshow docstring to warn about vrange for RGB images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = ['neuroscience', 'pytorch', 'visual information processing', 'machine
 dependencies = [
     "numpy>=1.1",
     "torch>=1.8,!=1.12.0",
-    "pyrtools>=1.0.9",
+    "pyrtools>=1.0.11",
     "scipy>=1.0",
     "matplotlib>=3.3",
     "tqdm>=4.29",

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -386,7 +386,7 @@ def imshow(
       ...     as_rgb=True,
       ...     zoom=0.5,
       ... )
-      <PyrFigure size ... with 1 Axes>
+      <PyrFigure size ... with 2 Axes>
       >>> po.plot.imshow(
       ...     [color_wheel, 2 * color_wheel],
       ...     title="vrange=auto1",
@@ -394,7 +394,7 @@ def imshow(
       ...     as_rgb=True,
       ...     zoom=0.5,
       ... )
-      <PyrFigure size ... with 1 Axes>
+      <PyrFigure size ... with 2 Axes>
 
     Notice that:
 
@@ -413,11 +413,11 @@ def imshow(
 
       >>> gray_whl = color_wheel.mean(1, keepdim=True)
       >>> po.plot.imshow([gray_whl, 2 * gray_whl], title="vrange=indep1", zoom=0.5)
-      <PyrFigure size ... with 1 Axes>
+      <PyrFigure size ... with 2 Axes>
       >>> po.plot.imshow(
       ...     [gray_whl, 2 * gray_whl], title="vrange=auto1", vrange="auto1", zoom=0.5
       ... )
-      <PyrFigure size ... with 1 Axes>
+      <PyrFigure size ... with 2 Axes>
 
     To avoid this problem, one can rescale the input before plotting using a function
     like :func:`plenoptic.process.rescale`:
@@ -432,7 +432,7 @@ def imshow(
       >>> imgs += [po.process.rescale(im) for im in imgs]
       >>> titles += ["rescaled", "rescaled"]
       >>> po.plot.imshow(imgs, as_rgb=True, zoom=0.5, col_wrap=2, title=titles)
-      <PyrFigure size ... with 1 Axes>
+      <PyrFigure size ... with 4 Axes>
 
     If ``as_rgb=False``, images with multiple channels will have each channel plotted
     as a separate grayscale image:

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -115,6 +115,13 @@ def imshow(
         displayed at the same height and width, thus, their heights and widths
         must be scalar multiples of each other.
     vrange
+
+        .. attention::
+           This argument only affects behavior for grayscale images. RGB
+           images will always be displayed with vrange [0, 1] (for floats) or
+           [0, 255] (for ints), because of how matplotlib handles them (see
+           :external:func:`matplotlib.pyplot.imshow`).
+
         If a 2-tuple, specifies the image values vmin/vmax that are mapped to
         the minimum and maximum value of the colormap, respectively. If a
         string:
@@ -190,9 +197,11 @@ def imshow(
         restrict the channels.
     as_rgb
         Whether to consider the channels as encoding RGB(A) values. If ``True``, we
-        attempt to plot the image in color, so your tensor must have 3 (or 4 if
-        you want the alpha channel) elements in the channel dimension. If ``False``,
-        we plot each channel as a separate grayscale image.
+        attempt to plot the image in color, so your tensor must have 3 (or 4 if you want
+        the alpha channel) elements in the channel dimension. Note that in this case,
+        the ``vrange`` argument is ignored and set to ``[0, 1]`` (if ``img`` has a
+        floating dtype) or ``[0, 255]`` (if integer dtype). If ``False``, we plot each
+        channel as a separate grayscale image.
     **kwargs
         Passed to :func:`matplotlib.pyplot.imshow`.
 
@@ -218,6 +227,12 @@ def imshow(
         one batch and neither ``batch_idx`` nor ``channel_idx`` is set.
     Exception
         If ``plot_complex`` takes an illegal value.
+
+    Warns
+    -----
+    UserWarning
+        If vrange is set and at least one of the videos is RGB, because matplotlib will
+        only plot RGB images with vranges of [0, 1] (for floats) or [0, 255] (for ints).
 
     See Also
     --------
@@ -354,8 +369,73 @@ def imshow(
       >>> po.plot.imshow(color_wheel, as_rgb=True, zoom=0.5)
       <PyrFigure size ... with 1 Axes>
 
-    Otherwise, images with multiple channels will have each channel plotted as a
-    separate grayscale image:
+    When ``as_rgb=True``, we have no control over the ``vrange`` (because of how
+    :func:`matplotlib.pyplot.imshow` handles color images): regardless of user-specified
+    arguments, ``vrange`` is set to ``[0, 1]`` (for floating-typed inputs) or ``[0,
+    255]`` (for integer-typed inputs). Additionally, any values outside that range will
+    be clipped:
+
+    .. plot::
+      :context: close-figs
+
+      >>> print(color_wheel.max(), (2 * color_wheel).max())
+      tensor(1.) tensor(2.)
+      >>> po.plot.imshow(
+      ...     [color_wheel, 2 * color_wheel],
+      ...     title="vrange=indep1",
+      ...     as_rgb=True,
+      ...     zoom=0.5,
+      ... )
+      <PyrFigure size ... with 1 Axes>
+      >>> po.plot.imshow(
+      ...     [color_wheel, 2 * color_wheel],
+      ...     title="vrange=auto1",
+      ...     vrange="auto1",
+      ...     as_rgb=True,
+      ...     zoom=0.5,
+      ... )
+      <PyrFigure size ... with 1 Axes>
+
+    Notice that:
+
+    - The two figures above are identical despite the different ``vrange`` argument.
+
+    - The two axes in each figure have the same plotted vrange (as shown in the title),
+      despite their different data ranges.
+
+    - That the image in the second axis (in each figure) has had many of its values
+      clipped to 1 and are thus displayed as white.
+
+    Compare this to the results of the same syntax with grayscale images:
+
+    .. plot::
+      :context: close-figs
+
+      >>> gray_whl = color_wheel.mean(1, keepdim=True)
+      >>> po.plot.imshow([gray_whl, 2 * gray_whl], title="vrange=indep1", zoom=0.5)
+      <PyrFigure size ... with 1 Axes>
+      >>> po.plot.imshow(
+      ...     [gray_whl, 2 * gray_whl], title="vrange=auto1", vrange="auto1", zoom=0.5
+      ... )
+      <PyrFigure size ... with 1 Axes>
+
+    To avoid this problem, one can rescale the input before plotting using a function
+    like :func:`plenoptic.process.rescale`:
+
+    .. plot::
+      :context: close-figs
+
+      >>> small_range = 0.5 * color_wheel
+      >>> big_range = 2 * color_wheel
+      >>> imgs = [small_range, big_range]
+      >>> titles = [f"data_range=[{i.min()}, {i.max()}]" for i in imgs]
+      >>> imgs += [po.process.rescale(im) for im in imgs]
+      >>> titles += ["rescaled", "rescaled"]
+      >>> po.plot.imshow(imgs, as_rgb=True, zoom=0.5, col_wrap=2, title=titles)
+      <PyrFigure size ... with 1 Axes>
+
+    If ``as_rgb=False``, images with multiple channels will have each channel plotted
+    as a separate grayscale image:
 
     .. plot::
       :context: close-figs
@@ -558,6 +638,13 @@ def animshow(
     repeat
         Whether to loop the animation or just play it once.
     vrange
+
+        .. attention::
+           This argument only affects behavior for grayscale images. RGB
+           images will always be displayed with vrange [0, 1] (for floats) or
+           [0, 255] (for ints), because of how matplotlib handles them (see
+           :external:func:`matplotlib.pyplot.imshow`).
+
         If a 2-tuple, specifies the image values vmin/vmax that are mapped to
         the minimum and maximum value of the colormap, respectively. If a
         string:
@@ -636,7 +723,9 @@ def animshow(
         attempt to plot the image in color, so your tensor must have 3 (or 4 if
         you want the alpha channel) elements in the channel dimension. If ``False``,
         we plot each channel as a separate grayscale image. Note that if ``True``,
-        clipping may result, see Warns section below for details.
+        clipping may result, see Warns section below for details. Additionally, if
+        ``True``, the ``vrange`` argument is ignored and set to ``[0, 1]`` (if ``img``
+        has a floating dtype) or ``[0, 255]`` (if integer dtype).
     **kwargs
         Passed to :func:`matplotlib.pyplot.imshow`.
 
@@ -668,6 +757,9 @@ def animshow(
         of :func:`matplotlib.pyplot.imshow`.) The warning will say how many frames of
         which video were clipped. To avoid clipping, you should remap ``video`` to
         [0, 1] before calling this function.
+    UserWarning
+        If vrange is set and at least one of the videos is RGB, because matplotlib will
+        only plot RGB images with vranges of [0, 1] (for floats) or [0, 255] (for ints).
 
     See Also
     --------

--- a/src/plenoptic/plot/display.py
+++ b/src/plenoptic/plot/display.py
@@ -120,7 +120,7 @@ def imshow(
            This argument only affects behavior for grayscale images. RGB
            images will always be displayed with vrange [0, 1] (for floats) or
            [0, 255] (for ints), because of how matplotlib handles them (see
-           :external:func:`matplotlib.pyplot.imshow`).
+           ``vmin``, ``vmax`` args in :external:func:`matplotlib.pyplot.imshow`).
 
         If a 2-tuple, specifies the image values vmin/vmax that are mapped to
         the minimum and maximum value of the colormap, respectively. If a
@@ -232,7 +232,8 @@ def imshow(
     -----
     UserWarning
         If vrange is set and at least one of the videos is RGB, because matplotlib will
-        only plot RGB images with vranges of [0, 1] (for floats) or [0, 255] (for ints).
+        only plot RGB images with vranges of [0, 1] (for floats) or [0, 255] (for ints)
+        (see ``vmin``, ``vmax`` args in :external:func:`matplotlib.pyplot.imshow`).
 
     See Also
     --------
@@ -369,8 +370,9 @@ def imshow(
       >>> po.plot.imshow(color_wheel, as_rgb=True, zoom=0.5)
       <PyrFigure size ... with 1 Axes>
 
-    When ``as_rgb=True``, we have no control over the ``vrange`` (because of how
-    :func:`matplotlib.pyplot.imshow` handles color images): regardless of user-specified
+    When ``as_rgb=True``, we have no control over the ``vrange`` because of how
+    :func:`matplotlib.pyplot.imshow` handles color images (see the documentation of
+    that function for the ``vmin``, ``vmax`` args). Thus, regardless of user-specified
     arguments, ``vrange`` is set to ``[0, 1]`` (for floating-typed inputs) or ``[0,
     255]`` (for integer-typed inputs). Additionally, any values outside that range will
     be clipped:
@@ -406,21 +408,9 @@ def imshow(
     - That the image in the second axis (in each figure) has had many of its values
       clipped to 1 and are thus displayed as white.
 
-    Compare this to the results of the same syntax with grayscale images:
-
-    .. plot::
-      :context: close-figs
-
-      >>> gray_whl = color_wheel.mean(1, keepdim=True)
-      >>> po.plot.imshow([gray_whl, 2 * gray_whl], title="vrange=indep1", zoom=0.5)
-      <PyrFigure size ... with 2 Axes>
-      >>> po.plot.imshow(
-      ...     [gray_whl, 2 * gray_whl], title="vrange=auto1", vrange="auto1", zoom=0.5
-      ... )
-      <PyrFigure size ... with 2 Axes>
-
-    To avoid this problem, one can rescale the input before plotting using a function
-    like :func:`plenoptic.process.rescale`:
+    To visualize 3-channel images that aren't defined in one of the supported ranges
+    (e.g., differences of RGB images), one can rescale the input before plotting using
+    a function like :func:`plenoptic.process.rescale`:
 
     .. plot::
       :context: close-figs

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -852,6 +852,7 @@ def template_test_synthesis_all_plot(
     plot_kwargs = {}
     from plenoptic.plot import synthesis
 
+    expectation = does_not_raise()
     if synth_image:
         included_plots.append("synthesis_imshow")
     if loss:
@@ -860,6 +861,13 @@ def template_test_synthesis_all_plot(
         included_plots.append("metamer_representation_error")
         as_rgb = synthesis_object.image.shape[1] > 1
         plot_kwargs["metamer_representation_error_kwargs"] = {"as_rgb": as_rgb}
+        # metamer_representation-error will pass vrange=indep0 by default, which will
+        # trigger the following warning if as_rgb=True. (users should probably just set
+        # as_rgb=False)
+        if as_rgb:
+            expectation = pytest.warns(
+                UserWarning, match="RGB images cannot have their vrange set"
+            )
     if histogram:
         included_plots.append("synthesis_histogram")
     width_ratios = {}
@@ -876,14 +884,15 @@ def template_test_synthesis_all_plot(
         )
     elif fig_creation == "pass-without":
         fig, axes = plt.subplots(1, 4)
-    fig = po.plot.synthesis_status(
-        synthesis_object,
-        iteration=iteration,
-        included_plots=included_plots,
-        fig=fig,
-        **plot_kwargs,
-        width_ratios=width_ratios,
-    )
+    with expectation:
+        fig = po.plot.synthesis_status(
+            synthesis_object,
+            iteration=iteration,
+            included_plots=included_plots,
+            fig=fig,
+            **plot_kwargs,
+            width_ratios=width_ratios,
+        )
 
 
 def template_test_synthesis_custom_fig(synthesis_object, func, fig_creation, tmp_path):
@@ -895,11 +904,19 @@ def template_test_synthesis_custom_fig(synthesis_object, func, fig_creation, tmp
     included_plots = ["synthesis_imshow", "synthesis_histogram"]
     # need to figure out which plotting function to call
     axes_idx = {"synthesis_imshow": 0}
+    expectation = does_not_raise()
     if isinstance(synthesis_object, po.Metamer):
         as_rgb = synthesis_object.image.shape[1] > 1
         plot_kwargs["metamer_representation_error_kwargs"] = {"as_rgb": as_rgb}
         included_plots.extend(["metamer_representation_error", "synthesis_loss"])
         axes_idx["metamer_representation_error"] = 8
+        # metamer_representation-error will pass vrange=indep0 by default, which will
+        # trigger the following warning if as_rgb=True. (users should probably just set
+        # as_rgb=False)
+        if as_rgb:
+            expectation = pytest.warns(
+                UserWarning, match="RGB images cannot have their vrange set"
+            )
     elif isinstance(synthesis_object, po.MADCompetition):
         included_plots.append("synthesis_loss")
     fig, axes = plt.subplots(3, 3, figsize=(35, 17))
@@ -912,27 +929,32 @@ def template_test_synthesis_custom_fig(synthesis_object, func, fig_creation, tmp
             axes_idx["synthesis_loss"] = 6
         if "synthesis_histogram" in included_plots:
             axes_idx["synthesis_histogram"] = 7
-    if func == "plot":
-        fig = po.plot.synthesis_status(
-            synthesis_object,
-            included_plots=included_plots,
-            fig=fig,
-            axes_idx=axes_idx,
-            **plot_kwargs,
-        )
-    elif fig_creation.endswith("preplot"):
-        po.plot.imshow(torch.rand_like(synthesis_object.image), ax=axes.flatten()[1])
-        po.plot.imshow(torch.rand_like(synthesis_object.image), ax=axes.flatten()[4])
-    if func == "animate":
-        # animate closes the matplotlib figure itself, so don't need to do it here
-        path = tmp_path / "test_anim.html"
-        po.plot.synthesis_animate(
-            synthesis_object,
-            fig=fig,
-            axes_idx=axes_idx,
-            included_plots=included_plots,
-            **plot_kwargs,
-        ).save(path)
+    with expectation:
+        if func == "plot":
+            fig = po.plot.synthesis_status(
+                synthesis_object,
+                included_plots=included_plots,
+                fig=fig,
+                axes_idx=axes_idx,
+                **plot_kwargs,
+            )
+        elif fig_creation.endswith("preplot"):
+            po.plot.imshow(
+                torch.rand_like(synthesis_object.image), ax=axes.flatten()[1]
+            )
+            po.plot.imshow(
+                torch.rand_like(synthesis_object.image), ax=axes.flatten()[4]
+            )
+        if func == "animate":
+            # animate closes the matplotlib figure itself, so don't need to do it here
+            path = tmp_path / "test_anim.html"
+            po.plot.synthesis_animate(
+                synthesis_object,
+                fig=fig,
+                axes_idx=axes_idx,
+                included_plots=included_plots,
+                **plot_kwargs,
+            ).save(path)
 
 
 class TestMADDisplay:


### PR DESCRIPTION
**Describe the change in this PR at a high-level**

This updates the docstrings of `imshow` and `animhow` to provide more information about how vrange is handled for RGB images. It relies on https://github.com/LabForComputationalVision/pyrtools/pull/51 (release v1.0.11) to update the titles and raise the warnings, so this is largely about alerting plenoptic users.

**Link any related issues, discussions, PRs**

Closes #479 

**Outstanding questions / particular feedback**

- How is the wording in the docstring? I had a bit of trouble writing something I was happy with.
- How is the example in the doctest? I ended up adding several sections -- are they clear? Are they all necessary?

**Describe changes**

- Adds admonition to vrange parameter
- Updates as_rgb parameter description as well
- Adds longish doctest trying to show how this works.
- Adds info about UserWarning (raised by pyrtools) that happens when vrange is changed
- Increases min pyrtools version so that it will get triggered

**Checklist**

Affirm that you have done the following:

- [x] I have described the changes in this PR, following the template above.
- [x] I have added any necessary tests.
- [x] I have added any necessary documentation. This includes docstrings, updates to existing files found in `docs/`, or (for large changes) adding new files to the `docs/` folder.
- [x] If a reproducible example was added: I have taken all required steps to ensure reproducibility, including setting the seed, using float64, calling `torch.use_deterministic_algorithms(True)`. See "Reproducibility and Compatibility" page in the docs for details.
- [x] If a public new class or function was added: I have double-checked that it is present in the API docs, adding it to one of the `rst` files in `docs/api/` or adding a new file as necessary.
